### PR TITLE
docs: adding equivalent for s[i] POP

### DIFF
--- a/docs/learn/tvm-instructions/instructions.md
+++ b/docs/learn/tvm-instructions/instructions.md
@@ -49,7 +49,7 @@ Here `0 <= i,j,k <= 15` if not stated otherwise.
 | **`2i`** | `s[i] PUSH` |  | Pushes a copy of the old `s[i]` into the stack. | `18` |
 | **`20`** | `DUP` | _`x - x x`_ | Same as [`s0 PUSH`](#instr-push). | `18` |
 | **`21`** | `OVER` | _`x y - x y x`_ | Same as [`s1 PUSH`](#instr-push). | `18` |
-| **`3i`** | `s[i] POP` |  | Pops the old `s0` value into the old `s[i]`. | `18` |
+| **`3i`** | `s[i] POP` |  | Pops the old `s0` value into the old `s[i]`. Equivalent to [`s[i] XCHG0`](#instr-xchg-0i) [`DROP`](#instr-drop) | `18` |
 | **`30`** | `DROP` | _`x -`_ | Same as [`s0 POP`](#instr-pop), discards the top-of-stack value. | `18` |
 | **`31`** | `NIP` | _`x y - y`_ | Same as [`s1 POP`](#instr-pop). | `18` |
 ### 2.2 Complex stack manipulation primitives


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Adding equivalent for s[i] POP

## Why is it important?

<!--- Describe your changes in detail -->

I tried to understand from the description what opcode does, and interviewed several developers, we could not give a correct answer to this. So I'm adding an equivalent to make it easier to understand.

## Related Issue

<!--- This project accepts pull requests related to open issues, if possible -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here, if possible: -->