### PR TITLE
Update collators.md (one word change)

### DIFF
--- a/docs/participate/nodes/collators.md
+++ b/docs/participate/nodes/collators.md
@@ -59,7 +59,7 @@ The easiest way is the following:
 - Stop validator `sudo systemctl stop validator`
 - Update service file `sudo nano /etc/systemd/system/validator.service`: add `--lite-validator` flag
 - Reload systemctl `sudo systemctl daemon-reload`
-- Start validator `sudo systemctl stop validator`
+- Start validator `sudo systemctl start validator`
 
 ## Lite server
 


### PR DESCRIPTION
Simple fix. I have changed one command for start validator after update config.

## Why is it important?
If someone will copy sting one by one then make a mistake and won't be able to run validator