### PR TITLE
Specified directory where func and fift executables will appear after…

### DIFF
--- a/docs/develop/howto/compile.md
+++ b/docs/develop/howto/compile.md
@@ -92,7 +92,7 @@ cmake --build . --target func
 To compile FunC smart contract:
 
 ```bash
-func -o output.fif -SPA source0.fc source1.fc ...
+./crypto/func -o output.fif -SPA source0.fc source1.fc ...
 ```
 
 ## Fift
@@ -106,7 +106,7 @@ cmake --build . --target fift
 To run Fift script:
 
 ```bash
-fift -s script.fif script_param0 script_param1 ..
+./crypto/fift -s script.fif script_param0 script_param1 ..
 ```
 
 ## Tonlib-cli


### PR DESCRIPTION
… cmake

<!--- Provide a general summary of your changes in the Title above -->

## Why is it important?

The directory containing corresponding binaries after build is non-obvious

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues, if possible -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here, if possible: -->