### PR TITLE
Fix all links in docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/suggest_tutorial.yaml
+++ b/.github/ISSUE_TEMPLATE/suggest_tutorial.yaml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        We'll consider [our tutorial guidelines](https://www.tonspace.co/contribute/guidelines) when reviewing the tutorial, so please take a look there first.
+        We'll consider [our tutorial guidelines](/contribute/guidelines) when reviewing the tutorial, so please take a look there first.
   - type: markdown
     id: tutorial_info
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,4 +5,4 @@
 
 ### Thank you for your interest in contributing!
 
-Please see [our contributing guide on documentation](https://tonspace.co/contribute) for the latest information on how to contribute!
+Please see [our contributing guide on documentation](/contribute) for the latest information on how to contribute!

--- a/docs/contribute/hacktoberfest/README.mdx
+++ b/docs/contribute/hacktoberfest/README.mdx
@@ -21,7 +21,7 @@ The Hacktoberfest rules for 2022 are as follows:
 * **Hacktoberfest is open to everyone**!
 * Register anytime between September 26 and October 31
 * Pull requests can be made in any GITHUB or GITLAB project:
-  * [List of projects on TON Ecosystem](https://tonspace.co/hacktonberfest)
+  * [List of projects on TON Ecosystem](/hacktonberfest)
   * [List of projects on GitHub](https://github.com/topics/hacktoberfest)
 * Have **4** pull/merge requests accepted between October 1 and October 31
 * The first 40,000 participants (maintainers and contributors) who complete Hacktoberfest can choose between two prizes: a tree planted in their honor or a Hacktoberfest 2022 t-shirt. _(from the Hacktoberfest community)_

--- a/docs/develop/dapps/tutorials/accept-payments-in-a-telegram-bot-2.md
+++ b/docs/develop/dapps/tutorials/accept-payments-in-a-telegram-bot-2.md
@@ -424,7 +424,7 @@ async def welcome_handler(message: types.Message):
 
     # Send welcome text and include the keyboard
     await message.answer('Hi!\nI am example bot '
-                         'made for [this article](https://www.tonspace.co/develop/dapps/payment-processing/accept-payments-in-a-telegram-bot-2).\n'
+                         'made for [this article](/develop/dapps/payment-processing/accept-payments-in-a-telegram-bot-2).\n'
                          'My goal is to show how simple it is to receive '
                          'payments in Toncoin with Python.\n\n'
                          'Use keyboard to test my functionality.',

--- a/docs/develop/dapps/tutorials/accept-payments-in-a-telegram-bot-js.md
+++ b/docs/develop/dapps/tutorials/accept-payments-in-a-telegram-bot-js.md
@@ -301,7 +301,7 @@ export default async function handleStart(ctx) {
   const menu = new InlineKeyboard()
     .text("Buy dumplings🥟", "buy")
     .row()
-    .url("Article with a detailed explanation of the bot's work", "https://tonspace.co/develop/dapps/payment-processing/accept-payments-in-a-telegram-bot-js/");
+    .url("Article with a detailed explanation of the bot's work", "/develop/dapps/payment-processing/accept-payments-in-a-telegram-bot-js/");
 
   await ctx.reply(
     `Hello stranger!

--- a/docs/develop/dapps/tutorials/jetton-minter.md
+++ b/docs/develop/dapps/tutorials/jetton-minter.md
@@ -106,7 +106,7 @@ Then go to **your token**, set the **amount** to send, and enter the **recipient
 
  ## ✏️ Jetton (token) customization
 
-With [FunC](https://www.tonspace.co/develop/func/overview) language you can change the behavior of the token in your favor.
+With [FunC](/develop/func/overview) language you can change the behavior of the token in your favor.
 
 To make any changes, begin here:
 

--- a/docs/develop/fift-and-tvm-assembly.md
+++ b/docs/develop/fift-and-tvm-assembly.md
@@ -118,4 +118,4 @@ int mul_mod_better(int a, int b, int m) inline_ref {        ;; 1110 gas units
 int mul_mod_best(int a, int b, int m) asm "x{A988} s,";     ;; 65 gas units
 ```
 
-`x{A988}` is opcode formatted according to https://ton.org/docs/learn/tvm-instructions/instructions#52-division: division with pre-multiplication, where the only returned result is remainder modulo third argument. But opcode needs to get into smart-contract code - that's what `s,` does: it stores slice on top of stack into builder slightly below.
+`x{A988}` is opcode formatted according to [5.2 Division](/learn/tvm-instructions/instructions#52-division): division with pre-multiplication, where the only returned result is remainder modulo third argument. But opcode needs to get into smart-contract code - that's what `s,` does: it stores slice on top of stack into builder slightly below.

--- a/docs/develop/onboarding-challenge.mdx
+++ b/docs/develop/onboarding-challenge.mdx
@@ -62,7 +62,7 @@ As with mining from years ago, you need a _non-custodial_ wallet with its addres
 So, prepare your wallet using these 2 steps:
 
 1. Install the Tonkeeper app on your smartphone.
-2. [Enable test mode in Tonkeeper](https://ton.org/docs/participate/wallets/apps#tonkeeper) to use testnet.
+2. [Enable test mode in Tonkeeper](/participate/wallets/apps#tonkeeper) to use testnet.
 
 Easy! Let's go to the development now.
 

--- a/docs/develop/smart-contracts/fees.md
+++ b/docs/develop/smart-contracts/fees.md
@@ -167,7 +167,7 @@ Average fee for minting one NFT is 0.08 TON.
 
 ### Cost of saving data in TON?
 
-Saving 1 MB of data for one year on TON will cost you 4.03 TON. Note that you don't usually need to store big amounts of data on-chain. Consider [TON Storage](https://ton.org/docs/participate/ton-storage/storage-daemon) if you need decentralized storage.
+Saving 1 MB of data for one year on TON will cost you 4.03 TON. Note that you don't usually need to store big amounts of data on-chain. Consider [TON Storage](/participate/ton-storage/storage-daemon) if you need decentralized storage.
 
 ### How to calculate fees in FunC?
 

--- a/docs/develop/smart-contracts/fees.md
+++ b/docs/develop/smart-contracts/fees.md
@@ -38,7 +38,7 @@ Validators receive a small fee for processing transactions, and charging higher 
 
 ### How to calculate fees?
 
-Fees on TON are difficult to calculate in advance, as their amount depends on transaction run time, account status, message content and size, blockchain network settings, and a number of other variables that cannot be calculated until the transaction is sent. Read about [computation fees](https://www.tonspace.co/develop/howto/fees-low-level#computation-fees) in low-level article overview.
+Fees on TON are difficult to calculate in advance, as their amount depends on transaction run time, account status, message content and size, blockchain network settings, and a number of other variables that cannot be calculated until the transaction is sent. Read about [computation fees](/develop/howto/fees-low-level#computation-fees) in low-level article overview.
 
 That is why even NFT marketplaces usually take an extra amount of TON (_~1 TON_) and return (_`1 - transaction_fee`_) later.
 

--- a/docs/develop/smart-contracts/sdk/toncli.md
+++ b/docs/develop/smart-contracts/sdk/toncli.md
@@ -103,7 +103,7 @@ toncli start nft_colletion/jetton_minter/nft_item/jetton_wallet
 
 All of these projects have a lot of interesting examples of toncli and blockchain interaction, as well as extremely tests that will help in developing custom smart contracts.
 
-## To test smart contracts using toncli, go to [testing](https://ton.org/docs/develop/smart-contracts/testing/toncli)
+## To test smart contracts using toncli, go to [testing](/develop/smart-contracts/testing/toncli)
 
 
 ## Useful articles

--- a/docs/learn/services/sites-www-proxy.md
+++ b/docs/learn/services/sites-www-proxy.md
@@ -19,7 +19,7 @@ TON Network is deeply integrated with TON Blockchain, the project’s native Ton
 * The network uses the UDP/IP and TCP/IP internet protocols.
 
 
-You can find a more technical explanation of the protocols on the TON Network in Chapter 3 of The Open Network’s __[White Paper](https://www.tonspace.co/learn/docs)__.
+You can find a more technical explanation of the protocols on the TON Network in Chapter 3 of The Open Network’s __[White Paper](/learn/docs)__.
 
 ### TON Blockchain relies on TON Network
 
@@ -35,7 +35,7 @@ TON Blockchain is not the only thing that uses TON Network.
 
 Starting today, you can launch a web server with your website and make it available on the TON Network (i.e. you can make a TON Site).
 
-Read the guide __[here](https://www.tonspace.co/learn/services/sites-www-proxy)__.
+Read the guide __[here](/learn/services/sites-www-proxy)__.
 
 ### Mandatory encryption and verifying the authenticity of data
 
@@ -69,11 +69,11 @@ The biggest problem is that your domain name can be blocked or taken away from y
 
 Anyone can write to a domain name registry, saying that your website is engaging in illegal activity. It would be a false claim, but the registry’s employee would have to block your site, even without having all the details to fully understand the situation. This would inevitably lead to a lot of headaches and large losses.
 
-TON Sites uses __[TON DNS](https://www.tonspace.co/learn/services/dns)__, a fully decentralized domain name system.
+TON Sites uses __[TON DNS](/learn/services/dns)__, a fully decentralized domain name system.
 
 Incumbent domain registries require owners to make non-trivial payments, which go to pay for employees and other expenses, whereas with TON DNS, all you have to do is make an annual micropayment as a symbolic “sign of life” to confirm domain ownership.
 
-__[How to link a TON Site to a domain](https://www.tonspace.co/participate/web3/site-management#how-to-link-a-ton-site-to-a-domain)__
+__[How to link a TON Site to a domain](/participate/web3/site-management#how-to-link-a-ton-site-to-a-domain)__
 
 ### Sub-domains
 
@@ -158,11 +158,11 @@ Everything mentioned above is what creates TON WWW: the collection of web pages 
 
 To gain access to the TON Network, first, users must connect to a special entry point. In technical terms, this is called an "entry proxy".
 
-Currently, you can use __[public entry points](https://www.tonspace.co/participate/web3/setting-proxy#public-entry-ton-proxies)__ launched by TON Foundation.
+Currently, you can use __[public entry points](/participate/web3/setting-proxy#public-entry-ton-proxies)__ launched by TON Foundation.
 
 __|__ _Use public entry points along with HTTP for trial purposes only, as in this case, traffic outside the TON Network is not encrypted_
 
-Tech-savvy users can already __[launch entry proxies](https://www.tonspace.co/participate/web3/sites-and-proxy#running-entry-proxy-on-remote-computer)__ directly on their devices — in the near future, this will become available to all users in the form of a simple application.
+Tech-savvy users can already __[launch entry proxies](/participate/web3/sites-and-proxy#running-entry-proxy-on-remote-computer)__ directly on their devices — in the near future, this will become available to all users in the form of a simple application.
 
 ### In a browser
 ![image](/img/docs/in_a_browser.jpg)
@@ -171,7 +171,7 @@ Because TON Proxy is compatible with HTTP Proxy, you can simply open the setting
 
 You’ll then be able to open “.ton” sites directly in your browser, just like regular websites.
 
-Here’s a __[guide](https://www.tonspace.co/participate/web3/setting-proxy)__ on setting up TON Proxy for various browsers.
+Here’s a __[guide](/participate/web3/setting-proxy)__ on setting up TON Proxy for various browsers.
 
 ### Wallets
 
@@ -222,7 +222,7 @@ Starting with the TON Proxy 2.0 version, full anonymity will be available in the
 
 For the third stage, decentralized Toncoin economy will launch for the use of intermediary TON Proxies, which provide privacy to users and security to sites.
 
-The payment will occur through the Payment Network technology, a network of payment channels __[developed](https://www.tonspace.co/learn/services/payments)__ in Q2 2022. An intermediary proxy node is going to receive micropayments for internet traffic packages (e.g. for 128 KiB) that run through it. These micropayments will be charged and deducted from users’ crypto wallets.
+The payment will occur through the Payment Network technology, a network of payment channels __[developed](/learn/services/payments)__ in Q2 2022. An intermediary proxy node is going to receive micropayments for internet traffic packages (e.g. for 128 KiB) that run through it. These micropayments will be charged and deducted from users’ crypto wallets.
 
 Thanks to this decentralized payments system, independent administrators will be able to run intermediary proxy nodes in various parts of the world, which will increase the effectiveness and speed of the network and make it more scalable and stable.
 

--- a/docs/participate/ton-storage/storage-daemon.md
+++ b/docs/participate/ton-storage/storage-daemon.md
@@ -10,11 +10,11 @@ You can download `storage-daemon` and `storage-daemon-cli` for Linux/Windows/Mac
 
 ## Compile from sources
 
-You can compile `storage-daemon` and `storage-damon-cli` from sources using this [instruction](https://ton.org/docs/develop/howto/compile#storage-daemon).
+You can compile `storage-daemon` and `storage-damon-cli` from sources using this [instruction](/develop/howto/compile#storage-daemon).
 
 ## Key concepts
 * *Bag of files* or *Bag* - a collection of files distributed through TON Storage
-* TON Storage's network part is based on technology similar to torrents, so the terms *Torrent*, *Bag of files*, and *Bag* will be used interchangeably. It's important to note some differences, however: TON Storage transfers data over [ADNL](https://ton.org/docs/learn/networking/adnl) by [RLDP](https://ton.org/docs/learn/networking/rldp) protocol, each *Bag* is distributed through its own network overlay, the merkle structure can exist in two versions - with large chunks for efficient downloading and small ones for efficient ownership proof, and [TON DHT](https://ton.org/docs/learn/networking/ton-dht) network is used for finding peers.
+* TON Storage's network part is based on technology similar to torrents, so the terms *Torrent*, *Bag of files*, and *Bag* will be used interchangeably. It's important to note some differences, however: TON Storage transfers data over [ADNL](/learn/networking/adnl) by [RLDP](/learn/networking/rldp) protocol, each *Bag* is distributed through its own network overlay, the merkle structure can exist in two versions - with large chunks for efficient downloading and small ones for efficient ownership proof, and [TON DHT](/learn/networking/ton-dht) network is used for finding peers.
 * A *Bag of files* consists of *torrent info* and a data block.
 * The data block starts with a *torrent header* - a structure that contains a list of files with their names and sizes. The files themselves follow in the data block.
 * The data block is divided into chunks (128 KB by default), and a *merkle tree* (made of TVM cells) is built on the SHA256 hashes of these chunks. This allows building and verifying *merkle proofs* of individual chunks, as well as efficiently updating the *Bag* by exchanging only the proof of the modified chunk.
@@ -35,7 +35,7 @@ You can compile `storage-daemon` and `storage-damon-cli` from sources using this
 ```storage-daemon -v 3 -C global.config.json -I <ip>:3333 -p 5555 -D storage-db```
 
 * `-v` - verbosity level (INFO)
-* `-C` - global network config ([download global config](https://ton.org/docs/develop/howto/compile#download-global-config))
+* `-C` - global network config ([download global config](/develop/howto/compile#download-global-config))
 * `-I` - IP address and port for adnl
 * `-p` - TCP port for console interface
 * `-D` - directory for the storage daemon database

--- a/docs/participate/ton-storage/storage-faq.md
+++ b/docs/participate/ton-storage/storage-faq.md
@@ -2,7 +2,7 @@
 
 ## How to assign a TON domain to a TON Storage bag of files
 
-1. [Upload](https://ton.org/docs/participate/ton-storage/storage-daemon#creating-a-bag-of-files) the bag of files to the network and get the Bag ID
+1. [Upload](/participate/ton-storage/storage-daemon#creating-a-bag-of-files) the bag of files to the network and get the Bag ID
 
 2. Open the Google Chrome browser on your computer.
 
@@ -17,7 +17,7 @@
 
 ## How to host static TON site in TON Storage
 
-1. [Create](https://ton.org/docs/participate/ton-storage/storage-daemon#creating-a-bag-of-files) the Bag from folder with website files, upload it to the network and get the Bag ID. Folder must contain `index.html` file.
+1. [Create](/participate/ton-storage/storage-daemon#creating-a-bag-of-files) the Bag from folder with website files, upload it to the network and get the Bag ID. Folder must contain `index.html` file.
 
 2. Open the Google Chrome browser on your computer.
 
@@ -46,7 +46,7 @@ dns_storage_address#7473 bag_id:uint256 = DNSRecord;
 
 ## How to host static TON site in TON Storage (Low Level)
 
-[Create](https://ton.org/docs/participate/ton-storage/storage-daemon#creating-a-bag-of-files) the Bag from folder with website files, upload it to the network and get the Bag ID. Folder must contain `index.html` file.
+[Create](/participate/ton-storage/storage-daemon#creating-a-bag-of-files) the Bag from folder with website files, upload it to the network and get the Bag ID. Folder must contain `index.html` file.
 
 You need to assign the following value to the sha256("site") DNS Record of your TON domain:
 

--- a/docs/participate/ton-storage/storage-provider.md
+++ b/docs/participate/ton-storage/storage-provider.md
@@ -8,7 +8,7 @@ You can download `storage-daemon` and `storage-daemon-cli` for Linux/Windows/Mac
 
 ## Compile from sources
 
-You can compile `storage-daemon` and `storage-damon-cli` from sources using this [instruction](https://ton.org/docs/develop/howto/compile#storage-daemon).
+You can compile `storage-daemon` and `storage-damon-cli` from sources using this [instruction](/develop/howto/compile#storage-daemon).
 
 ## Key concepts
 It consists of a smart contract that accepts storage requests and manages payment from clients, and an application that uploads and serves the files to clients. Here's how it works:

--- a/i18n/ko/docusaurus-plugin-content-docs/current/contribute/hacktoberfest/README.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/contribute/hacktoberfest/README.mdx
@@ -21,7 +21,7 @@ Rules of the Hacktoberfest event in 2022 are:
 * **Hacktoberfest is open to everyone**!
 * Register anytime between September 26 and October 31
 * Pull requests can be made in any GITHUB or GITLAB project:
-  * [List of projects on TON Ecosystem](https://tonspace.co/hacktonberfest)
+  * [List of projects on TON Ecosystem](/hacktonberfest)
   * [List of projects on GitHub](https://github.com/topics/hacktoberfest)
 * Have **4** pull/merge requests accepted between October 1 and October 31
 * The first 40,000 participants (maintainers and contributors) who complete Hacktoberfest can elect to receive one of two prizes: a tree planted in their name, or the Hacktoberfest 2022 t-shirt. _(from Hacktoberfest community)_

--- a/i18n/ko/docusaurus-plugin-content-docs/current/develop/dapps/payment-processing/accept-payments-in-a-telegram-bot-2.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/develop/dapps/payment-processing/accept-payments-in-a-telegram-bot-2.md
@@ -416,7 +416,7 @@ async def welcome_handler(message: types.Message):
 
     # Send welcome text and include the keyboard
     await message.answer('Hi!\nI am example bot '
-                         'made for [this article](https://www.tonspace.co/develop/dapps/payment-processing/accept-payments-in-a-telegram-bot-2).\n'
+                         'made for [this article](/develop/dapps/payment-processing/accept-payments-in-a-telegram-bot-2).\n'
                          'My goal is to show how simple it is to receive '
                          'payments in Toncoin with Python.\n\n'
                          'Use keyboard to test my functionality.',

--- a/i18n/ko/docusaurus-plugin-content-docs/current/develop/smart-contracts/fees.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/develop/smart-contracts/fees.md
@@ -38,7 +38,7 @@ Validators receive a small fee for processing transactions, and making higher co
 
 ### How to calculate fees?
 
-Fees on TON are difficult to calculate in advance, as their amount depends on transaction run time, account status, message content and size, blockchain's network setting – and also on many variables that cannot be calculated until the transaction is sent. Read about [computation fees](https://www.tonspace.co/develop/howto/fees-low-level#computation-fees) in low-level article overview.
+Fees on TON are difficult to calculate in advance, as their amount depends on transaction run time, account status, message content and size, blockchain's network setting – and also on many variables that cannot be calculated until the transaction is sent. Read about [computation fees](/develop/howto/fees-low-level#computation-fees) in low-level article overview.
 
 That is why even NFT marketplaces usually take an extra amount of TON (_~1 TON_) and return (_`1 - transaction_fee`_) later.
 

--- a/i18n/zh-Hant/docusaurus-plugin-content-docs/current/contribute/hacktoberfest/README.mdx
+++ b/i18n/zh-Hant/docusaurus-plugin-content-docs/current/contribute/hacktoberfest/README.mdx
@@ -21,7 +21,7 @@ The Hacktoberfest rules for 2022 are as follows:
 * **Hacktoberfest is open to everyone**!
 * Register anytime between September 26 and October 31
 * Pull requests can be made in any GITHUB or GITLAB project:
-  * [List of projects on TON Ecosystem](https://tonspace.co/hacktonberfest)
+  * [List of projects on TON Ecosystem](/hacktonberfest)
   * [List of projects on GitHub](https://github.com/topics/hacktoberfest)
 * Have **4** pull/merge requests accepted between October 1 and October 31
 * The first 40,000 participants (maintainers and contributors) who complete Hacktoberfest can choose between two prizes: a tree planted in their honor or a Hacktoberfest 2022 t-shirt. _(from the Hacktoberfest community)_

--- a/i18n/zh-Hant/docusaurus-plugin-content-docs/current/develop/dapps/tutorials/accept-payments-in-a-telegram-bot-2.md
+++ b/i18n/zh-Hant/docusaurus-plugin-content-docs/current/develop/dapps/tutorials/accept-payments-in-a-telegram-bot-2.md
@@ -424,7 +424,7 @@ async def welcome_handler(message: types.Message):
 
     # Send welcome text and include the keyboard
     await message.answer('Hi!\nI am example bot '
-                         'made for [this article](https://www.tonspace.co/develop/dapps/payment-processing/accept-payments-in-a-telegram-bot-2).\n'
+                         'made for [this article](/develop/dapps/payment-processing/accept-payments-in-a-telegram-bot-2).\n'
                          'My goal is to show how simple it is to receive '
                          'payments in Toncoin with Python.\n\n'
                          'Use keyboard to test my functionality.',

--- a/i18n/zh-Hant/docusaurus-plugin-content-docs/current/develop/dapps/tutorials/accept-payments-in-a-telegram-bot-js.md
+++ b/i18n/zh-Hant/docusaurus-plugin-content-docs/current/develop/dapps/tutorials/accept-payments-in-a-telegram-bot-js.md
@@ -301,7 +301,7 @@ export default async function handleStart(ctx) {
   const menu = new InlineKeyboard()
     .text("Buy dumplings🥟", "buy")
     .row()
-    .url("Article with a detailed explanation of the bot's work", "https://tonspace.co/develop/dapps/payment-processing/accept-payments-in-a-telegram-bot-js/");
+    .url("Article with a detailed explanation of the bot's work", "/develop/dapps/payment-processing/accept-payments-in-a-telegram-bot-js/");
 
   await ctx.reply(
     `Hello stranger!

--- a/i18n/zh-Hant/docusaurus-plugin-content-docs/current/develop/dapps/tutorials/jetton-minter.md
+++ b/i18n/zh-Hant/docusaurus-plugin-content-docs/current/develop/dapps/tutorials/jetton-minter.md
@@ -106,7 +106,7 @@ Then go to **your token**, set the **amount** to send, and enter the **recipient
 
  ## ✏️ Jetton (token) customization
 
-With [FunC](https://www.tonspace.co/develop/func/overview) language you can change the behavior of the token in your favor.
+With [FunC](/develop/func/overview) language you can change the behavior of the token in your favor.
 
 To make any changes, begin here:
 

--- a/i18n/zh-Hant/docusaurus-plugin-content-docs/current/develop/smart-contracts/fees.md
+++ b/i18n/zh-Hant/docusaurus-plugin-content-docs/current/develop/smart-contracts/fees.md
@@ -38,7 +38,7 @@ Validators receive a small fee for processing transactions, and charging higher 
 
 ### How to calculate fees?
 
-Fees on TON are difficult to calculate in advance, as their amount depends on transaction run time, account status, message content and size, blockchain network settings, and a number of other variables that cannot be calculated until the transaction is sent. Read about [computation fees](https://www.tonspace.co/develop/howto/fees-low-level#computation-fees) in low-level article overview.
+Fees on TON are difficult to calculate in advance, as their amount depends on transaction run time, account status, message content and size, blockchain network settings, and a number of other variables that cannot be calculated until the transaction is sent. Read about [computation fees](/develop/howto/fees-low-level#computation-fees) in low-level article overview.
 
 That is why even NFT marketplaces usually take an extra amount of TON (_~1 TON_) and return (_`1 - transaction_fee`_) later.
 

--- a/i18n/zh-Hant/docusaurus-plugin-content-docs/current/learn/services/sites-www-proxy.md
+++ b/i18n/zh-Hant/docusaurus-plugin-content-docs/current/learn/services/sites-www-proxy.md
@@ -19,7 +19,7 @@ TON Network is deeply integrated with TON Blockchain, the project’s native Ton
 * The network uses the UDP/IP and TCP/IP internet protocols.
 
 
-You can find a more technical explanation of the protocols on the TON Network in Chapter 3 of The Open Network’s __[White Paper](https://www.tonspace.co/learn/docs)__.
+You can find a more technical explanation of the protocols on the TON Network in Chapter 3 of The Open Network’s __[White Paper](/learn/docs)__.
 
 ### TON Blockchain relies on TON Network
 
@@ -35,7 +35,7 @@ TON Blockchain is not the only thing that uses TON Network.
 
 Starting today, you can launch a web server with your website and make it available on the TON Network (i.e. you can make a TON Site).
 
-Read the guide __[here](https://www.tonspace.co/learn/services/sites-www-proxy)__.
+Read the guide __[here](/learn/services/sites-www-proxy)__.
 
 ### Mandatory encryption and verifying the authenticity of data
 
@@ -69,11 +69,11 @@ The biggest problem is that your domain name can be blocked or taken away from y
 
 Anyone can write to a domain name registry, saying that your website is engaging in illegal activity. It would be a false claim, but the registry’s employee would have to block your site, even without having all the details to fully understand the situation. This would inevitably lead to a lot of headaches and large losses.
 
-TON Sites uses __[TON DNS](https://www.tonspace.co/learn/services/dns)__, a fully decentralized domain name system.
+TON Sites uses __[TON DNS](/learn/services/dns)__, a fully decentralized domain name system.
 
 Incumbent domain registries require owners to make non-trivial payments, which go to pay for employees and other expenses, whereas with TON DNS, all you have to do is make an annual micropayment as a symbolic “sign of life” to confirm domain ownership.
 
-__[How to link a TON Site to a domain](https://www.tonspace.co/participate/web3/site-management#how-to-link-a-ton-site-to-a-domain)__
+__[How to link a TON Site to a domain](/participate/web3/site-management#how-to-link-a-ton-site-to-a-domain)__
 
 ### Sub-domains
 
@@ -158,11 +158,11 @@ Everything mentioned above is what creates TON WWW: the collection of web pages 
 
 To gain access to the TON Network, first, users must connect to a special entry point. In technical terms, this is called an "entry proxy".
 
-Currently, you can use __[public entry points](https://www.tonspace.co/participate/web3/setting-proxy#public-entry-ton-proxies)__ launched by TON Foundation.
+Currently, you can use __[public entry points](/participate/web3/setting-proxy#public-entry-ton-proxies)__ launched by TON Foundation.
 
 __|__ _Use public entry points along with HTTP for trial purposes only, as in this case, traffic outside the TON Network is not encrypted_
 
-Tech-savvy users can already __[launch entry proxies](https://www.tonspace.co/participate/web3/sites-and-proxy#running-entry-proxy-on-remote-computer)__ directly on their devices — in the near future, this will become available to all users in the form of a simple application.
+Tech-savvy users can already __[launch entry proxies](/participate/web3/sites-and-proxy#running-entry-proxy-on-remote-computer)__ directly on their devices — in the near future, this will become available to all users in the form of a simple application.
 
 ### In a browser
 ![image](/img/docs/in_a_browser.jpg)
@@ -171,7 +171,7 @@ Because TON Proxy is compatible with HTTP Proxy, you can simply open the setting
 
 You’ll then be able to open “.ton” sites directly in your browser, just like regular websites.
 
-Here’s a __[guide](https://www.tonspace.co/participate/web3/setting-proxy)__ on setting up TON Proxy for various browsers.
+Here’s a __[guide](/participate/web3/setting-proxy)__ on setting up TON Proxy for various browsers.
 
 ### Wallets
 
@@ -222,7 +222,7 @@ Starting with the TON Proxy 2.0 version, full anonymity will be available in the
 
 For the third stage, decentralized Toncoin economy will launch for the use of intermediary TON Proxies, which provide privacy to users and security to sites.
 
-The payment will occur through the Payment Network technology, a network of payment channels __[developed](https://www.tonspace.co/learn/services/payments)__ in Q2 2022. An intermediary proxy node is going to receive micropayments for internet traffic packages (e.g. for 128 KiB) that run through it. These micropayments will be charged and deducted from users’ crypto wallets.
+The payment will occur through the Payment Network technology, a network of payment channels __[developed](/learn/services/payments)__ in Q2 2022. An intermediary proxy node is going to receive micropayments for internet traffic packages (e.g. for 128 KiB) that run through it. These micropayments will be charged and deducted from users’ crypto wallets.
 
 Thanks to this decentralized payments system, independent administrators will be able to run intermediary proxy nodes in various parts of the world, which will increase the effectiveness and speed of the network and make it more scalable and stable.
 


### PR DESCRIPTION
There were many absolute links like https://ton.org/docs/*****, or even some old legacy https://tonspace.co/****

I've replaced all of them with working relative links