### PR TITLE
Updated ligatures for "more or equal" and "less or equal" signs.

### DIFF
--- a/docs/develop/func/compiler_directives.md
+++ b/docs/develop/func/compiler_directives.md
@@ -18,24 +18,24 @@ The `#pragma` directive is used to provide additional information to the compile
 ### #pragma version
 Version pragma is used to enforce a specific version of FunC compiler when compiling the file.
 
-The version is specified in a semver format, that is, `a.b.c`, where `a` is the major version, `b` is the minor, and `c` is the patch.
+The version is specified in a semver format, that is, _a.b.c_, where _a_ is the major version, _b_ is the minor, and _c_ is the patch.
 
 There are several comparison operators available to a developer:
-* `a.b.c` or `=a.b.c`—requires exactly the `a.b.c` version of the compiler
-* `>a.b.c`—requires the compiler version to be higher than `a.b.c`,
-  * `>=a.b.c`—requires the compiler version to be higher or equal to `a.b.c`
-* `<a.b.c`—requires the compiler version to be lower than `a.b.c`,
-  * `<=a.b.c`—requires the compiler version to be lower or equal to `a.b.c`
-* `^a.b.c`—requires the major compiler version to be equal to the 'a' part and the minor to be no lower than the 'b' part,
-  * `^a.b`—requires the major compiler version to be equal to `a` part and minor be no lower than `b` part
-  * `^a`—requires the major compiler version to be no lower than `a` part
+* _a.b.c_ or _=a.b.c_—requires exactly the _a.b.c_ version of the compiler
+* _>a.b.c_—requires the compiler version to be higher than _a.b.c_,
+  * _>=a.b.c_—requires the compiler version to be higher or equal to _a.b.c_
+* _<a.b.c_—requires the compiler version to be lower than _a.b.c_,
+  * _<=a.b.c_—requires the compiler version to be lower or equal to _a.b.c_
+* _^a.b.c_—requires the major compiler version to be equal to the 'a' part and the minor to be no lower than the 'b' part,
+  * _^a.b_—requires the major compiler version to be equal to _a_ part and minor be no lower than _b_ part
+  * _^a_—requires the major compiler version to be no lower than _a_ part
 
-For other comparison operators (`=`, `>`, `>=`, `<`, `<=`) short format assumes zeros in omitted parts, that is:
-* `>a.b` is the same as `>a.b.0` (and therefore does NOT match thd `a.b.0` version)
-* `<=a` is the same as `<=a.0.0` (and therefore does NOT match the `a.0.1` version)
-* `^a.b.0` is **NOT** the same as `^a.b`
+For other comparison operators (_=_, _>_, _>=_, _<_, _<=_) short format assumes zeros in omitted parts, that is:
+* _>a.b_ is the same as _>a.b.0_ (and therefore does NOT match thd _a.b.0_ version)
+* _<=a_ is the same as _<=a.0.0_ (and therefore does NOT match the _a.0.1_ version)
+* _^a.b.0_ is **NOT** the same as _^a.b_
 
-For example, `^a.1.2` matches `a.1.3` but not `a.2.3` or `a.1.0`, however, `^a.1` matches them all. 
+For example, _^a.1.2_ matches _a.1.3_ but not _a.2.3_ or _a.1.0_, however, _^a.1_ matches them all. 
 
 This directive may be used multiple times; the compiler version must satisfy all provided conditions.
 


### PR DESCRIPTION
Fixed displays of ligatures in https://ton.org/docs/develop/func/compiler_directives articles for operators.
Made the sign ≤ to display it as <=, vice versa.