### PR TITLE
Buffer.slice is deprecated

### DIFF
--- a/docs/develop/dapps/tutorials/collection-minting.md
+++ b/docs/develop/dapps/tutorials/collection-minting.md
@@ -389,8 +389,8 @@ Firstly create function, that will convert our buffer into chunks:
 function bufferToChunks(buff: Buffer, chunkSize: number) {
   const chunks: Buffer[] = [];
   while (buff.byteLength > 0) {
-    chunks.push(buff.slice(0, chunkSize));
-    buff = buff.slice(chunkSize);
+    chunks.push(buff.subarray(0, chunkSize));
+    buff = buff.subarray(chunkSize);
   }
   return chunks;
 }


### PR DESCRIPTION
It's better to use buff.subarray instead of buff.slice

<!--- Provide a general summary of your changes in the Title above -->

## Why is it important?

LSP не ругается
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues, if possible -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here, if possible: -->