### PR TITLE
add ton-connect docs

### DIFF
--- a/docs/develop/dapps/README.md
+++ b/docs/develop/dapps/README.md
@@ -87,14 +87,13 @@ To add login button to your website or web app use the following:
 ### TON Connect
 
 [ton-connect](
-https://tonkeeper.gitbook.io/ton-connect-2.0-guide-for-sdk/) is a unified authorization standard for every wallet in the TON ecosystem. It's supported and developed by Tonkeeper team with tech advisors from TON Community.
+/develop/dapps/tonconnect) is a unified authorization standard for every wallet in the TON ecosystem. It's supported and developed by Tonkeeper team with tech advisors from TON Community.
 
 #### Documentation
 
-* [Introducing TON Connect](
-  https://tonkeeper.gitbook.io/ton-connect-2.0-guide-for-sdk/)
-* [TON Connect for Developers](https://tonkeeper.gitbook.io/ton-connect-2.0-guide-for-sdk/ton-connect-for-developers)
-* [TON Connect 2.0 vs 1.0](https://tonkeeper.gitbook.io/ton-connect-2.0-guide-for-sdk/ton-connect-2.0-vs-1.0)
+* [Introducing TON Connect](/develop/dapps/tonconnect)
+* [TON Connect for Developers](/develop/dapps/tonconnect/developers)
+* [TON Connect 2.0 vs 1.0](/develop/dapps/tonconnect/comparison)
 
 #### Development
 

--- a/docs/develop/dapps/tonconnect/README.md
+++ b/docs/develop/dapps/tonconnect/README.md
@@ -1,0 +1,15 @@
+# Overview
+
+TON Connect is a communication protocol between **wallets** and **apps** in the TON ecosystem.
+
+**Apps** in TON provide rich functionality and high performance, while protecting users’ funds via smart contracts. Therefore they are often called decentralized apps or “dapps”.
+
+**Wallets** provide the UI to approving transactions and hold users’ cryptographic keys securely on their personal devices.
+This separation of concerns enables rapid innovation and high level of security for the users: wallets do not need to build walled-garden ecosystems themselves, while the apps do not need to take the risk holding end users’ accounts. TON Connect aims of offering a seamless user experience between the wallets and the apps.
+
+In this documentation you will find main steps to implement TON Connect in your application.
+
+- [TON Connect for Business](/develop/dapps/tonconnect/business)
+- [TON Connect for Developers](/develop/dapps/tonconnect/developers)
+- [TON Connect for Security](/develop/dapps/tonconnect/security)
+- [TON Connect 2.0 vs 1.0](/develop/dapps/tonconnect/comparison)

--- a/docs/develop/dapps/tonconnect/business.md
+++ b/docs/develop/dapps/tonconnect/business.md
@@ -1,0 +1,58 @@
+# TON Connect for Business
+
+TON Connect offers powerful features, attracts traffic and increases retention.
+
+## Product features
+
+- secure and private authentication with controlled disclosure of personal data;
+- signing arbitrary transactions on the TON blockchain within a single user session;
+- instant connectivity between your app and the user’s wallet;
+- your app is automatically available right within the wallet.
+
+## Impact on product metrics
+
+- attract traffic through the wallets supporting TON Connect;
+- increase user retention by saving the app to recently opened list and favorites apps list;
+- increase user engagement through interaction with multiple applications;
+
+## Adopting TON Connect
+
+### Basic steps
+
+Implement TON Connect in your application using the SDK. The implementation requires minimal efforts, and can be performed by your app’s developer. The standard and documentation is available openly.
+
+Users launch your app and connect it to one of the wallets that support TON Connect via QR code and or a universal link. Apps could also be opened within a wallet in a built-in browser.
+
+Keep your up to date with future features in TON Connect.
+
+### Integration assistance from the TON Connect developers
+
+Describe the existing user flow of your application.
+
+Identify the operations you need (e.g. transaction authorization, message signing).
+
+Describe your technology stack.
+
+Send information to our [bizdev team](https://t.me/tonrostislav). We will offer you the optimal solution for your application.
+
+### Common implementation cases
+
+In this [SDK](https://github.com/ton-connect/sdk) you can find detailed instructions to implement TON Connect.
+
+Provided functionality allows:
+
+- connect to your application with a TON wallet,
+- log in to your backend using the wallet's address,
+- send transactions and then sign any actions with the wallet.
+
+SDK, specifications and a demo app are available on Github: [https://github.com/ton-connect/](https://github.com/ton-connect/demo-dapp)​
+
+### Currently supported technology stack:
+
+- any web applications — serverless and backends;
+- React-Native mobile apps;
+- coming soon: SDK for mobile applications in Swift, Java, Kotlin.
+
+TON Connect is an open protocol. You can implement and use it to develop dapps in any environment and with any programming language.
+
+For JavaScript applications, we have made a JS SDK that implements the protocol and allows you to integrate TON Connect in minutes. SDKs for other popular programming languages will be available in the future.

--- a/docs/develop/dapps/tonconnect/comparison.md
+++ b/docs/develop/dapps/tonconnect/comparison.md
@@ -1,0 +1,17 @@
+# TON Connect 2.0 vs 1.0
+
+TON Connect 2.0 solves many problems of the first version of the protocol. TON Connect 2.0 provides the highest level of security, user experience driven by real-time UX, and ease of development of decentralized applications.
+
+See the protocols comparison below:
+
+|                                    | TON&nbsp;Connect&nbsp;v1 |               TON&nbsp;Connect&nbsp;v2               |
+| :--------------------------------: | :----------------------: | :--------------------------------------------------: |
+|   Connecting to web-based dapps    |            ✔︎            |                          ✔︎                          |
+|        Sending transactions        |            ✔︎            |                          ✔︎                          |
+| Connecting dapps within the wallet |                          |                          ✔︎                          |
+|          Scanning QR code          |     for every action     |               once, during connection                |
+|          Serverless dapps          |                          |                          ✔︎                          |
+|            Realtime UX             |                          |                          ✔︎                          |
+|         Switching accounts         |                          |                         soon                         |
+| Messages from the app to the user  |                          |                         soon                         |
+|              Wallets               |        Tonkeeper         | Tonkeeper, OpenMask (soon), TonHub (soon) and others |

--- a/docs/develop/dapps/tonconnect/developers.md
+++ b/docs/develop/dapps/tonconnect/developers.md
@@ -10,21 +10,21 @@ Repository contains three packages:
 - ​[@tonconnect/protocol](https://www.npmjs.com/package/@tonconnect/protocol)​
 - @tonconnect/ui
 
-**TON Connect SDK**
+## TON Connect SDK
 
 - ​[github link](https://github.com/ton-connect/sdk/tree/main/packages/sdk)​
 - ​[npm link](https://www.npmjs.com/package/@tonconnect/sdk)​
 
 Use it to connect your app to TON wallets via TON Connect protocol. You can find the full description in the link above.
 
-**TON Connect protocol models**
+## TON Connect protocol models
 
 - ​[github link](https://github.com/ton-connect/sdk/tree/main/packages/protocol)​
 - ​[npm link](https://www.npmjs.com/package/@tonconnect/protocol)​
 
 This package contains protocol requests, responses and event models and encoding, decoding functions. You can use it to integrate TON Connect to your wallet app (written with TypeScript). If you want to integrate TON Connect to your dapp, you should use [@tonconnect/sdk](https://www.npmjs.com/package/@tonconnect/sdk).
 
-**TON Connect UI**
+## TON Connect UI
 
 This package is work in progress right now. It will allow you to integrate TON Connect to your app easier using our UI elements such as "connect wallet button", "select wallet dialog" and confirmation modals.
 
@@ -36,7 +36,7 @@ Bridge server on Go: [github link](https://github.com/ton-connect/bridge)​
 
 ​
 
-**Coming soon**
+## Coming soon
 
 In the near future, the standard TON Connect UI will be available to all developers, including:
 

--- a/docs/develop/dapps/tonconnect/developers.md
+++ b/docs/develop/dapps/tonconnect/developers.md
@@ -1,0 +1,55 @@
+# TON Connect for Developers
+
+**Before you start implementing TON Connect in your application or service, we recommend to read the following documentation.**
+
+This is the implementation of the TON Connect. To find more details about TON Connect protocol see the dedicated [docs](https://github.com/ton-connect/docs). Also you can observe example of the TON Connect integration in the dapp on [Github](https://github.com/ton-connect/demo-dapp).
+
+Repository contains three packages:
+
+- ​[@tonconnect/sdk](https://www.npmjs.com/package/@tonconnect/sdk)​
+- ​[@tonconnect/protocol](https://www.npmjs.com/package/@tonconnect/protocol)​
+- @tonconnect/ui
+
+**TON Connect SDK**
+
+- ​[github link](https://github.com/ton-connect/sdk/tree/main/packages/sdk)​
+- ​[npm link](https://www.npmjs.com/package/@tonconnect/sdk)​
+
+Use it to connect your app to TON wallets via TON Connect protocol. You can find the full description in the link above.
+
+**TON Connect protocol models**
+
+- ​[github link](https://github.com/ton-connect/sdk/tree/main/packages/protocol)​
+- ​[npm link](https://www.npmjs.com/package/@tonconnect/protocol)​
+
+This package contains protocol requests, responses and event models and encoding, decoding functions. You can use it to integrate TON Connect to your wallet app (written with TypeScript). If you want to integrate TON Connect to your dapp, you should use [@tonconnect/sdk](https://www.npmjs.com/package/@tonconnect/sdk).
+
+**TON Connect UI**
+
+This package is work in progress right now. It will allow you to integrate TON Connect to your app easier using our UI elements such as "connect wallet button", "select wallet dialog" and confirmation modals.
+
+Basic example of an app functionality in the dapp browser: [github link](https://ton-connect.github.io/demo-dapp/)​
+
+Example of a backend part of the dapp above [github link](https://github.com/ton-connect/demo-dapp-backend)​
+
+Bridge server on Go: [github link](https://github.com/ton-connect/bridge)​
+
+​
+
+**Coming soon**
+
+In the near future, the standard TON Connect UI will be available to all developers, including:
+
+- modal wallet selection window;
+
+- connect button;
+
+- interfaces for connecting and signing transactions, etc.
+
+This kit will simplify the implementation of TON Connect in your apps. Standard frontend frameworks will be supported, as well as applications implemented without frameworks
+
+For additional issues in the process of TON Connect 2.0 implementation, you should to contact with our team in the special chat: [Telegram chat for the Developers](https://t.me/tonkeeperdev)​
+
+​
+
+If you have any issues or proposals, you can send it directly through appropriate [GitHub directory](https://github.com/ton-connect/).

--- a/docs/develop/dapps/tonconnect/security.md
+++ b/docs/develop/dapps/tonconnect/security.md
@@ -1,0 +1,15 @@
+# TON Connect for Security
+
+TON Connect ensures that user has explicit control over the data they share, data does not leak in-between apps and wallets, and wallets offer strong cryptographic authentication to the apps.
+
+## User data and funds security
+
+- Users’ data is end-to-end encrypted when transmitted through the bridge to the wallet. This allows wallets and apps use third-party bridge servers without worrying about data integrity and safety.
+- User is authenticated with their wallet address. Users may use multiple wallets and can choose explicitly which one they are using with any particular app.
+- Protocol allows requesting personal data items (contact details, KYC info etc.) — the user explicitly confirms sharing of such data.
+
+You can find more details and code examples on [TON Connect Github](https://github.com/ton-connect/).
+
+​
+
+​

--- a/sidebars.js
+++ b/sidebars.js
@@ -295,6 +295,17 @@ const sidebars = {
         },
         {
           type: 'category',
+          label: 'Ton Connect',
+          items: [
+            'develop/dapps/tonconnect/README',
+            'develop/dapps/tonconnect/business',
+            'develop/dapps/tonconnect/developers',
+            'develop/dapps/tonconnect/security',
+            'develop/dapps/tonconnect/comparison',
+          ],
+        },
+        {
+          type: 'category',
           label: 'Payment Processing',
           items: [
             'develop/dapps/asset-processing/README',


### PR DESCRIPTION
Moving Ton Connect documentation from https://tonkeeper.gitbook.io/ton-connect-2.0-guide-for-sdk/