### PR TITLE
Network and data formats documentation from ton-deep-doc

### DIFF
--- a/docs/develop/data-formats/cell-boc.md
+++ b/docs/develop/data-formats/cell-boc.md
@@ -1,0 +1,208 @@
+# Cell & Bag of Cells
+
+## Cell
+Cell represents a container for data that can store up to 1023 bits and have up to 4 references to other Cells. In TON, everything consists of cells, contract code, stored data, blocks. This approach achieves flexibility.
+
+## Bag of Cells
+Bag of Cells - format for serializing cells into an array of bytes, described as [TL-B schema](https://github.com/ton-blockchain/ton/blob/24dc184a2ea67f9c47042b4104bbb4d82289fac1/crypto/tl/boc.tlb#L25).
+
+### Cell serialization
+Let's analyze this kind of cell:
+```
+1[8_] -> {
+  24[0AAAAA],
+  7[FE] -> {
+    24[0AAAAA]
+  }
+}
+```
+Here we have a 1-bit size root cell that has 2 links: the first to a 24-bit cell and the second to a 7-bit cell, which has 1 link to a 24-bit cell.
+
+We need to turn the cells into a flat set of bytes, for this we first need to leave only unique cells - we have 3 out of 4 of them. We have:
+```
+1[8_]
+24[0AAAAA]
+7[FE]
+```
+Now let's arrange them in such an order that the parent cells do not point backwards. The cell pointed to by the rest must be in the list after the ones that point to it. We get:
+```
+1[8_]      -> index 0 (root cell)
+7[FE]      -> index 1
+24[0AAAAA] -> index 2
+```
+
+Let's calculate descriptors for each of them. These are 2 bytes that store flags, information about the length of the data and the number of links. The flags will be omitted in the current parse, they are almost always 0. The first byte contains 5 flag bits and 3 link count bits. 
+The second byte is the length of the full 4-bit groups (but at least 1 if not empty). We get:
+```
+1[8_]      -> 0201 -> 2 links, length 1 
+7[FE]      -> 0101 -> 1 link, length 1
+24[0AAAAA] -> 0006 -> 0 links, length 6
+```
+For data with incomplete 4-bit groups, 1 bit is added to the end. It means the end bit of the group and is used to determine the true size of incomplete groups. Let's add it:
+```
+1[8_]      -> C0     -> 0b10000000->0b11000000
+7[FE]      -> FF     -> 0b11111110->0b11111111
+24[0AAAAA] -> 0AAAAA -> do not change (full groups)
+```
+
+Now let's add link indexes:
+```
+0 1[8_]      -> 0201 -> refers to 2 cells with such indexes
+1 7[FE]      -> 02 -> refers to cells with index 2
+2 24[0AAAAA] -> no links
+```
+
+And put it all together:
+```
+0201 C0     0201  
+0101 AA     02
+0006 0AAAAA 
+```
+
+And concat it into the single array of bytes:
+`0201c002010101ff0200060aaaaa`, size 14 bytes.
+
+[Serialization example](https://github.com/xssnick/tonutils-go/blob/3d9ee052689376061bf7e4a22037ff131183afad/tvm/cell/serialize.go#L205)
+
+### Packing in BoC
+Let's pack the cell from the previous section. We have already serialized it into a flat 14 byte array.
+
+We build the title according to [schema](https://github.com/ton-blockchain/ton/blob/24dc184a2ea67f9c47042b4104bbb4d82289fac1/crypto/tl/boc.tlb#L25).
+
+```
+b5ee9c72                      -> id tl-b of the BoC structure
+01                            -> flags and size:(## 3), in our case the flags are all 0,
+                                 and the number of bytes needed to store the number of cells is 1.
+                                 we get - 0b0_0_0_00_001
+01                            -> number of bytes to store the size of the serialized cells
+03                            -> number of cells, 1 byte (defined by 3 bits size:(## 3), equal to 3.
+01                            -> number of root cells - 1
+00                            -> absent, always 0 (in current implementations)
+0e                            -> size of serialized cells, 1 byte (size defined above), equal to 14
+00                            -> root cell index, size 1 (determined by 3 size:(## 3) bits from header),
+                                 always 0
+0201c002010101ff0200060aaaaa  -> serialized cells
+```
+
+We concat everything above into an array of bytes and get:
+`b5ee9c7201010301000e000201c002010101ff0200060aaaaa` This is our final BoC!
+
+BoC Implementation Examples: [Serialization](https://github.com/xssnick/tonutils-go/blob/master/tvm/cell/serialize.go), [Deserialization](https://github.com/xssnick/tonutils-go/blob/master/tvm/cell/parse.go)
+
+## Special cells
+
+Cells are divided into two types: ordinary and special. Most of the cells that the user works with are ordinary and simply carry information. But for the internal functionality of the network, special cells are often used, which work according to a slightly different scenario, depending on the subtype of the special cell.
+
+The type of special cell is determined by the first 8 bits of its data and can be one of the following:
+```
+0x01: PrunnedBranch
+0x02: Library
+0x03: MerkleProof
+0x04: MerkleUpdate
+```
+In the sections below, we will discuss special types in more detail.
+
+### Merkle Proof
+A cell of this type is a hash tree and carries a proof that a part of the cell tree data belongs to the full tree, while the verifier may not know the full contents of the tree, but only know its root hash.
+
+Within itself, a cell carries the root hash of an object, for example, a block, and a hash tree of its branches as a child cell. The internal tree itself repeats the structure of the original object, the proof of which it is, but at the same time, all branches that are not part of the data that needs to be proved and do not lead to it are replaced by special cells of the `PrunnedBranch` type, which instead of data store its hash. 
+Thus, having calculated the root hash of the entire tree, we should get the same hash from the root cell data of the merkle proof type, which should match the hash known to us in advance, for example, hash of a block. This approach allows us to prove, for example, the existence of a transaction in a block, provided that the one to whom we prove this knows the hash of the block.
+
+#### Proof example for getAccountState
+The object is a proof for the structure [ShardStateUnsplit](https://github.com/ton-blockchain/ton/blob/master/crypto/block/block.tlb#L399). But instead of the whole block - contains only our requested account - `EQCVRJ-RqeZWcDqgTzzcxUIrChFYs0SyKGUvye9kGOuEWndQ`. All branches that are not related to it and not leading to it are replaced with `Prunned`, and those that lead to it are `Ordinary` cells and contain the actual block data.
+
+The symbol `*` marks special cells, the root one has type 0x03 - MerkleProof, the rest 0x01 - Pruned.
+<details>
+  <summary><b>Show example</b></summary>
+
+```
+280[03E42E9D59FE3B0900D185EA76AA5F64C6FA0F0C723FFD3CCA5F22B21354064C540219]* -> {
+  362[9023AFE2FFFFFF110000000000000000000000000001E9AA7F0000000163C1322C00001F522060E3C10194CD420_] -> {
+    288[0101CA91D55F8B903536211B4FB74EA37FD7930C3774D76FE64B45BCB1FE0E1E26380002]*,
+    75[8209C398C55C7BDDF32_] -> {
+      76[0104E1CC62AE3DEEF99_] -> {
+        288[01011D8C7CB5BFB085D47FB85883C71A7A1DC5B4856A2B9C27DE05F63E994D4A557A0216]*,
+        76[0101A1AB8F37E15D045_] -> {
+          76[01010A762B5E3DB9BB3_] -> {
+            76[01007896888C1BF9AFF_] -> {
+              288[0101658DA3EABE6B20FA399239F51BF78EB7DB0D8AAE0572E682B986268E041F71590036]*,
+              68[00F45169A7CA17BB3_] -> {
+                68[00E1E486CCD6F2D24_] -> {
+                  288[0101F2B70E32B323C3E1817C1780D7A2A49D08BA63B9B9D024B3C713AB936ECA3FD40028]*,
+                  68[00E17E05DDDEF5882_] -> {
+                    68[00E0EEBE3D59F5624_] -> {
+                      288[0101447569C499386266F623BB34E72EF718158ACC2E76ED42F88C6D842D503CDF900020]*,
+                      68[00E0B73C712EA7A3C_] -> {
+                        68[00E026EB80E87B804_] -> {
+                          288[01015DB34588AAB7AF2A5034E0C26168E51FAED17544C56405B0F80CD967A4EE5BD9001B]*,
+                          68[00E023322BD069152_] -> {
+                            68[00E0220B791895CE8_] -> {
+                              68[00E0208438C7659B4_] -> {
+                                68[00E0201CBDC2FA57E_] -> {
+                                  288[010132D3C686F68E1E93D14D3DB79EE7D88FB582C87B35BB5B553D82AA25D09196130014]*,
+                                  60[00C047CA5AA50C4_] -> {
+                                    52[00BD53FE01932_] -> {
+                                      52[00A0AC70E85E2_] -> {
+                                        288[010178A421C00E63D315BAEB8086668F7D45632ACD4EF17B8A33884C1499856572E2000F]*,
+                                        44[00894655318_] -> {
+                                          44[0087FCFA2A6_] -> {
+                                            44[00805E35524_] -> {
+                                              288[010147E47997E4E71FC094644C589682DE513FB731A6B8E841EB2AB68DF4EF1BD92B0002]*,
+                                              53[E0A04027728E60] -> {
+                                                570[B991A9E656703AA04F3CDCC5422B0A1158B344B228652FC9EF6418EB845A001C09B2869397E6EAB3E5EC55401625FB84ED36424BB6EB0F344BC13953F74CC340000716D4326F30C_] -> {
+                                                  288[0101BC95189D8B489591E527DFE6FC8787A3A2D382C1DCB6AA9153D7A538F9FFA3B90007]*
+                                                },
+                                                288[0101D3016CE07C229433613139886E3B2578C61C374FB3AB0C1889666D8588B5B0090008]*
+                                              }
+                                            },
+                                            288[0101641854A854E746372DB4110640D8AA4AFFDCA2CE5F110980D7EB7CF4159652A7000B]*
+                                          },
+                                          288[01014C4C14F8F5E62FE6145EFBB10255D3F82082E492D8A8E6F17AC610C70A5B06A8000C]*
+                                        }
+                                      },
+                                      288[0101DBC646BFEA5C4D04E6D76C3DCD521BECDD2062F493B9727D3466E0F5272F2FC90010]*
+                                    },
+                                    288[01017B7679129CCE779E8ADA70B51D8FD2A5B1FD8180E98FE35944399D3E583E49140013]*
+                                  }
+                                },
+                                288[0101853D4CD469D08FBE03DA3DDA48568763B19BC5A711BB7887E9D7700D24314275001C]*
+                              },
+                              288[010156C1849FDD43EFEAD3B9FCFB246A5FC40D0D9AA4F4B0C877A9AEB5C4AFFF84850018]*
+                            },
+                            288[010157B0C46BA1C3726890924C2D7F3F4B755BF7B24363CC325B37C9F956DF569AD4001A]*
+                          }
+                        },
+                        288[01014FD09DCDD654FD4C3758B75C755893092B5D7845356647C3CB5028AE4CF75E26001C]*
+                      }
+                    },
+                    288[0101D3E6EF78A7FB3E14C066534F5172078FCC4382D2AD1512470C25E1504CB3BFE50025]*
+                  }
+                },
+                288[0101CDF101C69F77450BAC9532A70318AB7F0DD902A4A3EE2CE8CDF5262547B5CB68002A]*,
+                288[0101AAED7CCC3904836F362AE06EB234B71D64E02EB4BA6D6B7869197A9ED5C4B0B80001]*
+              },
+              288[0101AAED7CCC3904836F362AE06EB234B71D64E02EB4BA6D6B7869197A9ED5C4B0B80001]*
+            },
+            288[0101EE15491F5B3FFB71A0C759A476F99A84D7A1B5CF8A47B1DE5D1039882CD723710065]*,
+            288[0101EC90A44EEE02BED840C10E88351163EE9E3613EB9DBE8DA760783DA449714E280001]*
+          },
+          288[01011AAC6151A41BCC89EEE855D29D087ACDD30BC4F2069B246BE0C69E3C228C55110067]*,
+          288[0101BB06F3506745C5F6A6239D132A70B38439CB60FF95F62E45261BA12E844E889B0001]*
+        },
+        288[0101B3E9649D10CCB379368E81A3A7E8E49C8EB53F6ACC69B0BA2FFA80082F70EE390001]*
+      },
+      288[0101B3E9649D10CCB379368E81A3A7E8E49C8EB53F6ACC69B0BA2FFA80082F70EE390001]*
+    },
+    868[0000000000000000FFFFFFFFFFFFFFFF8270E631571EF77CCBBA0EF6D39D6343100001F5220425F440194CD434074F1CF0713270443B84FEA5C35142771F8C6895A2B36117743862354F4EBE767D25641E7D9D005816619EB807E1C18C943B86598038ADD33B65980DCB14EF2_] -> {
+      288[0101B3E9649D10CCB379368E81A3A7E8E49C8EB53F6ACC69B0BA2FFA80082F70EE390001]*
+    }
+  }
+}
+```
+
+</details>
+
+
+## References
+
+_Here a [link to the original article](https://github.com/xssnick/ton-deep-doc/blob/master/Cells-BoC.md) by [Oleg Baranov](https://github.com/xssnick)._

--- a/docs/develop/data-formats/tl-b.md
+++ b/docs/develop/data-formats/tl-b.md
@@ -1,0 +1,285 @@
+# TL-B
+In this section, complex and non-obvious TL-B structures are analyzed. To get started, I recommend reading [this documentation](/docs/learn/overviews/tl-b-language) first.
+
+## Unary
+Unary is commonly used for dynamic sizing in structures such as [hml_short](https://github.com/ton-blockchain/ton/blob/master/crypto/block/block.tlb#L29).
+
+Unary has 2 options:
+```
+unary_zero$0 = Unary ~0;
+unary_succ$1 {n:#} x:(Unary ~n) = Unary ~(n + 1);
+```
+
+With `unary_zero` everything is simple: if the first bit is 0, then the number you are looking for is 0.
+
+`unary_succ` is more interesting, it is loaded recursively and has the value `~(n + 1)`. This means that it calls itself until we hit `unary_zero`. In other words, the desired value will be equal to the number of units in a row.
+
+Let's analyze parsing `1110`.
+
+The call chain will be as follows:
+```unary_succ$1 -> unary_succ$1 -> unary_succ$1 -> unary_zero$0```
+
+Once we get to `unary_zero`, the value is returned to the top, just like in a recursive function call.
+Now, to understand the result, let's go along the return value path, that is, from the end:
+```0 -> ~(0 + 1) -> ~(1 + 1) -> ~(2 + 1) -> 3```
+
+## Either
+```
+left$0 {X:Type} {Y:Type} value:X = Either X Y;
+right$1 {X:Type} {Y:Type} value:Y = Either X Y;
+```
+It is used when one of two types is possible, while the choice of type depends on the prefix bit, if 0 - the left type is serialized, if 1 - the right one.
+It is used, for example, when serializing messages, when body can be either part of the main cell or a link.
+
+## Maybe
+```
+nothing$0 {X:Type} = Maybe X;
+just$1 {X:Type} value:X = Maybe X;
+```
+Used for optional values, if the first bit is 0 - the value itself is not serialized (skipped), if 1 - serialized.
+
+## Both
+```
+pair$_ {X:Type} {Y:Type} first:X second:Y = Both X Y;
+```
+Normal pair - both types are serialized, one after the other, without conditions.
+
+## Hashmap
+
+As an example of working with complex TL-B structures, let's take a look at `Hashmap`, which is a structure for storing `dict` from FunC smart contract code.
+
+The following TL-B structures are used to serialize a Hashmap with a fixed key length:
+```
+hm_edge#_ {n:#} {X:Type} {l:#} {m:#} label:(HmLabel ~l n) 
+          {n = (~m) + l} node:(HashmapNode m X) = Hashmap n X;
+
+hmn_leaf#_ {X:Type} value:X = HashmapNode 0 X;
+hmn_fork#_ {n:#} {X:Type} left:^(Hashmap n X) 
+           right:^(Hashmap n X) = HashmapNode (n + 1) X;
+
+hml_short$0 {m:#} {n:#} len:(Unary ~n) {n <= m} s:(n * Bit) = HmLabel ~n m;
+hml_long$10 {m:#} n:(#<= m) s:(n * Bit) = HmLabel ~n m;
+hml_same$11 {m:#} v:Bit n:(#<= m) = HmLabel ~n m;
+
+unary_zero$0 = Unary ~0;
+unary_succ$1 {n:#} x:(Unary ~n) = Unary ~(n + 1);
+
+hme_empty$0 {n:#} {X:Type} = HashmapE n X;
+hme_root$1 {n:#} {X:Type} root:^(Hashmap n X) = HashmapE n X;
+```
+Where the root structure is `HashmapE`. It can have one of the states: `hme_empty` or `hme_root`.
+
+### Hashmap parsing example
+
+For example, consider the following Cell, given in binary form.
+```
+1[1] -> {
+  2[00] -> {
+    7[1001000] -> {
+      25[1010000010000001100001001],
+      25[1010000010000000001101111]
+    },
+    28[1011100000000000001100001001]
+  }
+}
+```
+
+This Cell is a `HashmapE` with a key size of 8 bits and its values are `uint16` numbers. i.e. `HashmapE 8 uint16`. It has 3 keys:
+```
+1 = 777
+17 = 111
+128 = 777
+```
+
+To parse it, we need to know in advance which structure to use, `hme_empty` or `hme_root`. We can determine this by prefix, empty is 1 bit 0 (`hme_empty$0`), root is 1 bit 1 (`hme_root$1`). We read the first bit, it is equal to one (`1[1]`), which means we have `hme_root`.
+
+Let's fill the structure variables with known values, we get:
+`hme_root$1 {n:#} {X:Type} root:^(Hashmap 8 uint16) = HashmapE 8 uint16;`
+
+1 bit prefix is already read, what's inside `{}` are conditions and not read. (`{n:#}` means that n is any uint32 number, `{X:Type}` means that X is any type. The next thing we need to read is `root:^(Hashmap 8 uint16)`, `^` stands for a link, load it.
+```
+2[00] -> {
+    7[1001000] -> {
+      25[1010000010000001100001001],
+      25[1010000010000000001101111]
+    },
+    28[1011100000000000001100001001]
+  }
+```
+
+#### Start parsing branches
+According to our schema, this is the `Hashmap 8 uint16` structure. Let's fill it with known values, we get:
+```
+hm_edge#_ {n:#} {X:Type} {l:#} {m:#} label:(HmLabel ~l 8) 
+          {8 = (~m) + l} node:(HashmapNode m uint16) = Hashmap 8 uint16;
+```
+
+As we can see, conditional variables `{l:#}` and `{m:#}` have appeared, the values of which are unknown to us. Also, after reading the `label`, `n` is involved in the equation `{n = (~m) + l}`, in this case we can calculate `l` and `m`, the sign ` tells us about this ~`.
+
+To determine the value of `l` we need to load `label:(HmLabel ~l uint16)`. `HmLabel` has 3 structure options:
+```
+hml_short$0 {m:#} {n:#} len:(Unary ~n) {n <= m} s:(n * Bit) = HmLabel ~n m;
+hml_long$10 {m:#} n:(#<= m) s:(n * Bit) = HmLabel ~n m;
+hml_same$11 {m:#} v:Bit n:(#<= m) = HmLabel ~n m;
+```
+The option is determined by the prefix. In our root, at the moment, the cell has 2 zero bits (`2[00]`). We have only 1 option, which has a prefix starting with 0. It turns out we have `hml_short$0`.
+
+Fill `hml_short` with known values:
+```
+hml_short$0 {m:#} {n:#} len:(Unary ~n) {n <= 8} s:(n * Bit) = HmLabel ~n 8
+```
+We don't know `n`, but since it has a `~` character, we can calculate it. To do this, load `len:(Unary ~n)`, [[More about Unary]](#unary).
+In our case, we had `2[00]`, after defining the type `HmLabel` we have 1 bit out of two left, we load it and see that this is 0, which means our option is `unary_zero$0`. It turns out n from `HmLabel` is zero.
+
+Complete `hml_short` with the calculated value n:
+```
+hml_short$0 {m:#} {n:#} len:0 {n <= 8} s:(0 * Bit) = HmLabel 0 8
+```
+It turns out we have an empty `HmLabel`, s = 0, so there is nothing to download.
+
+We go back even higher and supplement our structure with the calculated value of `l`:
+```
+hm_edge#_ {n:#} {X:Type} {l:0} {m:#} label:(HmLabel 0 8) 
+          {8 = (~m) + 0} node:(HashmapNode m uint16) = Hashmap 8 uint16;
+```
+Now when we have calculated `l`, we can also calculate `m` using the equation `n = (~m) + 0`, i.e. `m = n - 0`, m = n = 8.
+
+We have determined all unknowns and can now load `node:(HashmapNode 8 uint16)`. HashmapNode we have options:
+```
+hmn_leaf#_ {X:Type} value:X = HashmapNode 0 X;
+hmn_fork#_ {n:#} {X:Type} left:^(Hashmap n X) 
+           right:^(Hashmap n X) = HashmapNode (n + 1) X;
+```
+In this case, we determine the option not by the prefix, but by the parameter, if n = 0, then we have `hmn_leaf`, otherwise `hmn_fork`. In our case, n = 8, we have `hmn_fork`. We take it and fill in the known values:
+```
+hmn_fork#_ {n:#} {X:uint16} left:^(Hashmap n uint16) 
+           right:^(Hashmap n uint16) = HashmapNode (n + 1) uint16;
+```
+Everything is not so obvious here, we have `HashmapNode (n + 1) uint16`. This means that the resulting n must be equal to our parameter, i.e. 8. To calculate the local n, we need to calculate it: `n = (n_local + 1)` -> `n_local = (n - 1)` -> `n_local = (8 - 1)` -> `n_local = 7`.
+```
+hmn_fork#_ {n:#} {X:uint16} left:^(Hashmap 7 uint16) 
+           right:^(Hashmap 7 uint16) = HashmapNode (7 + 1) uint16;
+```
+Now it's simple, load the left and right branches, and for each branch [repeat the process](#начинаем-парсинг-веток).
+
+#### Analyze the loading of values
+Continuing the previous example, let's look at loading the right branch, i.e. `28[1011100000000000001100001001]`
+
+We see `hm_edge` again, fill it with known values:
+```
+hm_edge#_ {n:#} {X:Type} {l:#} {m:#} label:(HmLabel ~l 7) 
+          {7 = (~m) + l} node:(HashmapNode m uint16) = Hashmap 7 uint16;
+```
+
+Load `HmLabel`, this time we have `hml_long` because the prefix is `10`.
+```
+hml_long$10 {m:#} n:(#<= m) s:(n * Bit) = HmLabel ~n m;
+```
+Let's fill it in:
+```
+hml_long$10 {m:#} n:(#<= 7) s:(n * Bit) = HmLabel ~n 7;
+```
+We see the new construction - `n:(#<= 7)`, it denotes a number of such a size can fit 7, in fact it is log2 from the number + 1. But for simplicity, you can count the number of bits that you need to write the number 7. 7 in binary form is `111`, so we need 3 bits, `n = 3`.
+```
+hml_long$10 {m:#} n:(## 3) s:(n * Bit) = HmLabel ~n 7;
+```
+We load `n`, and get `111`, that is 7 (coincidence). Next, load `s`, 7 bits - `0000000`. `s` is part of the key.
+
+We return to the top and fill in the resulting `l`:
+```
+hm_edge#_ {n:#} {X:Type} {l:#} {m:#} label:(HmLabel 7 7) 
+          {7 = (~m) + 7} node:(HashmapNode m uint16) = Hashmap 7 uint16;
+```
+Calculate `m`, `m = 7 - 7`, `m = 0`.
+
+Since `m = 0`, we got to the value, and the structure is applicable as a HashmapNode:
+```
+hmn_leaf#_ {X:Type} value:X = HashmapNode 0 X;
+```
+Everything is simple here: we substitute our uint16 type and load the value. The remaining 16 bits of `0000001100001001` in decimal form is 777, our value.
+
+Now let's restore the key. We collect together all the parts of the keys that go above us (we return to the top along the same path), and add 1 bit for each branch. If we went along the right branch, then we add 1, if along the left - 0. If there was a non-empty HmLabel above us, then we add its bits to the key.
+
+In our case, we take 7 bits from HmLabel `0000000` and add 1 in front of them, due to the fact that we got to the value on the right branch. We get 8 bits `10000000`, our key is the number `128`.
+
+## Other types of Hashmap
+There are also other types of dictionaries, they all have the same essence and, having figured out how to load the main Hashmap, you can load other types according to the same principle.
+
+### HashmapAugE
+```
+ahm_edge#_ {n:#} {X:Type} {Y:Type} {l:#} {m:#} 
+  label:(HmLabel ~l n) {n = (~m) + l} 
+  node:(HashmapAugNode m X Y) = HashmapAug n X Y;
+  
+ahmn_leaf#_ {X:Type} {Y:Type} extra:Y value:X = HashmapAugNode 0 X Y;
+
+ahmn_fork#_ {n:#} {X:Type} {Y:Type} left:^(HashmapAug n X Y)
+  right:^(HashmapAug n X Y) extra:Y = HashmapAugNode (n + 1) X Y;
+
+ahme_empty$0 {n:#} {X:Type} {Y:Type} extra:Y 
+          = HashmapAugE n X Y;
+          
+ahme_root$1 {n:#} {X:Type} {Y:Type} root:^(HashmapAug n X Y) 
+  extra:Y = HashmapAugE n X Y;
+```
+The difference from a regular Hashmap is the presence of an `extra:Y` field in each node (not just in leafs with values).
+
+### PfxHashmap
+```
+phm_edge#_ {n:#} {X:Type} {l:#} {m:#} label:(HmLabel ~l n) 
+           {n = (~m) + l} node:(PfxHashmapNode m X) 
+           = PfxHashmap n X;
+
+phmn_leaf$0 {n:#} {X:Type} value:X = PfxHashmapNode n X;
+phmn_fork$1 {n:#} {X:Type} left:^(PfxHashmap n X) 
+            right:^(PfxHashmap n X) = PfxHashmapNode (n + 1) X;
+
+phme_empty$0 {n:#} {X:Type} = PfxHashmapE n X;
+phme_root$1 {n:#} {X:Type} root:^(PfxHashmap n X) 
+            = PfxHashmapE n X;
+```
+The difference from the usual Hashmap is the ability to store keys of different lengths, due to the tag of the `phmn_leaf$0`, `phmn_fork$1` nodes.
+
+### VarHashmap
+```
+vhm_edge#_ {n:#} {X:Type} {l:#} {m:#} label:(HmLabel ~l n) 
+           {n = (~m) + l} node:(VarHashmapNode m X) 
+           = VarHashmap n X;
+vhmn_leaf$00 {n:#} {X:Type} value:X = VarHashmapNode n X;
+vhmn_fork$01 {n:#} {X:Type} left:^(VarHashmap n X) 
+             right:^(VarHashmap n X) value:(Maybe X) 
+             = VarHashmapNode (n + 1) X;
+vhmn_cont$1 {n:#} {X:Type} branch:Bit child:^(VarHashmap n X) 
+            value:X = VarHashmapNode (n + 1) X;
+
+// nothing$0 {X:Type} = Maybe X;
+// just$1 {X:Type} value:X = Maybe X;
+
+vhme_empty$0 {n:#} {X:Type} = VarHashmapE n X;
+vhme_root$1 {n:#} {X:Type} root:^(VarHashmap n X) 
+            = VarHashmapE n X;
+```
+The difference from the usual Hashmap is the ability to store keys of different lengths, due to the tag of the `vhmn_leaf$00`, `vhmn_fork$01` nodes. At the same time, `VarHashmap` is able to form a common value prefix (child map), at the expense of `vhmn_cont$1`.
+
+### BinTree
+```
+bta_leaf$0 {X:Type} {Y:Type} extra:Y leaf:X = BinTreeAug X Y;
+bta_fork$1 {X:Type} {Y:Type} left:^(BinTreeAug X Y) 
+           right:^(BinTreeAug X Y) extra:Y = BinTreeAug X Y;
+```
+A simple binary tree: the principle of key generation, like Hashmap, but without labels, only counting branch prefixes.
+
+
+## Addresses
+The addresses in TON are formed from the sha256 hash of the TL-B structure of StateInit. The address can be calculated even before the contract is deployed to the network.
+
+### Serialization
+The standard address like `EQBL2_3lMiyywU17g-or8N7v9hDmPCpttzBPE2isF2GTzpK4` is the base64 uri encoded bytes.
+Its length is 36 bytes, the last 2 of which are the crc16 checksum with the XMODEM table. The first byte is the flags, the second is the workchain.
+32 bytes in the middle are the data of the address itself, often represented in schemas as int256.
+
+[Decoding example](https://github.com/xssnick/tonutils-go/blob/3d9ee052689376061bf7e4a22037ff131183afad/address/addr.go#L156)
+
+## References
+
+_Here a [link to the original article](https://github.com/xssnick/ton-deep-doc/blob/master/TL-B.md) by [Oleg Baranov](https://github.com/xssnick)._

--- a/docs/develop/data-formats/tl.md
+++ b/docs/develop/data-formats/tl.md
@@ -1,0 +1,42 @@
+# TL
+
+TL (Type Language) is a language for describing data structures.
+
+For structuring useful data, when communicating, [TL schemas](https://github.com/ton-blockchain/ton/tree/master/tl/generate/scheme) are used.
+
+TL operates on 32 bit blocks. Accordingly, the data size in TL must be a multiple of 4 bytes.
+If the size of the object is not a multiple of 4, we need to add the required number of zero bytes up to the multiple.
+
+Numbers are always encoded in Little Endian order.
+
+More details about TL can be found in [Telegram documentation](https://core.telegram.org/mtproto/TL)
+
+## Encoding bytes array
+To encode an array of bytes, we first need to determine its size.
+If it is less than 254 bytes, then the encoding with 1 byte as the size is used. If more,
+then 0xFE is written as the first byte, as an indicator of a large array, and after it 3 bytes of size follow.
+
+For example, we encode the array `[0xAA, 0xBB]`, its size is 2. We use 1 byte
+size and then write the data itself, we get `[0x02, 0xAA, 0xBB]`, done, but we see
+that the final size is 3 and not a multiple of 4 bytes, then we need to add 1 byte of padding to make it 4. Result: `[0x02, 0xAA, 0xBB, 0x00]`.
+
+In case we need to encode an array whose size will be equal to, for example, 396,
+we do this: 396 >= 254, so we use 3 bytes for size encoding and 1 byte oversize indicator,
+we get: `[0xFE, 0x8C, 0x01, 0x00, array bytes]`, 396+4 = 400, which is a multiple of 4, no need to align.
+
+## Non-obvious serialization rules
+
+Often, a 4-byte prefix is written before the schema itself - its ID. The schema ID is a CRC32 with an IEEEE table from the schema text, while symbols such as `;` and brackets `()` are previously removed from the text. The serialization of a schema with an ID prefix is called **boxed**, this allows the parser to determine which schema comes before it if there are multiple options.
+
+How to determine whether to serialize as boxed or not? If our schema is part of another schema, then we need to look at how the field type is specified, if it is specified explicitly, then we serialize without a prefix, if not explicitly (there are many such types), then we need to serialize as boxed. Example:
+```
+pub.unenc data:bytes = PublicKey;
+pub.ed25519 key:int256 = PublicKey;
+pub.aes key:int256 = PublicKey;
+pub.overlay name:bytes = PublicKey;
+```
+We have such types, if `PublicKey` is specified in the schema, for example `adnl.node id:PublicKey addr_list:adnl.addressList = adnl.Node`, then it is not explicitly specified and we need to serialize with an ID prefix (boxed). And if it were specified like this: `adnl.node id:pub.ed25519 addr_list:adnl.addressList = adnl.Node`, then it would be explicit, and the prefix would not be needed.
+
+## References
+
+_Here a [link to the original article](https://github.com/xssnick/ton-deep-doc/blob/master/TL.md) by [Oleg Baranov](https://github.com/xssnick)._

--- a/docs/develop/network/adnl-tcp.md
+++ b/docs/develop/network/adnl-tcp.md
@@ -1,0 +1,508 @@
+# ADNL TCP - Liteserver
+
+This is the low level protocol on which all interaction in the TON network is built, it can work on top of any protocol, but is most often used on top of TCP and UDP. UDP is used for communication between nodes, and TCP is used for communication with lite servers.
+
+Now we will analyze ADNL running over TCP and learn how to interact with lite servers directly.
+
+In the TCP version of ADNL, network nodes use public keys ed25519 as addresses and establish a connection using a shared key obtained using the Elliptic Curve Diffie-Hellman procedure - ECDH.
+
+## Packet Structure
+Each ADNL TCP packet, except for the handshake, has the following structure:
+* 4 bytes of packet size in little endian (N)
+* 32 bytes nonce [[?]](## "Random bytes to protect against checksum attacks")
+* (N - 64) payload bytes
+* 32 bytes SHA256 checksum from nonce and payload
+
+The entire packet, including the size, is **AES-CTR** encrypted.
+After decryption, it is necessary to check whether the checksum matches the data, to check, you just need to calculate the checksum yourself and compare the result with what we have in the packet.
+
+The handshake packet is an exception, it is transmitted in a partially unencrypted form and is described in the next chapter.
+
+## Establishing a connection
+To establish a connection, we need to know the ip, port and public key of the server, and generate our own private and public key ed25519.
+
+Public server data such as ip, port and key can be obtained from the [global config](https://ton-blockchain.github.io/global.config.json). IP in the config in numerical form, it can be brought to normal form using, for example [this tool](https://www.browserling.com/tools/dec-to-ip). The public key in the config in base64 format.
+
+The client generates 160 random bytes, some of which will be used by the parties as the basis for AES encryption.
+
+Of these, 2 permanent AES-CTR ciphers are created, which will be used by the parties to encrypt/decrypt messages after the handshake.
+* Cipher A - key 0 - 31 bytes, iv 64 - 79 bytes
+* Cipher B - key 32 - 63 bytes, iv 80 - 95 bytes
+
+The ciphers are applied in this order:
+* Cipher A is used by the server to encrypt the messages it sends.
+* Cipher A is used by the client to decrypt received messages.
+* Cipher B is used by the client to encrypt the messages it sends.
+* Cipher B is used by the server to decrypt received messages.
+
+To establish a connection, the client must send a handshake packet containing:
+* [32 bytes] **Server key ID** [[Details]](#getting-key-id)
+* [32 bytes] **Our public key is ed25519**
+* [32 bytes] **SHA256 hash from our 160 bytes**
+* [160 bytes] **Our 160 bytes encrypted** [[Details]](#handshake-packet-data-encryption)
+
+When receiving a handshake packet, the server will do the same actions, receive an ECDH key, decrypt 160 bytes and create 2 permanent keys. If everything works out, the server will respond with an empty ADNL packet, without payload, to decrypt which (as well as subsequent ones) we need to use one of the permanent ciphers.
+
+From this point on, the connection can be considered established.
+
+After we have established a connection, we can start receiving information; the TL language is used to serialize data.
+
+[More about TL](/docs/develop/data-formats/tl)
+
+## Ping&Pong
+It is optimal to send a ping packet once every 5 seconds. This is necessary to maintain the connection while no data is being transmitted, otherwise the server may terminate the connection.
+
+The ping packet, like all the others, is built according to the standard schema described [above](#packet-structure), and carries the request ID and ping ID as payload data.
+
+Let's find the desired schema for the ping request [here](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/tl/generate/scheme/ton_api.tl#L35) and calculate the schema id as
+`crc32_IEEEE("tcp.ping random_id:long = tcp.Pong")`. When converted to little endian bytes, we get **9a2b084d**.
+
+Thus, our ADNL ping packet will look like this:
+* 4 bytes of packet size in little endian -> 64 + (4+8) = **76**
+* 32 bytes nonce -> random 32 bytes
+* 4 bytes of ID TL schema -> **9a2b084d**
+* 8 bytes of request id -> random uint64 number
+* 32 bytes of SHA256 checksum from nonce and payload
+
+We send our packet and wait for [tcp.pong](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/tl/generate/scheme/ton_api.tl#L23), `random_id` will be equal to the one we sent in ping packet.
+
+## Receiving information from a Liteserver
+All requests that are aimed at obtaining information from the blockchain are wrapped in [Liteserver Query](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/tl/generate/scheme/lite_api.tl#L83) schema, which in turn is wrapped in [ADNL Query](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/tl/generate/scheme/lite_api.tl#L22) schema.
+
+LiteQuery:
+`liteServer.query data:bytes = Object`, id **df068c79**
+
+ADNLQuery:
+`adnl.message.query query_id:int256 query:bytes = adnl.Message`, id **7af98bb4**
+
+LiteQuery is passed inside ADNLQuery, as `query:bytes`, and the final query is passed inside LiteQuery, as `data:bytes`.
+
+[Parsing encoding bytes in TL](/docs/develop/data-formats/tl)
+
+### getMasterchainInfo
+Now, since we already know how to generate TL packets for the Lite API, we can request information about the current TON masterchain block.
+The masterchain block is used in many further requests as an input parameter to indicate the state (moment) in which we need information.
+
+We are looking for the [TL schema we need](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/tl/generate/scheme/lite_api.tl#L60), calculate its ID and build the packet:
+
+* 4 bytes of packet size in little endian -> 64 + (4+32+(1+4+(1+4+3)+3)) = **116**
+* 32 bytes nonce -> random 32 bytes
+* 4 bytes of ID ADNLQuery schema -> **7af98bb4**
+* 32 bytes `query_id:int256` -> random 32 bytes
+* * 1 byte array size -> **12**
+* * 4 byte of ID LiteQuery schema -> **df068c79**
+* * * 1 byte array size -> **4**
+* * * 4 bytes of ID getMasterchainInfo schema -> **2ee6b589**
+* * * 3 zero bytes of padding (alignment to 8)
+* * 3 zero bytes of padding (alignment to 16)
+* 32 bytes of checksum SHA256 from nonce and payload
+
+Packet example in hex:
+```
+74000000                                                             -> packet size (116)
+5fb13e11977cb5cff0fbf7f23f674d734cb7c4bf01322c5e6b928c5d8ea09cfd     -> nonce
+  7af98bb4                                                           -> ADNLQuery
+  77c1545b96fa136b8e01cc08338bec47e8a43215492dda6d4d7e286382bb00c4   -> query_id
+    0c                                                               -> array size
+    df068c79                                                         -> LiteQuery
+      04                                                             -> array size
+      2ee6b589                                                       -> getMasterchainInfo
+      000000                                                         -> 3 bytes of padding
+    000000                                                           -> 3 bytes of padding
+ac2253594c86bd308ed631d57a63db4ab21279e9382e416128b58ee95897e164     -> sha256
+```
+
+In response, we expect to receive [liteServer.masterchainInfo](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/tl/generate/scheme/lite_api.tl#L30), consisting of last:[ton.blockIdExt](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/tl/generate/scheme/tonlib_api.tl#L51) state_root_hash:int256 и init:[tonNode.zeroStateIdExt](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/tl/generate/scheme/ton_api.tl#L359).
+
+The received packet is deserialized in the same way as the sent one - has same algorithm, but in the opposite direction, except that the response is wrapped only in [ADNLAnswer](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/tl/generate/scheme/lite_api.tl#L23).
+
+After decoding the response, we get a packet of the form:
+```
+20010000                                                                  -> packet size (288)
+5558b3227092e39782bd4ff9ef74bee875ab2b0661cf17efdfcd4da4e53e78e6          -> nonce
+  1684ac0f                                                                -> ADNLAnswer
+  77c1545b96fa136b8e01cc08338bec47e8a43215492dda6d4d7e286382bb00c4        -> query_id (identical to request)
+    b8                                                                    -> array size
+    81288385                                                              -> liteServer.masterchainInfo
+                                                                          last:tonNode.blockIdExt
+        ffffffff                                                          -> workchain:int
+        0000000000000080                                                  -> shard:long
+        27405801                                                          -> seqno:int   
+        e585a47bd5978f6a4fb2b56aa2082ec9deac33aaae19e78241b97522e1fb43d4  -> root_hash:int256
+        876851b60521311853f59c002d46b0bd80054af4bce340787a00bd04e0123517  -> file_hash:int256
+      8b4d3b38b06bb484015faf9821c3ba1c609a25b74f30e1e585b8c8e820ef0976    -> state_root_hash:int256
+                                                                          init:tonNode.zeroStateIdExt 
+        ffffffff                                                          -> workchain:int
+        17a3a92992aabea785a7a090985a265cd31f323d849da51239737e321fb05569  -> root_hash:int256      
+        5e994fcf4d425c0a6ce6a792594b7173205f740a39cd56f537defd28b48a0f6e  -> file_hash:int256
+    000000                                                                -> 3 bytes of padding
+520c46d1ea4daccdf27ae21750ff4982d59a30672b3ce8674195e8a23e270d21          -> sha256
+```
+
+### runSmcMethod
+We already know how to get the masterchain block, so now we can call any lite server methods.
+Let's analyze **runSmcMethod** - this is a method that calls a function from a smart contract and returns a result. Here we need to understand some new data types such as [TL-B](/docs/develop/data-formats/tl-b), [Cell](/docs/develop/data-formats/cell-boc#cell) and [BoC](/docs/develop/data-formats/cell-boc#bag-of-cells).
+
+To execute the smart contract method, we need to build and send a request using the TL schema:
+`liteServer.runSmcMethod mode:# id:tonNode.blockIdExt account:liteServer.accountId method_id:long params:bytes = liteServer.RunMethodResult`
+
+And wait for a response with schema:
+`liteServer.runMethodResult mode:# id:tonNode.blockIdExt shardblk:tonNode.blockIdExt shard_proof:mode.0?bytes proof:mode.0?bytes state_proof:mode.1?bytes init_c7:mode.3?bytes lib_extras:mode.4?bytes exit_code:int result:mode.2?bytes = liteServer.RunMethodResult;`
+
+In the request, we see the following fields:
+1. mode:# - uint32 bitmask of what we want to see in the response, for example, `result:mode.2?bytes` will only be present in the response if the bit with index 2 is set to one.
+2. id:tonNode.blockIdExt - is our master block state that we got in the previous chapter.
+3. account:[liteServer.accountId](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/tl/generate/scheme/lite_api.tl#L27) - workchain and smart contract address data.
+4. method_id:long - 8 bytes, in which crc16 with the XMODEM table is written on behalf of the called method + bit 17 is set [[Calculation]](https://github.com/xssnick/tonutils-go/blob/88f83bc3554ca78453dd1a42e9e9ea82554e3dd2/ton/runmethod.go#L16)
+5. params:bytes - [Stack](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/crypto/block/block.tlb#L783) serialized in [BoC](/docs/develop/data-formats/cell-boc#bag-of-cells), containing arguments to call the method. [[Implementation example]](https://github.com/xssnick/tonutils-go/blob/88f83bc3554ca78453dd1a42e9e9ea82554e3dd2/tlb/stack.go)
+
+For example, we only need `result:mode.2?bytes`, then our mode will be equal to 0b100, that is 4. In response, we will get:
+1. mode:# -> what was sent - 4.
+2. id:tonNode.blockIdExt -> our master block against which the method was executed
+3. shardblk:tonNode.blockIdExt -> shard block where the contract account is located
+4. exit_code:int -> 4 bytes which is the exit code when executing the method. If everything is successful, then = 0, if not, it is equal to the exception code.
+5. result:mode.2?bytes -> [Stack](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/crypto/block/block.tlb#L783) serialized in [BoC](/docs/develop/data-formats/cell-boc#bag-of-cells), containing the values returned by the method.
+
+Let's analyze the call and getting the result from the `a2` method of the contract `EQBL2_3lMiyywU17g-or8N7v9hDmPCpttzBPE2isF2GTzpK4`:
+
+Method code in FunC:
+```
+(cell, cell) a2() method_id {
+  cell a = begin_cell().store_uint(0xAABBCC8, 32).end_cell();
+  cell b = begin_cell().store_uint(0xCCFFCC1, 32).end_cell();
+  return (a, b);
+}
+```
+
+Fill out our request:
+* `mode` = 4, we only need the result -> `04000000`
+* `id` = result of execution getMasterchainInfo
+* `account` = workchain 0 (4 bytes `00000000`), and int256 [obtained from our contract address](/docs/develop/data-formats/tl-b#addresses), i.e. 32 bytes `4bdbfde5322cb2c14d7b83ea2bf0deeff610e63c2a6db7304f1368ac176193ce`
+* `method_id` = [computed](https://github.com/xssnick/tonutils-go/blob/88f83bc3554ca78453dd1a42e9e9ea82554e3dd2/ton/runmethod.go#L16) id from `a2` -> `0a2e010000000000`
+* `params:bytes` = Our method does not accept input parameters, so we need to pass it an empty stack (`000000`, cell 3 bytes - stack depth 0) serialized in [BoC](/docs/develop/data-formats/cell-boc#bag-of-cells) -> `b5ee9c72010101010005000006000000` -> serialize in bytes and get `10b5ee9c72410101010005000006000000000000` 0x10 - size, 3 bytes in the end - padding.
+
+In response, we get:
+* `mode:#` -> not interesting
+* `id:tonNode.blockIdExt` -> not interesting
+* `shardblk:tonNode.blockIdExt` -> not interesting
+* `exit_code:int` -> is 0 if execution was successful
+* `result:mode.2?bytes` -> [Stack](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/crypto/block/block.tlb#L783) containing the data returned by the method in [BoC](/docs/develop/data-formats/cell-boc#bag-of-cells) format, we will unpack it.
+
+Inside `result` we received `b5ee9c7201010501001b000208000002030102020203030400080ccffcc1000000080aabbcc8`, this is [BoC](/docs/develop/data-formats/cell-boc#bag-of-cells) containing the data. When we deserialize it, we will get a cell:
+```
+32[00000203] -> {
+  8[03] -> {
+    0[],
+    32[0AABBCC8]
+  },
+  32[0CCFFCC1]
+}
+```
+If we parse it, we will get 2 values of the cell type, which our FunC method returns.
+The first 3 bytes of the root cell `000002` - is the depth of the stack, that is 2. This means that the method returned 2 values.
+
+We continue parsing, the next 8 bits (1 byte) is the value type at the current stack level. For some types, it may take 2 bytes. Possible options can be seen in [schema](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/crypto/block/block.tlb#L766).
+In our case, we have `03`, which means:
+```
+vm_stk_cell#03 cell:^Cell = VmStackValue;
+```
+So the type of our value is - cell, and, according to the schema, it stores the value itself as a reference. But, if we look at the stack element storage schema:
+```
+vm_stk_cons#_ {n:#} rest:^(VmStackList n) tos:VmStackValue = VmStackList (n + 1);
+```
+We will see that the first link `rest:^(VmStackList n)` - is the cell of the next value on the stack, and our value `tos:VmStackValue` comes second, so to get the value we need to read the second link, that is `32[0CCFFCC1]` - this is our first cell that the contract returned.
+
+Now we can go deeper and get the second element of the stack, we go through the first link, now we have:
+```
+8[03] -> {
+    0[],
+    32[0AABBCC8]
+  }
+```
+We repeat the same process. The first 8 bits = `03` - that is, again cell. The second reference is the value `32[0AABBCC8]` and since our stack depth is 2, we complete the pass. n total, we have 2 values returned by the contract - `32[0CCFFCC1]` and `32[0AABBCC8]`.
+
+Note that they are in reverse order. In the same way, you need to pass arguments when calling a function - in reverse order from what we see in the FunC code.
+
+[Implementation example](https://github.com/xssnick/tonutils-go/blob/46dbf5f820af066ab10c5639a508b4295e5aa0fb/ton/runmethod.go#L24)
+
+### getAccountState
+To get account state data such as balance, code and contract data, we can use [getAccountState](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/tl/generate/scheme/lite_api.tl#L68). For the request, we need a [fresh master block](#getmasterchaininfo) and account address. In response, we will receive the TL structure [AccountState](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/tl/generate/scheme/lite_api.tl#L38).
+
+Let's analyze the AccountState TL schema:
+```
+liteServer.accountState id:tonNode.blockIdExt shardblk:tonNode.blockIdExt shard_proof:bytes proof:bytes state:bytes = liteServer.AccountState;
+```
+1. `id` - is our master block, regarding which we got the data.
+2. `shardblk` - workchain shard block where our account is located, regarding which we received data.
+3. `shard_proof` - merkle proof of a shard block.
+4. `proof` - merkle proof of account status.
+5. `state` - [BoC](/docs/develop/data-formats/cell-boc#bag-of-cells) TL-B [account state scheme](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/crypto/block/block.tlb#L232).
+
+Of all this data, what we need is in the state, we will analyze it.
+
+For example, let's get the status of account `EQAhE3sLxHZpsyZ_HecMuwzvXHKLjYx4kEUehhOy2JmCcHCT`, `state` in the response will be (at the moment of writing this article):
+```
+b5ee9c720102350100051e000277c0021137b0bc47669b3267f1de70cbb0cef5c728b8d8c7890451e8613b2d899827026a886043179d3f6000006e233be8722201d7d239dba7d818134001020114ff00f4a413f4bcf2c80b0d021d0000000105036248628d00000000e003040201cb05060013a03128bb16000000002002012007080043d218d748bc4d4f4ff93481fd41c39945d5587b8e2aa2d8a35eaf99eee92d9ba96004020120090a0201200b0c00432c915453c736b7692b5b4c76f3a90e6aeec7a02de9876c8a5eee589c104723a18020004307776cd691fbe13e891ed6dbd15461c098b1b95c822af605be8dc331e7d45571002000433817dc8de305734b0c8a3ad05264e9765a04a39dbe03dd9973aa612a61f766d7c02000431f8c67147ceba1700d3503e54c0820f965f4f82e5210e9a3224a776c8f3fad1840200201200e0f020148101104daf220c7008e8330db3ce08308d71820f90101d307db3c22c00013a1537178f40e6fa1f29fdb3c541abaf910f2a006f40420f90101d31f5118baf2aad33f705301f00a01c20801830abcb1f26853158040f40e6fa120980ea420c20af2670edff823aa1f5340b9f2615423a3534e2a2d2b2c0202cc12130201201819020120141502016616170003d1840223f2980bc7a0737d0986d9e52ed9e013c7a21c2b2f002d00a908b5d244a824c8b5d2a5c0b5007404fc02ba1b04a0004f085ba44c78081ba44c3800740835d2b0c026b500bc02f21633c5b332781c75c8f20073c5bd0032600201201a1b02012020210115bbed96d5034705520db3c8340201481c1d0201201e1f0173b11d7420c235c6083e404074c1e08075313b50f614c81e3d039be87ca7f5c2ffd78c7e443ca82b807d01085ba4d6dc4cb83e405636cf0069006031003daeda80e800e800fa02017a0211fc8080fc80dd794ff805e47a0000e78b64c00015ae19574100d56676a1ec40020120222302014824250151b7255b678626466a4610081e81cdf431c24d845a4000331a61e62e005ae0261c0b6fee1c0b77746e102d0185b5599b6786abe06fedb1c68a2270081e8f8df4a411c4605a400031c34410021ae424bae064f613990039e2ca840090081e886052261c52261c52265c4036625ccd88302d02012026270203993828290111ac1a6d9e2f81b609402d0015adf94100cc9576a1ec1840010da936cf0557c1602d0015addc2ce0806ab33b50f6200220db3c02f265f8005043714313db3ced542d34000ad3ffd3073004a0db3c2fae5320b0f26212b102a425b3531cb9b0258100e1aa23a028bcb0f269820186a0f8010597021110023e3e308e8d11101fdb3c40d778f44310bd05e254165b5473e7561053dcdb3c54710a547abc2e2f32300020ed44d0d31fd307d307d33ff404f404d10048018e1a30d20001f2a3d307d3075003d70120f90105f90115baf2a45003e06c2170542013000c01c8cbffcb0704d6db3ced54f80f70256e5389beb198106e102d50c75f078f1b30542403504ddb3c5055a046501049103a4b0953b9db3c5054167fe2f800078325a18e2c268040f4966fa52094305303b9de208e1638393908d2000197d3073016f007059130e27f080705926c31e2b3e63006343132330060708e2903d08308d718d307f40430531678f40e6fa1f2a5d70bff544544f910f2a6ae5220b15203bd14a1236ee66c2232007e5230be8e205f03f8009322d74a9802d307d402fb0002e83270c8ca0040148040f44302f0078e1771c8cb0014cb0712cb0758cf0158cf1640138040f44301e201208e8a104510344300db3ced54925f06e234001cc8cb1fcb07cb07cb3ff400f400c9
+```
+
+[Parse this BoC](/docs/develop/data-formats/cell-boc#bag-of-cells) and get
+
+<details>
+  <summary>large cell</summary>
+
+  ```
+  473[C0021137B0BC47669B3267F1DE70CBB0CEF5C728B8D8C7890451E8613B2D899827026A886043179D3F6000006E233BE8722201D7D239DBA7D818130_] -> {
+    80[FF00F4A413F4BCF2C80B] -> {
+      2[0_] -> {
+        4[4_] -> {
+          8[CC] -> {
+            2[0_] -> {
+              13[D180],
+              141[F2980BC7A0737D0986D9E52ED9E013C7A218] -> {
+                40[D3FFD30730],
+                48[01C8CBFFCB07]
+              }
+            },
+            6[64] -> {
+              178[00A908B5D244A824C8B5D2A5C0B5007404FC02BA1B048_],
+              314[085BA44C78081BA44C3800740835D2B0C026B500BC02F21633C5B332781C75C8F20073C5BD00324_]
+            }
+          },
+          2[0_] -> {
+            2[0_] -> {
+              84[BBED96D5034705520DB3C_] -> {
+                112[C8CB1FCB07CB07CB3FF400F400C9]
+              },
+              4[4_] -> {
+                2[0_] -> {
+                  241[AEDA80E800E800FA02017A0211FC8080FC80DD794FF805E47A0000E78B648_],
+                  81[AE19574100D56676A1EC0_]
+                },
+                458[B11D7420C235C6083E404074C1E08075313B50F614C81E3D039BE87CA7F5C2FFD78C7E443CA82B807D01085BA4D6DC4CB83E405636CF0069004_] -> {
+                  384[708E2903D08308D718D307F40430531678F40E6FA1F2A5D70BFF544544F910F2A6AE5220B15203BD14A1236EE66C2232]
+                }
+              }
+            },
+            2[0_] -> {
+              2[0_] -> {
+                323[B7255B678626466A4610081E81CDF431C24D845A4000331A61E62E005AE0261C0B6FEE1C0B77746E0_] -> {
+                  128[ED44D0D31FD307D307D33FF404F404D1]
+                },
+                531[B5599B6786ABE06FEDB1C68A2270081E8F8DF4A411C4605A400031C34410021AE424BAE064F613990039E2CA840090081E886052261C52261C52265C4036625CCD882_] -> {
+                  128[ED44D0D31FD307D307D33FF404F404D1]
+                }
+              },
+              4[4_] -> {
+                2[0_] -> {
+                  65[AC1A6D9E2F81B6090_] -> {
+                    128[ED44D0D31FD307D307D33FF404F404D1]
+                  },
+                  81[ADF94100CC9576A1EC180_]
+                },
+                12[993_] -> {
+                  50[A936CF0557C14_] -> {
+                    128[ED44D0D31FD307D307D33FF404F404D1]
+                  },
+                  82[ADDC2CE0806AB33B50F60_]
+                }
+              }
+            }
+          }
+        },
+        872[F220C7008E8330DB3CE08308D71820F90101D307DB3C22C00013A1537178F40E6FA1F29FDB3C541ABAF910F2A006F40420F90101D31F5118BAF2AAD33F705301F00A01C20801830ABCB1F26853158040F40E6FA120980EA420C20AF2670EDFF823AA1F5340B9F2615423A3534E] -> {
+          128[DB3C02F265F8005043714313DB3CED54] -> {
+            128[ED44D0D31FD307D307D33FF404F404D1],
+            112[C8CB1FCB07CB07CB3FF400F400C9]
+          },
+          128[ED44D0D31FD307D307D33FF404F404D1],
+          40[D3FFD30730],
+          640[DB3C2FAE5320B0F26212B102A425B3531CB9B0258100E1AA23A028BCB0F269820186A0F8010597021110023E3E308E8D11101FDB3C40D778F44310BD05E254165B5473E7561053DCDB3C54710A547ABC] -> {
+            288[018E1A30D20001F2A3D307D3075003D70120F90105F90115BAF2A45003E06C2170542013],
+            48[01C8CBFFCB07],
+            504[5230BE8E205F03F8009322D74A9802D307D402FB0002E83270C8CA0040148040F44302F0078E1771C8CB0014CB0712CB0758CF0158CF1640138040F44301E2],
+            856[DB3CED54F80F70256E5389BEB198106E102D50C75F078F1B30542403504DDB3C5055A046501049103A4B0953B9DB3C5054167FE2F800078325A18E2C268040F4966FA52094305303B9DE208E1638393908D2000197D3073016F007059130E27F080705926C31E2B3E63006] -> {
+              112[C8CB1FCB07CB07CB3FF400F400C9],
+              384[708E2903D08308D718D307F40430531678F40E6FA1F2A5D70BFF544544F910F2A6AE5220B15203BD14A1236EE66C2232],
+              504[5230BE8E205F03F8009322D74A9802D307D402FB0002E83270C8CA0040148040F44302F0078E1771C8CB0014CB0712CB0758CF0158CF1640138040F44301E2],
+              128[8E8A104510344300DB3CED54925F06E2] -> {
+                112[C8CB1FCB07CB07CB3FF400F400C9]
+              }
+            }
+          }
+        }
+      }
+    },
+    114[0000000105036248628D00000000C_] -> {
+      7[CA] -> {
+        2[0_] -> {
+          2[0_] -> {
+            266[2C915453C736B7692B5B4C76F3A90E6AEEC7A02DE9876C8A5EEE589C104723A1800_],
+            266[07776CD691FBE13E891ED6DBD15461C098B1B95C822AF605BE8DC331E7D45571000_]
+          },
+          2[0_] -> {
+            266[3817DC8DE305734B0C8A3AD05264E9765A04A39DBE03DD9973AA612A61F766D7C00_],
+            266[1F8C67147CEBA1700D3503E54C0820F965F4F82E5210E9A3224A776C8F3FAD18400_]
+          }
+        },
+        269[D218D748BC4D4F4FF93481FD41C39945D5587B8E2AA2D8A35EAF99EEE92D9BA96000]
+      },
+      74[A03128BB16000000000_]
+    }
+  }
+  ```
+
+</details>
+
+Now we need to parse the cell according to the TL-B structure:
+```
+account_none$0 = Account;
+
+account$1 addr:MsgAddressInt storage_stat:StorageInfo
+          storage:AccountStorage = Account;
+```
+Our structure references other structures, such as:
+```
+anycast_info$_ depth:(#<= 30) { depth >= 1 } rewrite_pfx:(bits depth) = Anycast;
+addr_std$10 anycast:(Maybe Anycast) workchain_id:int8 address:bits256  = MsgAddressInt;
+addr_var$11 anycast:(Maybe Anycast) addr_len:(## 9) workchain_id:int32 address:(bits addr_len) = MsgAddressInt;
+   
+storage_info$_ used:StorageUsed last_paid:uint32 due_payment:(Maybe Grams) = StorageInfo;
+storage_used$_ cells:(VarUInteger 7) bits:(VarUInteger 7) public_cells:(VarUInteger 7) = StorageUsed;
+  
+account_storage$_ last_trans_lt:uint64 balance:CurrencyCollection state:AccountState = AccountStorage;
+
+currencies$_ grams:Grams other:ExtraCurrencyCollection = CurrencyCollection;
+           
+var_uint$_ {n:#} len:(#< n) value:(uint (len * 8)) = VarUInteger n;
+var_int$_ {n:#} len:(#< n) value:(int (len * 8)) = VarInteger n;
+nanograms$_ amount:(VarUInteger 16) = Grams;  
+           
+account_uninit$00 = AccountState;
+account_active$1 _:StateInit = AccountState;
+account_frozen$01 state_hash:bits256 = AccountState;
+```
+
+As we can see, the cell contains a lot of data, but we will analyze the main cases and getting a balance. You can analyze the rest in a similar way.
+
+Let's start parsing. In the root cell data we have:
+```
+C0021137B0BC47669B3267F1DE70CBB0CEF5C728B8D8C7890451E8613B2D899827026A886043179D3F6000006E233BE8722201D7D239DBA7D818130_
+```
+Convert it to binary form and get:
+```
+11000000000000100001000100110111101100001011110001000111011001101001101100110010011001111111000111011110011100001100101110110000110011101111010111000111001010001011100011011000110001111000100100000100010100011110100001100001001110110010110110001001100110000010011100000010011010101000100001100000010000110001011110011101001111110110000000000000000000000110111000100011001110111110100001110010001000100000000111010111110100100011100111011011101001111101100000011000000100110
+```
+Let's look at our main TL-B structure, we see that we have 2 options for what can be there - `account_none$0` or `account$1`. We can understand which option we have by reading the prefix declared after the symbol $, in our case it is 1 bit. If there is 0, then we have `account_none`, or 1, then `account`.
+
+Our first bit from the data above = 1, so we are working with `account$1` and will use the schema:
+```
+account$1 addr:MsgAddressInt storage_stat:StorageInfo
+          storage:AccountStorage = Account;
+```
+Next we have `addr:MsgAddressInt`, we see that for MsgAddressInt we also have several options:
+```
+addr_std$10 anycast:(Maybe Anycast) workchain_id:int8 address:bits256  = MsgAddressInt;
+addr_var$11 anycast:(Maybe Anycast) addr_len:(## 9) workchain_id:int32 address:(bits addr_len) = MsgAddressInt;
+```
+To understand which one to work with, we, like last time, read the prefix bits, this time we read 2 bits. We cut off the already read bit, `1000000...` remains, we read the first 2 bits and get `10`, which means we are working with `addr_std$10`.
+
+Next we need to parse `anycast:(Maybe Anycast)`, Maybe means we should read 1 bit, and if it's one, read Anycast, otherwise skip. Our remaining bits are `00000...`, read 1 bit, it's 0, so we skip Anycast.
+
+Next, we have `workchain_id: int8`, everything is simple here, we read 8 bits, this will be the workchain ID. We read the next 8 bits, all zeros, so the workchain is 0.
+
+Next, we read `address:bits256`, this is 256 bits of the address, in the same way as with `workchain_id`. On reading, we get `21137B0BC47669B3267F1DE70CBB0CEF5C728B8D8C7890451E8613B2D8998270` in hex representation.
+
+
+We read the address `addr:MsgAddressInt`, then we have `storage_stat:StorageInfo` from the main structure, its schema is:
+```
+storage_info$_ used:StorageUsed last_paid:uint32 due_payment:(Maybe Grams) = StorageInfo;
+```
+First comes `used:StorageUsed`, with the schema:
+```
+storage_used$_ cells:(VarUInteger 7) bits:(VarUInteger 7) public_cells:(VarUInteger 7) = StorageUsed;
+```
+This is the number of cells and bits used to store account data. Each field is defined as `VarUInteger 7`, which means a uint of dynamic size, but a maximum of 7 bits. You can understand how it is arranged according to the scheme:
+```
+var_uint$_ {n:#} len:(#< n) value:(uint (len * 8)) = VarUInteger n;
+```
+In our case, n will be equal to 7. In len we will have `(#< 7)` which means the number of bits that can hold a number up to 7. You can determine it by translating 7-1=6 into binary form - `110`, we get 3 bits, so length len = 3 bits. And value is `(uint (len * 8))`. To determine it, we need to read 3 bits of the length, get a number and multiply by 8, this will be the size of `value`, that is, the number of bits that need to be read to get the value of VarUInteger.
+
+Read `cells:(VarUInteger 7)`, take our next bits from the root cell, look at the next 16 bits to understand, this is `0010011010101000`. We read the first 3 bits of len, this is `001`, i.e. 1, we get the size (uint (1 * 8)), we get uint 8, we read 8 bits, it will be `cells`, `00110101`, i.e. 53 in decimal form. We do the same for `bits` and `public_cells`.
+
+We successfully read `used:StorageUsed`, next we have `last_paid:uint32`, we read 32 bits. Everything is just as simple with `due_payment:(Maybe Grams)` here Maybe, which will be 0, so we skip Grams. But, if Maybe is 1, we can look at the Grams `amount:(VarUInteger 16) = Grams` schema and immediately understand that we already know how to work with this. Like last time, only instead of 7 we have 16.
+
+Next we have `storage:AccountStorage` with a schema:
+```
+account_storage$_ last_trans_lt:uint64 balance:CurrencyCollection state:AccountState = AccountStorage;
+```
+We read `last_trans_lt:uint64`, this is 64 bits, storing lt of the last account transaction. And finally, the balance represented by the schema:
+```
+currencies$_ grams:Grams other:ExtraCurrencyCollection = CurrencyCollection;
+```
+From here we will read `grams:Grams` which will be the account balance in nano-tones.
+`grams:Grams` is `VarUInteger 16`, to store 16 (in binary form `10000`, subtracting 1 we get `1111`), then we read the first 4 bits, and multiply the resulting value by 8, then we read the received number of bits, it is our balance.
+
+Let's analyze our remaining bits according to our data:
+```
+100000000111010111110100100011100111011011101001111101100000011000000100110
+```
+Read first 4 bits - `1000`, this is 8. 8*8=64, read next 64 bits = `0000011101011111010010001110011101101110100111110110000001100000`, removing extra zero bits, we get `11101011111010010001110011101101110100111110110000001100000`, that is equal to `531223439883591776`, and, translating from nano to TON, we get `531223439.883591776`.
+
+We will stop here, since we have already analyzed all the main cases, the rest can be obtained in a similar way with what we have analyzed. Also, additional information on parsing TL-B can be found in [official documentation](/TL-B.md)
+
+### Other methods
+Now, having studied all the information, you can call and process responses for other lite-server methods as well. Same principle :)
+
+## Additional technical details of the handshake
+
+### Getting key ID
+The key id is the SHA256 hash of the serialized TL schema.
+
+The most commonly used TL schemas for the keys are:
+```
+pub.ed25519 key:int256 = PublicKey -- ID c6b41348
+pub.aes key:int256 = PublicKey     -- ID d4adbc2d
+pub.overlay name:bytes = PublicKey -- ID cb45ba34
+pub.unenc data:bytes = PublicKey   -- ID 0a451fb6
+pk.aes key:int256 = PrivateKey     -- ID 3751e8a5
+```
+
+As an example, for keys of type ED25519 that are used for handshake, the key ID will be the SHA256 hash from
+**[0xC6, 0xB4, 0x13, 0x48]** and **public key**, (36 byte array, prefix + key)
+
+[Code example](https://github.com/xssnick/tonutils-go/blob/2b5e5a0e6ceaf3f28309b0833cb45de81c580acc/liteclient/crypto.go#L16)
+
+### Handshake packet data encryption
+The handshake packet is sent in a semi-open form, only 160 bytes are encrypted, containing information about permanent ciphers.
+
+To encrypt them, we need an AES-CTR cipher, to get it we need a SHA256 hash of 160 bytes and [ECDH shared key](#getting-a-shared-key-using-ecdh)
+
+The cipher is built like this:
+* key = (0 - 15 bytes of public key) + (16 - 31 bytes of hash)
+* iv = (0 - 3 hash bytes) + (20 - 31 public key bytes)
+
+After the cipher is assembled, we encrypt our 160 bytes with it.
+
+[Code example](https://github.com/xssnick/tonutils-go/blob/2b5e5a0e6ceaf3f28309b0833cb45de81c580acc/liteclient/connection.go#L361)
+
+### Getting a shared key using ECDH
+To calculate the shared key, we need our private key and the server's public key.
+
+The essence of DH is to obtain a shared secret key, without disclosing private information. I will give an example of how this happens, in the most simplified form. Suppose we need to generate a shared key between us and the server, the process will look like this:
+1. We generate secret and public numbers like **6** and **7**
+2. The server generates secret and public numbers like **5** and **15**
+3. We exchange public numbers with the server, send **7** to the server, it sends us **15**.
+4. We calculate: **7^6 mod 15 = 4**
+5. The server calculates: **7^5 mod 15 = 7**
+6. We exchange the received numbers, we give the server **4**, it gives us **7**
+7. We calculate **7^6 mod 15 = 4**
+8. The server calculates: **4^5 mod 15 = 4**
+9. Shared key = **4**
+
+The details of the ECDH itself will be omitted for the sake of simplicity. It is calculated using 2 keys, private and public, by finding a common point on the curve. If interested, it is better to read about it separately.
+
+[Code example](https://github.com/xssnick/tonutils-go/blob/2b5e5a0e6ceaf3f28309b0833cb45de81c580acc/liteclient/crypto.go#L32)
+
+## References
+
+_Here a [link to the original article](https://github.com/xssnick/ton-deep-doc/blob/master/ADNL-TCP-Liteserver.md) by [Oleg Baranov](https://github.com/xssnick)._

--- a/docs/develop/network/adnl-udp.md
+++ b/docs/develop/network/adnl-udp.md
@@ -1,0 +1,328 @@
+# ADNL UDP - Internode
+
+ADNL over UDP is used by nodes and TON components to communicate with each other. It is a low-level protocol on top of which other, higher-level TON protocols such as DHT and RLDP operate. 
+In this article, we will learn how ADNL over UDP works for basic communication between nodes.
+
+Unlike ADNL over TCP, in the UDP implementation, the handshake takes place in a different form, and an additional layer is used in the form of channels, but other principles are similar: 
+encryption keys are also generated based on our private key and the peer's public key, which is known in advance from the config or received from other network nodes.
+
+In the UDP version of ADNL, the connection is established in the same time with the receiving of initial data from the peer if the initiator sent 'create channel' message, the channel's key will be calculated and the channel creation will be confirmed.
+When the channel is established, further communication will continue inside it.
+
+## Packet structure and communication
+
+### First packets
+Let's analyze the initialization of the connection with the DHT node and obtaining a signed list of its addresses in order to understand how the protocol works.
+
+Find the node you like in [global config](https://ton-blockchain.github.io/global.config.json), in the `dht.nodes` section. For example:
+```json
+{
+  "@type": "dht.node",
+  "id": {
+    "@type": "pub.ed25519",
+    "key": "fZnkoIAxrTd4xeBgVpZFRm5SvVvSx7eN3Vbe8c83YMk="
+  },
+  "addr_list": {
+    "@type": "adnl.addressList",
+    "addrs": [
+      {
+        "@type": "adnl.address.udp",
+        "ip": 1091897261,
+        "port": 15813
+      }
+    ],
+    "version": 0,
+    "reinit_date": 0,
+    "priority": 0,
+    "expire_at": 0
+  },
+  "version": -1,
+  "signature": "cmaMrV/9wuaHOOyXYjoxBnckJktJqrQZ2i+YaY3ehIyiL3LkW81OQ91vm8zzsx1kwwadGZNzgq4hI4PCB/U5Dw=="
+}
+```
+
+1. Let's take its ED25519 key, `fZnkoIAxrTd4xeBgVpZFRm5SvVvSx7eN3Vbe8c83YMk`, and decode it from base64
+2. Take its IP address `1091897261` and translate it into an understandable format using [service](https://www.browserling.com/tools/dec-to-ip) or using conversion to little endian bytes, we will get `65.21.7.173`
+3. Combine with the port, get `65.21.7.173:15813` and establish a UDP connection.
+
+We want to open a channel to communicate with node and get some information, and as the main task - to receive a list of signed addresses from it. To do this, we will generate 2 messages, the first - [create a channel](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/tl/generate/scheme/ton_api.tl#L129):
+```
+adnl.message.createChannel key:int256 date:int = adnl.Message
+```
+Here we have 2 parameters - key and date. As a date, we will specify the current unix timestamp. And for the key - we need to generate a new ED25519 private+public key pair specially for the channel, they will be used for initialization of [public encryption key](/docs/develop/network/adnl-tcp#getting-a-shared-key-using-ecdh). We will use our generated public key in the `key` parameter of the message, and just save the private one for now.
+
+Serialize the filled TL structure and get:
+```
+bbc373e6                                                         -- TL ID adnl.message.createChannel 
+d59d8e3991be20b54dde8b78b3af18b379a62fa30e64af361c75452f6af019d7 -- key
+555c8763                                                         -- date
+```
+
+Next, let's move to our main query - [get a list of addresses](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/tl/generate/scheme/ton_api.tl#L198). 
+To execute it, we first need to serialize its TL structure:
+```
+dht.getSignedAddressList = dht.Node
+```
+It has no parameters, so we just serialize it. It will be just its id - `ed4879a9`.
+
+Next, since this is a higher level request of the DHT protocol, we need to first wrap it in an `adnl.message.query` TL structure:
+```
+adnl.message.query query_id:int256 query:bytes = adnl.Message
+```
+As `query_id` we generate random 32 bytes, as `query` we use our main request, [wrapped as an array of bytes](/docs/develop/data-formats/tl#encoding-bytes-array).
+We will get:
+```
+7af98bb4                                                         -- TL ID adnl.message.query
+d7be82afbc80516ebca39784b8e2209886a69601251571444514b7f17fcd8875 -- query_id
+04 ed4879a9 000000                                               -- query
+```
+
+### Building the packet
+
+All communication is carried out using packets, the content of which is [TL structure](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/tl/generate/scheme/ton_api.tl#L81):
+```
+adnl.packetContents 
+  rand1:bytes                                     -- random 7 or 15 bytes
+  flags:#                                         -- bit flags, used to determine the presence of fields further
+  from:flags.0?PublicKey                          -- sender's public key
+  from_short:flags.1?adnl.id.short                -- sender's ID
+  message:flags.2?adnl.Message                    -- message (used if there is only one message)
+  messages:flags.3?(vector adnl.Message)          -- messages (if there are > 1)
+  address:flags.4?adnl.addressList                -- list of our addresses
+  priority_address:flags.5?adnl.addressList       -- priority list of our addresses
+  seqno:flags.6?long                              -- packet sequence number
+  confirm_seqno:flags.7?long                      -- sequence number of the last packet received
+  recv_addr_list_version:flags.8?int              -- address version 
+  recv_priority_addr_list_version:flags.9?int     -- priority address version
+  reinit_date:flags.10?int                        -- connection reinitialization date (counter reset)
+  dst_reinit_date:flags.10?int                    -- connection reinitialization date from the last received packet
+  signature:flags.11?bytes                        -- signature
+  rand2:bytes                                     -- random 7 or 15 bytes
+        = adnl.PacketContents
+        
+```
+
+Once we have serialized all the messages we want to send, we can start building the packet. 
+Packets to be sent to a channel differ in content from packets that are sent before the channel is initialized. 
+First, let's analyze the main packet, which is used for initialization.
+
+During the initial data exchange, outside the channel, the serialized content structure of the packet is prefixed with the public key of the peer - 32 bytes. 
+Our public key is 32 bytes, the sha256 hash of the serialized TL of the content structure of the packet - 32 bytes. 
+The content of the packet is encrypted using the [shared key](/docs/develop/network/adnl-tcp#getting-a-shared-key-using-ecdh), obtained from our private key and the public key of the server.
+
+Serialize our packet content structure, and parse it byte by byte:
+```
+89cd42d1                                                               -- TL ID adnl.packetContents
+0f 4e0e7dd6d0c5646c204573bc47e567                                      -- rand1, 15 (0f) random bytes
+d9050000                                                               -- flags (0x05d9) -> 0b0000010111011001
+                                                                       -- from (present because flag's zero bit = 1)
+c6b41348                                                                  -- TL ID pub.ed25519
+   afc46336dd352049b366c7fd3fc1b143a518f0d02d9faef896cb0155488915d6       -- key:int256
+                                                                       -- messages (present because flag's third bit = 1)
+02000000                                                                  -- vector adnl.Message, size = 2 messages   
+   bbc373e6                                                                  -- TL ID adnl.message.createChannel
+   d59d8e3991be20b54dde8b78b3af18b379a62fa30e64af361c75452f6af019d7          -- key
+   555c8763                                                                  -- date (date of creation)
+   
+   7af98bb4                                                                  -- TL ID [adnl.message.query](/)
+   d7be82afbc80516ebca39784b8e2209886a69601251571444514b7f17fcd8875          -- query_id
+   04 ed4879a9 000000                                                        -- query (bytes size 4, padding 3)
+                                                                       -- address (present because flag's fourth bit = 1), without TL ID since it is specified explicitly
+00000000                                                                  -- addrs (empty vector, because we are in client mode and do not have an address on wiretap)
+555c8763                                                                  -- version (usually initialization date)
+555c8763                                                                  -- reinit_date (usually initialization date)
+00000000                                                                  -- priority
+00000000                                                                  -- expire_at
+
+0100000000000000                                                       -- seqno (present because flag's sixth bit = 1)
+0000000000000000                                                       -- confirm_seqno (present because flag's seventh bit = 1)
+555c8763                                                               -- recv_addr_list_version (present because flag's eighth bit = 1, usually initialization date)
+555c8763                                                               -- reinit_date (present because flag's tenth bit = 1, usually initialization date)
+00000000                                                               -- dst_reinit_date (present because flag's tenth bit = 1)
+0f 2b6a8c0509f85da9f3c7e11c86ba22                                      -- rand2, 15 (0f) random bytes
+```
+After serialization - we need to sign the resulting byte array with our private client's (not channel's) ED25519 key, which we generated and saved before. 
+After we have generated the signature (64 bytes in size), we need to add it to the packet, serialize it again, but now add the 11th bit to the flag, which means the presence of the signature:
+```
+89cd42d1                                                               -- TL ID adnl.packetContents
+0f 4e0e7dd6d0c5646c204573bc47e567                                      -- rand1, 15 (0f) random bytes
+d90d0000                                                               -- flags (0x0dd9) -> 0b0000110111011001
+                                                                       -- from (present because flag's zero bit = 1)
+c6b41348                                                                  -- TL ID pub.ed25519
+   afc46336dd352049b366c7fd3fc1b143a518f0d02d9faef896cb0155488915d6       -- key:int256
+                                                                       -- messages (present because flag's third bit = 1)
+02000000                                                                  -- vector adnl.Message, size = 2 message   
+   bbc373e6                                                                  -- TL ID adnl.message.createChannel
+   d59d8e3991be20b54dde8b78b3af18b379a62fa30e64af361c75452f6af019d7          -- key
+   555c8763                                                                  -- date (date of creation)
+   
+   7af98bb4                                                                  -- TL ID adnl.message.query
+   d7be82afbc80516ebca39784b8e2209886a69601251571444514b7f17fcd8875          -- query_id
+   04 ed4879a9 000000                                                        -- query (bytes size 4, padding 3)
+                                                                       -- address (present because flag's fourth bit = 1), without TL ID since it is specified explicitly
+00000000                                                                  -- addrs (empty vector, because we are in client mode and do not have an address on wiretap)
+555c8763                                                                  -- version (usually initialization date)
+555c8763                                                                  -- reinit_date (usually initialization date)
+00000000                                                                  -- priority
+00000000                                                                  -- expire_at
+
+0100000000000000                                                       -- seqno (present because flag's sixth bit = 1)
+0000000000000000                                                       -- confirm_seqno (present because flag's seventh bit = 1)
+555c8763                                                               -- recv_addr_list_version (present because flag's eighth bit = 1, usually initialization date)
+555c8763                                                               -- reinit_date (present because flag's tenth bit = 1, usually initialization date)
+00000000                                                               -- dst_reinit_date (present because flag's tenth bit = 1)
+40 b453fbcbd8e884586b464290fe07475ee0da9df0b8d191e41e44f8f42a63a710    -- signature (present because flag's eleventh bit = 1), (bytes size 64, padding 3)
+   341eefe8ffdc56de73db50a25989816dda17a4ac6c2f72f49804a97ff41df502    --
+   000000                                                              --
+0f 2b6a8c0509f85da9f3c7e11c86ba22                                      -- rand2, 15 (0f) random bytes
+```
+Now we have an assembled, signed and serialized packet, which is an array of bytes. 
+For subsequent verification of its integrity by the recipient, we need to calculate packet's sha256 hash. For example, let this be `408a2a4ed623b25a2e2ba8bbe92d01a3b5dbd22c97525092ac3203ce4044dcd2`.
+
+Now let's encrypt the content of our packet with the AES-CTR cipher, using [shared key](/docs/develop/network/adnl-tcp#getting-a-shared-key-using-ecdh), obtained from our private key and the public key of the peer (not the channel's key).
+
+We are almost ready for sending, just remains to [calculate ID](/docs/develop/network/adnl-tcp#getting-key-id) of ED25519 peer key and concat everything together:
+```
+daa76538d99c79ea097a67086ec05acca12d1fefdbc9c96a76ab5a12e66c7ebb  -- server Key ID
+afc46336dd352049b366c7fd3fc1b143a518f0d02d9faef896cb0155488915d6  -- our public key
+408a2a4ed623b25a2e2ba8bbe92d01a3b5dbd22c97525092ac3203ce4044dcd2  -- sha256 content hash (before encryption)
+...                                                               -- encrypted content of the packet
+```
+Now we can send our built packet to peer via UDP, and wait for a response.
+
+In response, we will receive a packet with similar structure, but with different messages. It will consist of:
+```
+
+68426d4906bafbd5fe25baf9e0608cf24fffa7eca0aece70765d64f61f82f005  -- ID of our key
+2d11e4a08031ad3778c5e060569645466e52bd1bd2c7b78ddd56def1cf3760c9  -- server public key, for shared key
+f32fa6286d8ae61c0588b5a03873a220a3163cad2293a5dace5f03f06681e88a  -- sha256 content hash (before encryption)
+...                                                               -- the encrypted content of the packet
+```
+
+The deserialization of the packet from the server is as follows:
+1. We check the ID of the key from the packet to understand that the packet is for us.
+2. Using the public key of the server from the packet and our private key, we calculate a shared key and decrypt the content of the packet
+3. Compare the sha256 hash sent to us with the hash received from the decrypted data, they must match
+4. Start deserializing the packet content using the `adnl.packetContents` TL schema
+
+The content of the packet will look like this:
+```
+89cd42d1                                                               -- TL ID adnl.packetContents
+0f 985558683d58c9847b4013ec93ea28                                      -- rand1, 15 (0f) random bytes
+ca0d0000                                                               -- flags (0x0dca) -> 0b0000110111001010
+daa76538d99c79ea097a67086ec05acca12d1fefdbc9c96a76ab5a12e66c7ebb       -- from_short (because flag's first bit = 1)
+02000000                                                               -- messages (present because flag's third bit = 1)
+   691ddd60                                                               -- TL ID adnl.message.confirmChannel 
+   db19d5f297b2b0d76ef79be91ad3ae01d8d9f80fab8981d8ed0c9d67b92be4e3       -- key (server channel public key)
+   d59d8e3991be20b54dde8b78b3af18b379a62fa30e64af361c75452f6af019d7       -- peer_key (our public channel key)
+   94848863                                                               -- date
+   
+   1684ac0f                                                               -- TL ID adnl.message.answer 
+   d7be82afbc80516ebca39784b8e2209886a69601251571444514b7f17fcd8875       -- query_id
+   90 48325384c6b413487d99e4a08031ad3778c5e060569645466e52bd5bd2c7b       -- answer (the answer to our request, we will analyze its content in an article about DHT)
+      78ddd56def1cf3760c901000000e7a60d67ad071541c53d0000ee354563ee       --
+      35456300000000000000009484886340d46cc50450661a205ad47bacd318c       --
+      65c8fd8e8f797a87884c1bad09a11c36669babb88f75eb83781c6957bc976       --
+      6a234f65b9f6e7cc9b53500fbe2c44f3b3790f000000                        --
+      000000                                                              --
+0100000000000000                                                       -- seqno (present because flag's sixth bit = 1)
+0100000000000000                                                       -- confirm_seqno (present because flag's seventh bit = 1)
+94848863                                                               -- recv_addr_list_version (present because flag's eighth bit = 1, usually initialization date)
+ee354563                                                               -- reinit_date (present because flag's tenth bit = 1, usually initialization date)
+94848863                                                               -- dst_reinit_date (present because flag's tenth bit = 1)
+40 5c26a2a05e584e9d20d11fb17538692137d1f7c0a1a3c97e609ee853ea9360ab6   -- signature (present because flag's eleventh bit = 1), (bytes size 64, padding 3)
+   d84263630fe02dfd41efb5cd965ce6496ac57f0e51281ab0fdce06e809c7901     --
+   000000                                                              --
+0f c3354d35749ffd088411599101deb2                                      -- rand2, 15 (0f) random bytes
+```
+The server responded to us with two messages: `adnl.message.confirmChannel` and `adnl.message.answer`. 
+With `adnl.message.answer` everything is simple, this is the answer to our request `dht.getSignedAddressList`, we will analyze it in the article about DHT.
+
+Let's focus on `adnl.message.confirmChannel`, which means that the peer has confirmed the creation of the channel and sent us its public channel key. Now, having our private channel key and the peer's public channel key, we can calculate the [shared key](/docs/develop/network/adnl-tcp#getting-a-shared-key-using-ecdh).
+
+Now when we have calculated the shared channel key, we need to make 2 keys out of it - one for encrypting outgoing messages, the other for decrypting incoming messages. 
+Making 2 keys out of it is quite simple, the second key is equal to the shared key written in reverse order. Example:
+```
+Shared key : AABB2233
+
+First key: AABB2233
+Second key: 3322BBAA
+```
+It remains to determine which key to use for what, we can do this by comparing the id of our public channel key with the id of the public key of the server channel, converting them to a numerical form - uint256. This approach is used to ensure that both the server and the client determine which key to use for what. If the server uses the first key for encryption, then with this approach the client will always use it for decryption.
+
+The terms of use are:
+```
+The server id is smaller than our id:
+Encryption: First Key
+Decryption: Second Key
+
+The server id is larger than our id:
+Encryption: Second Key
+Decryption: First Key
+
+If the ids are equal (nearly impossible):
+Encryption: First Key
+Decryption: First Key
+```
+[[Implementation example]](https://github.com/xssnick/tonutils-go/blob/46dbf5f820af066ab10c5639a508b4295e5aa0fb/adnl/adnl.go#L502)
+
+### Communication in a channel
+
+All subsequent packet exchange will occur within the channel, and channel keys will be used for encryption. 
+Let's send the same `dht.getSignedAddressList` request inside a newly created channel to see the difference.
+
+Let's build the packet for the channel using the same `adnl.packetContents` structure:
+```
+89cd42d1                                                               -- TL ID adnl.packetContents
+0f c1fbe8c4ab8f8e733de83abac17915                                      -- rand1, 15 (0f) random bytes
+c4000000                                                               -- flags (0x00c4) -> 0b0000000011000100
+                                                                       -- message (because second bit = 1)
+7af98bb4                                                                  -- TL ID adnl.message.query
+fe3c0f39a89917b7f393533d1d06b605b673ffae8bbfab210150fe9d29083c35          -- query_id
+04 ed4879a9 000000                                                        -- query (our dht.getSignedAddressList packed in bytes with padding 3)
+0200000000000000                                                       -- seqno (because flag's sixth bit = 1), 2 because it is our second message
+0100000000000000                                                       -- confirm_seqno (flag's seventh bit = 1), 1 because it is the last seqno received from the server
+07 e4092842a8ae18                                                      -- rand2, 7 (07) random bytes
+```
+The packets in a channel are quite simple and essentially consist of sequences (seqno) and the messages themselves.
+
+After serialization, like last time, we calculate the sha256 hash of the packet. Then we encrypt the packet using the key intended for the outgoing packets of the channel. 
+[Calculate](/docs/develop/network/adnl-tcp#getting-key-id) `pub.aes` ID of encryption key of our outgoing messages, and we build our packet:
+```
+bcd1cf47b9e657200ba21d94b822052cf553a548f51f539423c8139a83162180 -- ID of encryption key of our outgoing messages 
+6185385aeee5faae7992eb350f26ba253e8c7c5fa1e3e1879d9a0666b9bd6080 -- sha256 content hash (before encryption)
+...                                                              -- the encrypted content of the packet
+```
+We send a packet via UDP and wait for a response. In response, we will receive a packet of the same type as we sent (the same fields), but with the answer to our request `dht.getSignedAddressList`.
+
+## Other message types
+For basic communication, messages like `adnl.message.query` and `adnl.message.answer` are used, which we discussed above, but other types of messages are also used for some situations, which we will discuss in this section.
+
+### adnl.message.part
+This message type is a piece of one of the other possible message types, such as `adnl.message.answer`. This method of data transferring is used when the message is too large to be transmitted in a single UDP datagram.
+```
+adnl.message.part 
+hash:int256            -- sha256 hash of the original message
+total_size:int         -- original message size
+offset:int             -- offset according to the beginning of the original message
+data:bytes             -- piece of data of the original message
+   = adnl.Message;
+```
+Thus, in order to assemble the original message, we need to get several parts and, according to the offsets, concat them into a single bytes array. 
+And then process it as a message (according to the ID prefix in this bytes array).
+
+### adnl.message.custom
+```
+adnl.message.custom data:bytes = adnl.Message;
+```
+Such messages are used when the logic at the higher level does not correspond to the request-response format, messages of this type allow you to completely move the processing to the higher level, since the message carries only an array of bytes, without query_id and other fields. 
+Messages of this type are used, for example, in RLDP, since there can be only one response to many requests, this logic is controlled by RLDP itself.
+
+### Conclusion
+
+Further communication takes place on the basis of the logic described in this article,
+but the content of the packets depends on higher level protocols such as DHT and RLDP.
+
+## References
+
+_Here a [link to the original article](https://github.com/xssnick/ton-deep-doc/blob/master/ADNL-UDP-Internal.md) by [Oleg Baranov](https://github.com/xssnick)._

--- a/docs/develop/network/dht.md
+++ b/docs/develop/network/dht.md
@@ -1,0 +1,168 @@
+# DHT
+
+DHT stands for Distributed Hash Table and is essentially a distributed key-value database,
+where each member of the network can store something, for example, information about themselves.
+
+The implementation of DHT in TON is inherently similar to the implementation of [Kademlia](https://codethechange.stanford.edu/guides/guide_kademlia.html), which is used in IPFS.
+Any network member can run a DHT node, generate keys and store data.
+To do this, he needs to generate a random ID and inform other nodes about himself.
+
+To determine which node to store the data on, an algorithm is used to determine the "distance" between the node and the key.
+The algorithm is simple: we take the ID of the node and the ID of the key, we perform the XOR operation. The smaller the value, the closer the node.
+The task is to store the key on the nodes as close as possible to the key, so that other network participants can, using
+the same algorithm, find a node that can give data on this key.
+
+## Finding a value by key
+Let's look at an example with a search for a key, [connect to any DHT node and establish a connection via ADNL UDP](/docs/develop/network/adnl-udp#packet-structure-and-communication).
+
+For example, we want to find the address and public key for connecting to the node that hosts foundation.ton site. 
+Let's say we have already obtained the ADNL address of this site by executing the Get method of the DNS contract. 
+The ADNL address in hex representation is `516618cf6cbe9004f6883e742c9a2e3ca53ed02e3e36f4cef62a98ee1e449174`. 
+Now our goal is to find the ip, port and public key of the node that has this address.
+
+To do this, we need to get the ID of the DHT key, first we will fill the DHT key schema:
+```
+dht.key id:int256 name:bytes idx:int = dht.Key
+```
+`name` is the type of key, for ADNL addresses the word `address` is used, and, for example, to search for shardchain nodes - `nodes`. But the key type can be any array of bytes, depending on the value you are looking for.
+
+Filling in this schema, we get:
+```
+8fde67f6                                                           -- TL ID dht.key
+516618cf6cbe9004f6883e742c9a2e3ca53ed02e3e36f4cef62a98ee1e449174   -- our searched ADNL address
+07 61646472657373                                                  -- key type, the word "address" as an TL array of bytes
+00000000                                                           -- index 0 because there is only 1 key
+```
+Next - get the key ID, sha256 hash from the bytes serialized above. It will be `b30af0538916421b46df4ce580bf3a29316831e0c3323a7f156df0236c5b2f75`
+
+Now we can start searching. To do this, we need to execute a query that has [schema](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/tl/generate/scheme/ton_api.tl#L197):
+```
+dht.findValue key:int256 k:int = dht.ValueResult
+```
+`key` is the id of our DHT key, and `k` is the "width" of the search, the smaller it is, the more accurate, but fewer potential nodes to query. The maximum k for nodes in a TON is 10, usually 6 is used.
+
+Let's populate this structure, serialize and send the request using the `adnl.message.query` schema. [You can read more about this in another article](/docs/develop/network/adnl-udp#packet-structure-and-communication).
+
+In response, we can get:
+* `dht.valueNotFound` - if the value is not found.
+* `dht.valueFound` - if the value is found on this node.
+
+##### dht.valueNotFound
+If we get `dht.valueNotFound`, the response will contain a list of nodes that are known to the node we requested and are as close as possible to the key we requested from the list of nodes known to it. In this case, we need to connect and add the received nodes to the list known to us. 
+After that, from the list of all nodes known to us, select the closest, accessible and not yet requested, and make the same request to it. And so on until we try all the nodes in the range we have chosen or until we stop receiving new nodes.
+
+Let's analyze the response fields in more detail, the schemas used:
+```
+adnl.address.udp ip:int port:int = adnl.Address;
+adnl.addressList addrs:(vector adnl.Address) version:int reinit_date:int priority:int expire_at:int = adnl.AddressList;
+
+dht.node id:PublicKey addr_list:adnl.addressList version:int signature:bytes = dht.Node;
+dht.nodes nodes:(vector dht.node) = dht.Nodes;
+
+dht.valueNotFound nodes:dht.nodes = dht.ValueResult;
+```
+`dht.nodes -> nodes` -  list of DHT nodes (array).
+
+Each node has an `id` which is its public key, usually [pub.ed25519](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/tl/generate/scheme/ton_api.tl#L47), used as a server key to connect to the node via ADNL. Also, each node has a list of addresses `addr_list:adnl.addressList`, version and signature.
+
+We need to check the signature of each node, for this we read the value of `signature` and set the field to zero (we make it an empty bytes array). After - we serialize the TL structure `dht.node` with the empty signature and check the `signature` field that was before emptying. 
+We check on the received serialized bytes, using the public key from `id` field. [[Implementation example]](https://github.com/xssnick/tonutils-go/blob/46dbf5f820af066ab10c5639a508b4295e5aa0fb/adnl/dht/client.go#L91)
+
+From the list `addrs:(vector adnl.Address)` we take the address and try to establish an ADNL UDP connection, as the server key we use `id`, which is the public key.
+
+To find out the "distance" to this node - we need to take [key id](/docs/develop/network/adnl-tcp#getting-key-id) from the key from the `id` field and check the distance by the XOR operation from the node's key id and the desired key. 
+If the distance is small enough, we can make the same request to this node. And so on, until we find a value or there are no more new nodes.
+
+##### dht.valueFound
+The response will contain the value itself, the full key information, and optionally a signature (depends on value type).
+
+Let's analyze the response fields in more detail, the schemas used:
+```
+adnl.address.udp ip:int port:int = adnl.Address;
+adnl.addressList addrs:(vector adnl.Address) version:int reinit_date:int priority:int expire_at:int = adnl.AddressList;
+
+dht.key id:int256 name:bytes idx:int = dht.Key;
+
+dht.updateRule.signature = dht.UpdateRule;
+dht.updateRule.anybody = dht.UpdateRule;
+dht.updateRule.overlayNodes = dht.UpdateRule;
+
+dht.keyDescription key:dht.key id:PublicKey update_rule:dht.UpdateRule signature:bytes = dht.KeyDescription;
+
+dht.value key:dht.keyDescription value:bytes ttl:int signature:bytes = dht.Value; 
+
+dht.valueFound value:dht.Value = dht.ValueResult;
+```
+First, let's analyze `key:dht.keyDescription`, it is a complete description of the key, the key itself and information about who and how can update the value.
+
+* `key:dht.key` - the key must match the one from which we took the key ID for the search.
+* `id:PublicKey` - the public key of the record owner.
+* `update_rule:dht.UpdateRule` - record update rule.
+* * `dht.updateRule.signature` - only the owner of the private key can update the record, the `signature` of both the key and the value must be valid
+* * `dht.updateRule.anybody` - everyone can update the record, `signature` is empty and not checked
+* * `dht.updateRule.overlayNodes` - nodes from the same overlay can update the key, used to find nodes of the same overlay and add yourself
+
+###### dht.updateRule.signature
+After reading the description of the key, we act depending on the `updateRule`, for the ADNL address lookup case the type is always `dht.updateRule.signature`. 
+We check the key signature in the same way as last time, make the signature an empty byte array, serialize and check. After - we repeat the same for the value, i.e. for the entire `dht.value` object (while returning the key signature to its place).
+
+[[Implementation example]](https://github.com/xssnick/tonutils-go/blob/46dbf5f820af066ab10c5639a508b4295e5aa0fb/adnl/dht/client.go#L331)
+
+###### dht.updateRule.overlayNodes
+Used for keys containing information about other nodes-shards of the workchain in the network, the value always has the TL structure `overlay.nodes`. 
+The value field must be empty.
+
+```
+overlay.node id:PublicKey overlay:int256 version:int signature:bytes = overlay.Node;
+overlay.nodes nodes:(vector overlay.node) = overlay.Nodes;
+```
+To check for validity, we must check all `nodes` and for each check `signature` against its `id` by serializing the TL structure:
+```
+overlay.node.toSign id:adnl.id.short overlay:int256 version:int = overlay.node.ToSign;
+```
+As we can see, id should be replaced with adnl.id.short, which is the key id (hash) of the `id` field from the original structure. After serialization - we check the signature with the data.
+
+As a result, we get a valid list of nodes that are able to give us information about the workchain shard we need.
+###### dht.updateRule.anybody
+There are no signatures, anyone can update.
+
+#### Using a value
+
+When everything is verified and the `ttl:int` value has not expired, we can start working with the value itself, i.e. `value:bytes`. For an ADNL address, there must be an `adnl.addressList` structure inside. 
+It will contain ip addresses and ports of servers corresponding to the requested ADNL address. In our case, there will most likely be 1 RLDP-HTTP address of the `foundation.ton` service. 
+We will use the public key `id:PublicKey` from the DHT key information as the server key.
+
+After the connection is established, we can request the pages of the site using the RLDP protocol. The task from the DHT side at this stage is completed.
+
+### Search for nodes that store the state of the blockchain
+
+DHT is also used to find information about the nodes that store the data of workchains and their shards. The process is the same as when searching for any key, the only difference is in the serialization of the key itself and the validation of the response, we will analyze these points in this section.
+
+In order to get data, for example, of the masterchain and its shards, we need to fill in the TL structure:
+```
+tonNode.shardPublicOverlayId workchain:int shard:long zero_state_file_hash:int256 = tonNode.ShardPublicOverlayId;
+```
+Where `workchain` in the case of a masterchain will be equal to -1, its shard will be equal to -922337203685477580 (0xFFFFFFFFFFFFFFFF), and `zero_state_file_hash` is the hash of the zero state of the chain (file_hash), like other data, it can be taken from the global network config, in the `"validator"` field
+```json
+"zero_state": {
+  "workchain": -1,
+  "shard": -9223372036854775808, 
+  "seqno": 0,
+  "root_hash": "F6OpKZKqvqeFp6CQmFomXNMfMj2EnaUSOXN+Mh+wVWk=",
+  "file_hash": "XplPz01CXAps5qeSWUtxcyBfdAo5zVb1N979KLSKD24="
+}
+```
+After we have filled in `tonNode.shardPublicOverlayId`, we serialize it and get the key id from it by hashing (as always).
+
+We need to use the resulting key ID as `name` to fill in the `pub.overlay name:bytes = PublicKey` structure, wrapping it in TL bytes array. Next, we serialize it, and we get the key ID now from it.
+
+The resulting id will be the key to use in `dht.findValue`, and the `name` field's value will be the word `nodes`. We repeat the process from the previous section, everything is the same as last time, but `updateRule` will be [dht.updateRule.overlayNodes](#dhtupdateruleoverlaynodes).
+
+After validation - we will get the public keys (`id`) of the nodes that have information about our workchain and shard. To get the ADNL addresses of the nodes, we need to make IDs from the keys (using the hashing method) and repeat the procedure described above for each of the ADNL addresses, as with the ADNL address of the `foundation.ton` domain.
+
+As a result, we will get the addresses of the nodes from which, if we want, we can find out the addresses of other nodes of this chain using [overlay.getRandomPeers](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/tl/generate/scheme/ton_api.tl#L237). 
+We will also be able to receive all the information about the blocks from these nodes.
+
+## References
+
+_Here a [link to the original article](https://github.com/xssnick/ton-deep-doc/blob/master/DHT.md) by [Oleg Baranov](https://github.com/xssnick)._

--- a/docs/develop/network/overlay.md
+++ b/docs/develop/network/overlay.md
@@ -1,0 +1,73 @@
+# Overlay subnetworks
+
+The architecture of TON is built in such a way that a lot of chains can exist simultaneously and independently in it - they can be both private or public.
+Nodes have the ability to choose which shards and chains they store and process.
+At the same time, the communication protocol remains unchanged due to its universality. Protocols such as DHT, RLDP and Overlays allow this to be achieved.
+We are already familiar with the first two, in this section we will learn what Overlay is.
+
+Overlays are responsible for dividing a single network into additional subnetworks. Overlays can be both public, to which anyone can connect, and private, where additional credentials is needed for entry, known only to a certain amount of people.
+
+All chains in TON, including the masterchain, communicate using their own overlay.
+To join it, you need to find the nodes that are already in it, and start exchanging data with them.
+For the public overlays you can find nodes using DHT.
+
+## Interaction with overlay nodes
+
+We have already analyzed an example with finding overlay nodes in an article about DHT,
+in the section [Search for nodes that store the state of the blockchain](/docs/develop/network/dht#search-for-nodes-that-store-the-state-of-the-blockchain). 
+In this section, we will focus on interacting with them.
+
+When querying the DHT, we will get the addresses of the overlay nodes, from which we can find out the addresses of other nodes of this overlay using [overlay.getRandomPeers](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/tl/generate/scheme/ton_api.tl#L237) query.
+Once we connect to a sufficient number of nodes, we can receive all blocks information and other chain events from them, as well as send our transactions to them for processing.
+
+### Find more neighbors
+
+Let's look at an example of getting nodes in an overlay.
+
+To do this, send a request `overlay.getRandomPeers` to any known node of the overlay, serialize the TL schema:
+```
+overlay.node id:PublicKey overlay:int256 version:int signature:bytes = overlay.Node;
+overlay.nodes nodes:(vector overlay.node) = overlay.Nodes;
+
+overlay.getRandomPeers peers:overlay.nodes = overlay.Nodes;
+```
+`peers` - should contain the peers we know, so we don't get them back, but since we don't know any yet, `peers.nodes` will be an empty array. 
+
+In case if we want to not just get some information, but participate in overlay and get broadcasts, we should also add in `peers` information about our node, from which we're doing request. 
+When peers will get info about us - they will start to send us broadcasts using ADNL or RLDP.
+
+Each request inside the overlay must be prefixed with the TL schema:
+```
+overlay.query overlay:int256 = True;
+```
+The `overlay` should be the id of the overlay - the id of the `tonNode.ShardPublicOverlayId` schema key - the same one we used to search the DHT.
+
+We need to concat 2 serialized schemas by simply concatenating 2 serialized byte arrays, `overlay.query` will come first, `overlay.getRandomPeers` second.
+
+We wrap the resulting array in the `adnl.message.query` schema and send it via ADNL. In response, we are waiting for `overlay.nodes` - this will be a list of overlay nodes to which we can connect and, if necessary, repeat the same request to new of them until we get enough connections.
+
+### Functional requests
+
+Once the connection is established, we can access the overlay nodes using [requests](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/tl/generate/scheme/ton_api.tl#L413) `tonNode.*`.
+
+For requests of this kind, the RLDP protocol is used. And it's important not to forget the `overlay.query` prefix - it must be used for every query in the overlay.
+
+There is nothing unusual about the requests themselves, they are very similar to what we [did in the article about ADNL TCP](/docs/develop/network/adnl-tcp#getmasterchaininfo).
+
+For example, the `downloadBlockFull` request uses the already familiar schema of block id:
+```
+tonNode.downloadBlockFull block:tonNode.blockIdExt = tonNode.DataFull;
+```
+By passing it, we will be able to download the full information about the block, in response we will receive:
+```
+tonNode.dataFull id:tonNode.blockIdExt proof:bytes block:bytes is_link:Bool = tonNode.DataFull;
+  or
+tonNode.dataFullEmpty = tonNode.DataFull;
+```
+If present, the `block` field will contain data in TL-B format.
+
+Thus, we can receive information directly from the nodes.
+
+## References
+
+_Here a [link to the original article](https://github.com/xssnick/ton-deep-doc/blob/master/Overlay-Network.md) by [Oleg Baranov](https://github.com/xssnick)._

--- a/docs/develop/network/rldp.md
+++ b/docs/develop/network/rldp.md
@@ -1,0 +1,182 @@
+# RLDP
+
+RLDP - Reliable Large Datagram Protocol - is a protocol that runs on top of ADNL UDP, which is used to transfer large data blocks and
+includes Forward Error Correction (FEC) algorithms as a replacement of acknowledgment packets on the other side. 
+This makes it possible to transfer data between network components more efficiently, but with more traffic consumption.
+
+RLDP is used everywhere in TON infrastructure, for example, to download blocks from other nodes and transfer data to them,
+to access TON websites and TON Storage.
+
+## Protocol
+
+RLDP uses the following TL structures for communication:
+```
+fec.raptorQ data_size:int symbol_size:int symbols_count:int = fec.Type;
+fec.roundRobin data_size:int symbol_size:int symbols_count:int = fec.Type;
+fec.online data_size:int symbol_size:int symbols_count:int = fec.Type;
+
+rldp.messagePart transfer_id:int256 fec_type:fec.Type part:int total_size:long seqno:int data:bytes = rldp.MessagePart;
+rldp.confirm transfer_id:int256 part:int seqno:int = rldp.MessagePart;
+rldp.complete transfer_id:int256 part:int = rldp.MessagePart;
+
+rldp.message id:int256 data:bytes = rldp.Message;
+rldp.query query_id:int256 max_answer_size:long timeout:int data:bytes = rldp.Message;
+rldp.answer query_id:int256 data:bytes = rldp.Message;
+```
+The serialized structure is wrapped in the `adnl.message.custom` TL schema and sent over ADNL UDP. 
+RLDP Transfers are used to transfer big data, a random `transfer_id` is generated, and the data itself is processed by the FEC algorithm. 
+The resulting pieces are wrapped in a `rldp.messagePart` structure and sent to the peer until the peer sends us `rldp.complete` or until timeout. 
+
+When the receiver has collected the pieces of `rldp.messagePart` necessary to assemble a complete message, it concat them all together, decodes using FEC and 
+deserializes the resulting byte array into one of the `rldp.query` or `rldp.answer` structures, depending on the type (tl prefix id).
+
+### FEC
+
+Valid Forward Error Correction algorithms for use with RLDP are RoundRobin, Online, and RaptorQ.
+Currently for data encoding [RaptorQ](https://www.qualcomm.com/media/documents/files/raptorq-technical-overview.pdf) is used.
+
+#### RaptorQ
+The essence of RaptorQ is that the data is divided into so-called symbols - blocks of the same, predetermined size.
+
+Matrices are created from blocks, and discrete mathematical operations are applied to them. This allows us to create an almost infinite number of symbols.
+from the same data. All symbols are mixed, and it is possible to recover lost packets without requesting additional data from the server, while using fewer packets than it would be if we sent the same pieces in a loop.
+
+The generated symbols are sent to the peer until he reports that all data has been received and restored (decoded) by applying the same discrete operations.
+
+[[Implementation example of RaptorQ in Golang]](https://github.com/xssnick/tonutils-go/tree/46dbf5f820af066ab10c5639a508b4295e5aa0fb/adnl/rldp/raptorq)
+
+## RLDP-HTTP
+
+To interact with TON Sites, HTTP wrapped in RLDP is used. The hoster runs his site on any HTTP webserver and starts rldp-http-proxy next to it. 
+All requests from the TON network come via the RLDP protocol to the proxy, and the proxy reassembles the request into simple HTTP and calls the original web server locally.
+
+The user on his side launches the proxy, for example, [Tonutils Proxy](https://github.com/xssnick/TonUtils-Proxy), and uses the `.ton` sites, all traffic is wrapped in the reverse order, requests go to the local HTTP proxy, and it sends them via RLDP to the remote TON site.
+
+HTTP inside RLDP is implemented using TL structures:
+```
+http.header name:string value:string = http.Header;
+http.payloadPart data:bytes trailer:(vector http.header) last:Bool = http.PayloadPart;
+http.response http_version:string status_code:int reason:string headers:(vector http.header) no_payload:Bool = http.Response;
+
+http.request id:int256 method:string url:string http_version:string headers:(vector http.header) = http.Response;
+http.getNextPayloadPart id:int256 seqno:int max_chunk_size:int = http.PayloadPart;
+```
+This is not pure HTTP in text form, everything is wrapped in binary TL and unwrapped back to be sent to the web server or browser by the proxy itself.
+
+The scheme of work is as follows:
+* Client sends `http.request`
+* The server checks the `Content-Length` header when receiving a request
+* * If not 0, sends a `http.getNextPayloadPart` request to the client
+* * When receiving a request, the client sends `http.payloadPart` - the requested body piece depending on `seqno` and `max_chunk_size`.
+* * The server repeats requests, incrementing `seqno`, until it receives all the chunks from the client, i.e. until the `last:Bool` field of the last chunk received is true.
+* After processing the request, the server sends `http.response`, the client checks the `Content-Length` header
+* * If it is not 0, then sends a `http.getNextPayloadPart` request to the server, and the operations are repeated, as in the case of the client but vice-versa.
+
+## Request the TON Site
+
+To understand how RLDP works, let's look at an example of getting data from the TON site `foundation.ton`. 
+Let's say we have already got its ADNL address by calling the Get method of the NFT-DNS contract, [determined the address and port of the RLDP service using DHT](https://github.com/xssnick/ton-deep-doc/blob/46dbf5f820af066ab10c5639a508b4295e5aa0fb/DHT.md), and [connected to it over ADNL UDP](https://github.com/xssnick/ton-deep-doc/blob/46dbf5f820af066ab10c5639a508b4295e5aa0fb/ADNL-UDP-Internal.md).
+
+### Send a GET request to `foundation.ton`
+To do this, fill in the structure:
+```
+http.request id:int256 method:string url:string http_version:string headers:(vector http.header) = http.Response;
+```
+
+Serialize `http.request` by filling in the fields:
+```
+e191b161                                                           -- TL ID http.request      
+116505dac8a9a3cdb464f9b5dd9af78594f23f1c295099a9b50c8245de471194   -- id           = {random}
+03 474554                                                          -- method       = string `GET`
+16 687474703a2f2f666f756e646174696f6e2e746f6e2f 00                 -- url          = string `http://foundation.ton/`
+08 485454502f312e31 000000                                         -- http_version = string `HTTP/1.1`
+01000000                                                           -- headers (1)
+   04 486f7374 000000                                              -- name         = Host
+   0e 666f756e646174696f6e2e746f6e 00                              -- value        = foundation.ton
+```
+
+Now let's wrap our serialized `http.request` into `rldp.query` and serialize it too:
+```
+694d798a                                                              -- TL ID rldp.query
+184c01cb1a1e4dc9322e5cabe8aa2d2a0a4dd82011edaf59eb66f3d4d15b1c5c      -- query_id        = {random}
+0004040000000000                                                      -- max_answer_size = 257 KB, can be any sufficient size that we accept as headers
+258f9063                                                              -- timeout (unix)  = 1670418213
+34 e191b161116505dac8a9a3cdb464f9b5dd9af78594f23f1c295099a9b50c8245   -- data (http.request)
+   de4711940347455416687474703a2f2f666f756e646174696f6e2e746f6e2f00
+   08485454502f312e310000000100000004486f73740000000e666f756e646174
+   696f6e2e746f6e00 000000
+```
+
+### Encoding and sending packets
+
+Now we need to apply the FEC RaptorQ algorithm to this data.
+
+Let's create an encoder, for this we need to turn the resulting byte array into symbols of a fixed size. In TON, the symbol size is 768 bytes.
+To do this, let's split the array into pieces of 768 bytes. In the last piece, if it comes out smaller than 768, it will need to be padded with zero bytes to the required size.
+
+Our array is 156 bytes in size, which means there will be only 1 piece, and we need to pad it with 612 zero bytes to a size of 768.
+
+Also, constants are selected for the encoder, depending on the size of the data and the symbol, you can learn more about this in the documentation of RaptorQ itself, but in order not to get into mathematical jungle, I recommend using a ready-made library that implements such encoding. 
+[[Example of creating an encoder]](https://github.com/xssnick/tonutils-go/blob/46dbf5f820af066ab10c5639a508b4295e5aa0fb/adnl/rldp/raptorq/encoder.go#L15) and [[Symbol encoding example]](https://github.com/xssnick/tonutils-go/blob/be3411cf412f23e6889bf0b648904306a15936e7/adnl/rldp/raptorq/solver.go#L26).
+
+Symbols are encoded and sent in a round-robin style: we initially define `seqno` which is 0, and increment it by 1 for each successive encoded packet. For example, if we have 2 symbols, then we encode and send the first one, increase seqno by 1, then the second and increase seqno by 1, then again the first one and increase seqno, which at this moment is already equal to 2, by another 1. 
+And so until we receive a message that the peer has accepted the data.
+
+Now, when we have created the encoder, we are ready to send data, for this we will fill in the TL schema:
+```
+fec.raptorQ data_size:int symbol_size:int symbols_count:int = fec.Type;
+
+rldp.messagePart transfer_id:int256 fec_type:fec.Type part:int total_size:long seqno:int data:bytes = rldp.MessagePart;
+```
+* `transfer_id` - random int256, the same for all messageParts within the same data transfer.
+*  `fec_type` is `fec.raptorQ`.
+*  * `data_size` = 156
+*  * `symbol_size` = 768
+*  * `symbols_count` = 1
+*  `part` in our case always 0, can be used for transfers that hit the size limit.
+*  `total_size` = 156. The size of our transfer data.
+*  `seqno` - for the first packet will be equal to 0, and for each subsequent packet it will increase by 1, will be used as parameter to decode and encode symbol.
+*  `data` - our encoded symbol, 768 bytes in size.
+
+After serializing `rldp.messagePart`, wrap it in `adnl.message.custom` and send it over ADNL UDP.
+
+We send packets in a loop, increasing seqno all the time, until we wait for the `rldp.complete` message from the peer, or we stop on a timeout. After we have sent a number of packets equal to the number of our symbols, we can slow down and send an additional packet, for example, once every 10 milliseconds or fewer. 
+The extra packets are used for recovery in case of data loss, since UDP is a fast but unreliable protocol.
+
+[[Implementation example]](https://github.com/xssnick/tonutils-go/blob/be3411cf412f23e6889bf0b648904306a15936e7/adnl/rldp/rldp.go#L249)
+
+### Processing the response from `foundation.ton`
+
+During the sending, we can already expect a response from the server, in our case we are waiting for `rldp.answer` with `http.response` inside. 
+It will come to us in the same way, in the form of an RLDP transfer, as it was sent at the time of the request, but `transfer_id` will be inverted (each byte XOR 0xFF). 
+We will get `adnl.message.custom` messages containing `rldp.messagePart`.
+
+First we need to get the FEC information from the first received message of the transfer, specifically the `data_size`, `symbol_size` and `symbols_count` parameters from the `fec.raptorQ` messagePart structure.
+We need them to initialize the RaptorQ decoder. [[Example]](https://github.com/xssnick/tonutils-go/blob/be3411cf412f23e6889bf0b648904306a15936e7/adnl/rldp/rldp.go#L137)
+
+After initialization, we add the received symbols with their `seqno` to our decoder, and once we have accumulated the minimum required number equal to `symbols_count`, we can try to decode the full message. On success, we will send `rldp.complete`. [[Example]](https://github.com/xssnick/tonutils-go/blob/be3411cf412f23e6889bf0b648904306a15936e7/adnl/rldp/rldp.go#L168)
+
+The result will be a `rldp.answer` message with the same query_id as in the `rldp.query` we sent. The data must contain `http.response`.
+```
+http.response http_version:string status_code:int reason:string headers:(vector http.header) no_payload:Bool = http.Response;
+```
+With the main fields, I think everything is clear, the essence is the same as in HTTP. 
+An interesting flag here is `no_payload`, if it is true, then there is no body in the response, (`Content-Length` = 0).
+The response from the server can be considered received.
+
+If `no_payload` = false, then there is content in the response, and we need to get it. 
+To do this, we need to send a request with a TL schema `http.getNextPayloadPart` wrapped in `rldp.query`.
+```
+http.getNextPayloadPart id:int256 seqno:int max_chunk_size:int = http.PayloadPart;
+```
+`id` should be the same as we sent in `http.request`, `seqno` - 0, and +1 for each next part. `max_chunk_size` is the maximum chunk size we are ready to accept, typically 128 KB (131072 bytes) is used.
+
+In response, we will receive:
+```
+http.payloadPart data:bytes trailer:(vector http.header) last:Bool = http.PayloadPart;
+```
+If `last` = true, then we have reached the end, we can put all the pieces together and get a complete response body, for example, html.
+
+## References
+
+_Here a [link to the original article](https://github.com/xssnick/ton-deep-doc/blob/master/RLDP.md) by [Oleg Baranov](https://github.com/xssnick)._

--- a/docs/learn/networking/low-level-adnl.md
+++ b/docs/learn/networking/low-level-adnl.md
@@ -73,6 +73,10 @@ The receiving peer must fetch the first 4 bytes, decrypt it into the `length` fi
 
 The first datagram in the session always goes from the server to the client after a handshake packet was successfully accepted by the server and it's actual buffer is empty. The client should decrypt it and disconnect from the server in case of failure, because it means that the server has not followed the protocol properly and the actual session keys differs on the server and client side.
 
+### Communication details
+
+If you want to dive into communication details, you could check article [ADNL TCP - Liteserver](/docs/develop/network/adnl-tcp) to see some examples.
+
 ### Security considerations
 #### Handshake padding
 It is unknown why the initial TON team decided to include this field into the handshake. `aes_params` integrity is protected by a SHA-256 hash and confidentiality is protected by the key derived from the `secret` parameter. Probably, it was intended to migrate from AES-CTR at some point. To do this, specification may be extended to include a special magic value in `aes_params`, which will signal that the peer is ready to use the updated primitives. The response to such a handshake may be decrypted twice, with new and old schemes, to clarify which scheme the other peer is actually using.
@@ -85,7 +89,8 @@ If an encryption key is derived only from the `secret` parameter, it will be sta
 It is not obvious why the `nonce` field in the datagram is present because, even without it, any two ciphertexts will differ because of the session-bounded keys for AES and encryption in CTR mode. However, the following attack can be performed in the case of an absent or predictable nonce. CTR encryption mode turns block ciphers, such as AES, into stream ciphers to make it possible to perform a bit-flipping attack. If the attacker knows the plaintext which belongs to encrypted datagram, they can obtain a pure keystream, XOR it with their own plaintext and efficiently replace the message which was sent by peer. The buffer integrity is protected by a SHA-256 hash, but an attacker can replace it too because having knowledge of a full plaintext means having knowledge of its hash. The nonce field is present to prevent such an attack, so no attacker can replace the SHA-256 without having knowledge of the nonce.
 
 ## P2P protocol (ADNL over UDP)
-TBD
+
+Detailed description can be found in article [ADNL UDP - Internode](/docs/develop/network/adnl-udp).
 
 ## References
 - [The Open Network, p. 80](https://ton.org/ton.pdf)

--- a/docs/learn/networking/overlay-subnetworks.md
+++ b/docs/learn/networking/overlay-subnetworks.md
@@ -28,6 +28,6 @@ Overlay subnetworks can be public or private.
 Overlay subnetworks work according to a special [gossip](https://en.wikipedia.org/wiki/Gossip_protocol) protocol.
 
 :::info
-Read more about ADNL overlay subnetworks in Chapter 3.3 of the [TON Whitepaper](https://ton.org/docs/ton.pdf).
+Read more about overlays in [Overlay subnetworks](/docs/develop/network/overlay) article, or in Chapter 3.3 of the [TON Whitepaper](https://ton.org/docs/ton.pdf).
 :::
 

--- a/docs/learn/networking/rldp.md
+++ b/docs/learn/networking/rldp.md
@@ -11,3 +11,7 @@ A reliable arbitrary-size datagram protocol built upon the ADNL, called RLDP,
 is used instead of a TCP-like protocol. This reliable datagram protocol can
 be employed, for instance, to send RPC queries to remote hosts and receive
 answers from them.
+
+:::info
+Detailed description with examples can be found in [RLDP](/docs/develop/network/rldp) article of `develop` section.
+:::

--- a/docs/learn/networking/ton-dht.md
+++ b/docs/learn/networking/ton-dht.md
@@ -64,5 +64,5 @@ new sequence number is larger (to prevent replay attacks).
 TON DHT is not only used to store the IP Addresses of ADNL Nodes, but is also used for other purposes - it can store a list of addresses of the nodes which are storing a specific torrent of TON Storage, a list of addresses of nodes included in an overlay subnetwork, ADNL Addresses of TON services or ADNL Addresses of accounts of the TON Blockchain and so on.
 
 :::info
-Read more about TON DHT in Chapter 3.2. of the [TON Whitepaper](https://ton.org/docs/ton.pdf).
+Read more about TON DHT in [DHT](/docs/develop/network/dht) article, or in Chapter 3.2. of the [TON Whitepaper](https://ton.org/docs/ton.pdf).
 :::

--- a/docs/learn/overviews/TL-B.md
+++ b/docs/learn/overviews/TL-B.md
@@ -140,6 +140,12 @@ The **Backus–Naur form** can be found at [TlbParser.bnf](https://github.com/an
 TL-B is also supported by [intellij-ton plugin](https://github.com/andreypfau/intellij-ton).
 
 Docs on TL-B can be found in the [TVM Whitepaper](https://ton.org/tvm.pdf) and in a concise (they have been collected in one place) format [here](https://github.com/tonstack/TL-B-docs).
+
 ## Generator of serializators and deserializators
 An example of a generator used by a TON node can be found in the [Ton node sources](https://github.com/ton-blockchain/ton/blob/master/crypto/tl/tlbc.cpp).
+
+## More about TL-B
+
+If you want to know more about TL-B serialization and see some examples of complex structures parsing, 
+you can continue by reading [TL-B](/docs/develop/data-formats/tl-b) article at `develop` section of documentation.
 

--- a/docs/learn/overviews/cells.md
+++ b/docs/learn/overviews/cells.md
@@ -43,6 +43,8 @@ Any object in TON (message, message queue, block, whole blockchain state, contra
 The process of serialization is described by a TL-B scheme: a formal description of how this object can be serialized into _Builder_ or how to parse an object of a given type from the _Slice_.
 TL-B for cells is the same as TL or ProtoBuf for byte-streams.
 
+If you want to know more details about cell (de)serialization, you could read [Cell & Bag of Cells](/docs/develop/data-formats/cell-boc) article.
+
 :::tip TL-B
 Navigate to the [TL-B](/learn/overviews/TL-B) section for more information.
 :::

--- a/sidebars.js
+++ b/sidebars.js
@@ -442,6 +442,26 @@ const sidebars = {
         'develop/howto/validator',
         {
           type: 'category',
+          label: 'Data formats',
+          items: [
+            'develop/data-formats/cell-boc',
+            'develop/data-formats/tl',
+            'develop/data-formats/tl-b'
+          ]
+        },
+        {
+          type: 'category',
+          label: 'Network protocols',
+          items: [
+            'develop/network/adnl-tcp',
+            'develop/network/adnl-udp',
+            'develop/network/dht',
+            'develop/network/rldp',
+            'develop/network/overlay'
+          ]
+        },
+        {
+          type: 'category',
           label: 'Archived',
           items: [
             'develop/archive/pow-givers',


### PR DESCRIPTION
## Ton Deep Doc translation and adaptation

Added documentation (with real examples) of TON network protocols, such as: ADNL UDP/TCP, RLDP, DHT, Overlays and more.
Also added description of data formats such as: BoC, Cell, Merkle Proofs

Information is based on the translated [ton-deep-doc](https://github.com/xssnick/ton-deep-doc) with some extensions and formatting.

## Related Issue

https://github.com/ton-society/ton-footsteps/issues/128