### PR TITLE
Invalid fiftlib download link

### DIFF
--- a/docs/develop/smart-contracts/environment/installation.md
+++ b/docs/develop/smart-contracts/environment/installation.md
@@ -108,7 +108,7 @@ Instead of the `%USERNAME%` keyword, you must insert your own `username`.
    fift -V && func -V && lite-client -V
    ```
 
-  4. If you plan to `use fift`, also download [fiftlib.zip](https://github.com/ton-defi-org/ton-binaries/releases/download/fiftlib/fiftlib.zip), open the zip in some directory on your device (like `/usr/local/lib/fiftlib`), and set the environment variable `FIFTPATH` to point to this directory.
+  4. If you plan to `use fift`, also download [fiftlib.zip](https://github.com/ton-defi-org/ton-binaries/releases/download/macos-m1-0.3.0/fiftlib.zip), open the zip in some directory on your device (like `/usr/local/lib/fiftlib`), and set the environment variable `FIFTPATH` to point to this directory.
    
    ```
    unzip fiftlib.zip


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Why is it important?
<!--- Describe your changes in detail -->
It's important to keep the documentation up to date and replace invalid links as soon as possible. In the documentation for TON Developers under Environment / Installation / MacOS / 2. Setup Binaries / 4. Install fift lib, is an invalid download link referenced.

## Reference 
[TON Development Documentation](https://ton.org/docs/develop/smart-contracts/environment/installation#2-setup-your-binaries)

<!--- This project accepts pull requests related to open issues, if possible -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here, if possible: -->