### PR TITLE
Add information about `openssl3.3` on MacOS Intel

### DIFF
--- a/docs/develop/howto/compile.md
+++ b/docs/develop/howto/compile.md
@@ -8,7 +8,7 @@ This section describes instructions and manuals for interacting with TON at a lo
 
 The software is likely to compile and work properly on most Linux systems. It should work on macOS and even Windows.
 
-1) Download the newest version of the TON Blockchain sources available at the GitHub repository https://github.com/ton-blockchain/ton/ :
+1) Download the newest version of the TON Blockchain sources available at the GitHub repository https://github.com/ton-blockchain/ton/:
 
 ```bash
 git clone --recurse-submodules https://github.com/ton-blockchain/ton.git
@@ -35,7 +35,7 @@ sudo apt install build-essential cmake clang openssl libssl-dev zlib1g-dev gperf
 mkdir ton-build
 ```
 
-   Then run the following in a terminal of Linux:
+Then run the following in a terminal of Linux or MacOS:
 
 ```bash
 cd ton-build
@@ -43,6 +43,27 @@ export CC=clang
 export CXX=clang++
 cmake -DCMAKE_BUILD_TYPE=Release ../ton && cmake --build . -j$(nproc)
 ```
+
+:::warning
+On MacOS Intel before next step we need maybe install `openssl3.3` with `brew` or just link the lib:
+
+```zsh
+brew install openssl3.3
+```
+
+Then need to inspect `/usr/local/opt`:
+
+```zsh
+ls /usr/local/opt
+```
+
+Find `openssl` lib and export local variable:
+
+```zsh
+export OPENSSL_ROOT_DIR=/usr/local/opt/openssl@3.3
+```
+
+:::
 
 :::tip
 If you are compiling on a computer with low memory (e.g., 1 Gb), don't forget to [create a swap partitions](/develop/howto/compile-swap).


### PR DESCRIPTION
One of core variables when compiling TON from sources did not revealed in the docs

## Why is it important?

Everytime when updating TON you may not have this variable and code will not compile

## Related Issue

-