### PR TITLE
Typo of "test giver" base64 address in the addresses.md

### DIFF
--- a/docs/learn/overviews/addresses.md
+++ b/docs/learn/overviews/addresses.md
@@ -119,7 +119,7 @@ For example, the "test giver" (a special smart contract residing in the masterch
 
 Let's convert "test giver" raw address to the user-friendly form:
 
-* `kf/8uRo6OBbQ97jCx2EIuKm8Wmt6Vb15-KsQHFLbKSMiYIny` (base64)
+* `kf/8uRo6OBbQ97jCx2EIuKm8Wmt6Vb15+KsQHFLbKSMiYIny` (base64)
 * `kf_8uRo6OBbQ97jCx2EIuKm8Wmt6Vb15-KsQHFLbKSMiYIny` (base64url)
 
 :::info


### PR DESCRIPTION
typo

## Why is it important?

there is a typo in this address

## Related Issue
