### PR TITLE
docs: adding a mention that is possible to run TON Sites via docker

### DIFF
--- a/docs/develop/dapps/tutorials/how-to-run-ton-site.md
+++ b/docs/develop/dapps/tutorials/how-to-run-ton-site.md
@@ -45,6 +45,8 @@ docker-compose up -d
 
 ### ⚙️ Installing from sources
 
+Otherwise, if you don't want to use [Docker](#-running-with-docker), you can download the sources and install it manually.
+
 Before you start, make sure that you already have a regular website running on port 80. We will consider installing on a Linux machine, but the same steps can be performed on other operating systems.
 
 1.  Download the newest version of the TON blockchain sources, available at GitHub repository https://github.com/ton-blockchain/ton/:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Adding a mention that is possible to run TON Sites via docker.

## Why is it important?

<!--- Describe your changes in detail -->
This change in the documentation makes it easier to understand that the section on installing and running TON Sites from sources is an alternative way.

## Related Issue

<!--- This project accepts pull requests related to open issues, if possible -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here, if possible: -->