### PR TITLE
Fix explanation of TL-B conditional fields

### DIFF
--- a/docs/learn/overviews/tl-b-language.mdx
+++ b/docs/learn/overviews/tl-b-language.mdx
@@ -151,7 +151,7 @@ block_info#9bc7a987 version:uint32
   = BlockInfo;
 ```
 
-In this example, the cell reference `^BlkMasterInfo` will be serialized only if `not_master` > 0. And the `GlobalVersion` will be serialized only if `flags == 0`.
+In this example, the cell reference `^BlkMasterInfo` will be serialized only if `not_master` > 0. And the `GlobalVersion` will be serialized only if the bit at index 0 in a binary representation of `flags` is set.
 
 ## Namespaces
 


### PR DESCRIPTION


According to [the TL specification](https://core.telegram.org/mtproto/TL-combinators#conditional-fields) `flags . 0` means the bit at index 0 is set. 

That's how BlockInfo::unpack looks like
```c++
bool BlockInfo::unpack(vm::CellSlice& cs, BlockInfo::Record& data) const {
  int prev_seq_no;
  return cs.fetch_ulong(32) == 0x9bc7a987U
      && cs.fetch_uint_to(32, data.version)
      && cs.fetch_bool_to(data.not_master)
      && cs.fetch_bool_to(data.after_merge)
      && cs.fetch_bool_to(data.before_split)
      && cs.fetch_bool_to(data.after_split)
      && cs.fetch_bool_to(data.want_split)
      && cs.fetch_bool_to(data.want_merge)
      && cs.fetch_bool_to(data.key_block)
      && cs.fetch_bool_to(data.vert_seqno_incr)
      && cs.fetch_uint_to(8, data.flags)
      && data.flags <= 1
      && cs.fetch_uint_to(32, data.seq_no)
      && cs.fetch_uint_to(32, data.vert_seq_no)
      && data.vert_seqno_incr <= data.vert_seq_no
      && add_r1(prev_seq_no, 1, data.seq_no)
      && cs.fetch_subslice_to(104, data.shard)
      && cs.fetch_uint_to(32, data.gen_utime)
      && cs.fetch_uint_to(64, data.start_lt)
      && cs.fetch_uint_to(64, data.end_lt)
      && cs.fetch_uint_to(32, data.gen_validator_list_hash_short)
      && cs.fetch_uint_to(32, data.gen_catchain_seqno)
      && cs.fetch_uint_to(32, data.min_ref_mc_seqno)
      && cs.fetch_uint_to(32, data.prev_key_block_seqno)
      && (!(data.flags & 1) || cs.fetch_subslice_to(104, data.gen_software))
      && (!data.not_master || cs.fetch_ref_to(data.master_ref))
      && cs.fetch_ref_to(data.prev_ref)
      && (!data.vert_seqno_incr || cs.fetch_ref_to(data.prev_vert_ref));
}
```
and there
https://github.com/ton-blockchain/ton/blob/8329a589942b69547a9a132b5d091976391b1a8b/validator/impl/collator.cpp#L3796-L3807

## Why is it important?

This PR fixes misleading explanation. 

