### PR TITLE
Weekly update 28

### DIFF
--- a/docs/develop/dapps/README.md
+++ b/docs/develop/dapps/README.md
@@ -44,43 +44,17 @@ If you are a web or bot developer, you may find the following repositories usefu
 - [10+ examples from xssnick/tonutils-go](https://github.com/xssnick/tonutils-go/tree/master/example)
 - [7+ examples from tonkeeper/tongo](https://github.com/tonkeeper/tongo/tree/master/example)
 
-## Most popular SDK
+## TON SDKs
 
-Here is a list of modern SDKs that are constantly supported and improved:
+Learn the complete list of The Open Network SDKs from the SDKs page:
+* [SDK](/develop/dapps/apis/sdk)
 
-### JavaScript SDK
-
-* [ton-community/ton](https://github.com/ton-community/ton) — _Modern_ cross-platform client for TON by the TON Community
-* [toncenter/tonweb](https://github.com/toncenter/tonweb) — cross-platform client for TON Blockchain by TON Center
-* [@tegro/ton3-client](https://github.com/TegroTON/ton3-client) — JS ton3-client for tonhold API by TonHold
-* [nns2009/ton-payment-tracker](https://github.com/nns2009/ton-payment-tracker) — TON payment tracker.
-
-### Python SDK
-
-- [psylopunk/pytonlib](https://github.com/psylopunk/pytonlib) — Python SDK (ADNL API)
-- [toncenter/pytonlib](https://github.com/toncenter/pytonlib) — Python SDK (ADNL API)
-- [tonfactory/tonsdk](https://github.com/tonfactory/tonsdk) — Analogue of the tonweb js library (TON Center HTTP API)
-- [tons](https://pypi.org/project/tons/) — Easy-to-use CLI to work with TON wallets.
-
-### Go SDK
-
-- [xssnick/tonutils-go](https://github.com/xssnick/tonutils-go) — Golang SDK for TON Blockchain. 
-- [tonkeeper/tongo](https://github.com/tonkeeper/tongo) — Golang SDK with native ADNL support, cells manipulations and CGO for TVM and tx emulations.
-
-
-### Kotlin / Java SDK
-
-- [ton-kotlin](https://github.com/andreypfau/ton-kotlin) — Kotlin SDK for TON Blockchain
-
-### Rust SDK
-
-- [ston-fi/tonlib-rs](https://github.com/ston-fi/tonlib-rs) — Rust SDK for The Open Network.
 
 ## Telegram WebApps (TWA)
 
 - [Telegram WebApps Documentation](https://core.telegram.org/bots/webapps) — full description on Telegram website.
 
-### SDK
+### TWA SDKs
 
 - [ton-defi-org/tonstarter-twa](https://github.com/ton-defi-org/tonstarter-twa) — template for new TWA interaction with TON
 - [twa-dev/boilerplate](https://github.com/twa-dev/Boilerplate) — another boilerplate for a new TWA.
@@ -105,28 +79,8 @@ To add login button to your website or web app use the following:
 * [Introducing TON Connect](/develop/dapps/ton-connect)
 * [TON Connect for Developers](/develop/dapps/ton-connect/developers)
 * [TON Connect 2.0 vs 1.0](/develop/dapps/ton-connect/comparison)
+* [ton-connect/wallets-list](https://github.com/ton-connect/wallets-list) — list of supported wallets (add yours!)
 
-#### Development
-
-- [ton-connect/sdk](https://github.com/ton-connect) — JS SDK for authorization
-- [ton-connect/docs](https://github.com/ton-connect/docs) — Documentation of standard
-- [ton-connect/wallets-list](https://github.com/ton-connect/wallets-list) — list of supported wallets (add yours!)
-
-## TonLib SDK
-
-:::caution low-level
-These technologies contains very low-level stack, so please use it if any other SDKs don't work for you. It will save a lot of your time.
-:::
-
-TonLib was one of the first libraries for working with TON Blockchain.
-
-- [C++ TonLib](https://github.com/ton-blockchain/ton/tree/master/example/cpp)
-- [Python TonLib wrapper](https://github.com/toncenter/pytonlib)
-- [Golang TonLib wrapper](https://github.com/ton-blockchain/tonlib-go)
-- [Java TonLib wrapper (JNI)](https://github.com/ton-blockchain/tonlib-java)
-- [tonlib-xcframework](https://github.com/labraburn/tonlib-xcframework)—builder for Apple that generates .xcramework for all architectures
-- [labraburn/SwiftyTON](https://github.com/labraburn/SwiftyTON)—native Swift wrapper for tonlib with async/await
-- [labraburn/node-tonlib](https://github.com/labraburn/node-tonlib)—C++ addon for NodeJS to work with tonlibjson
 
 ### Usage examples
 

--- a/docs/develop/dapps/apis/sdk.mdx
+++ b/docs/develop/dapps/apis/sdk.mdx
@@ -5,8 +5,8 @@ Data provider is an [RPC](/develop/dapps/apis/toncenter#rpc-nodes) provided by t
 
 | Library |	Language |	API Type support |	Description |
 |---------|----------|-------|--------------|
+|[ton](https://github.com/ton-org/ton)	|TypeScript|`api/v2`, `api/v4`|Convenient cross-platform client for development dApps on TON Blockchain.|
 |[tonweb](https://github.com/toncenter/tonweb)|JavaScript|`api/v2` |TON JavaScript SDK for Payments Systems and DEX Development.|
-|[ton](https://github.com/ton-core/ton)	|TypeScript|`api/v2`, `api/v4`|Convenient cross-platform client for TON blockchain.|
 |[tonsdk](https://github.com/tonfactory/tonsdk) |   Python       | `api/v2` |         This low-level Python library allows you to work with the TON blockchain.     |
 |[TonTools](https://github.com/yungwine/TonTools)| Python| `api/v2` |TonTools is a high-level OOP library for Python, which can be used to interact with TON Blockchain.|
 |[TonSdk.NET](https://github.com/continuation-team/TonSdk.NET)| C#| `api/v2`|Native C# SDK for The Open Network |
@@ -42,8 +42,20 @@ The data provider is a [Liteserver](/participate/run-nodes/liteserver), which ca
 
 ### Legacy TonLib SDK
 
-- [Desktop standard wallet](https://github.com/ton-blockchain/wallet-desktop) (C++ and Qt)
-- [Android standard wallet](https://github.com/ton-blockchain/wallet-android) (Java)
-- [iOS standard wallet](https://github.com/ton-blockchain/wallet-ios) (Swift)
-- [TonLib CLI](https://github.com/ton-blockchain/ton/blob/master/tonlib/tonlib/tonlib-cli.cpp) (C++)
+:::caution low-level
+These technologies contains very low-level stack, so please use it if any other SDKs don't work for you. It will save a lot of your time.
+:::
+
+TonLib was one of the first libraries for working with TON Blockchain.
+
+- [C++ TonLib](https://github.com/ton-blockchain/ton/tree/master/example/cpp)
+- [Python TonLib wrapper](https://github.com/toncenter/pytonlib)
+- [Golang TonLib wrapper](https://github.com/ton-blockchain/tonlib-go)
+- [Java TonLib wrapper (JNI)](https://github.com/ton-blockchain/tonlib-java)
+- [tonlib-xcframework](https://github.com/labraburn/tonlib-xcframework)—builder for Apple that generates .xcramework for all architectures
+- [labraburn/SwiftyTON](https://github.com/labraburn/SwiftyTON)—native Swift wrapper for tonlib with async/await
+- [labraburn/node-tonlib](https://github.com/labraburn/node-tonlib)—C++ addon for NodeJS to work with tonlibjson
+
+
+
 

--- a/docs/develop/dapps/apis/sdk.mdx
+++ b/docs/develop/dapps/apis/sdk.mdx
@@ -6,7 +6,7 @@ Data provider is an [RPC](/develop/dapps/apis/toncenter#rpc-nodes) provided by t
 | Library |	Language |	API Type support |	Description |
 |---------|----------|-------|--------------|
 |[ton](https://github.com/ton-org/ton)	|TypeScript|`api/v2`, `api/v4`|Convenient cross-platform client for development dApps on TON Blockchain.|
-|[tonweb](https://github.com/toncenter/tonweb)|JavaScript|`api/v2` |TON JavaScript SDK for Payments Systems and DEX Development.|
+|[tonweb](https://github.com/toncenter/tonweb)|JavaScript|`api/v2` |TON JS SDK, with minimal external dependencies and enhanced security, is suitable for the development of payment systems and DEXs.|
 |[tonsdk](https://github.com/tonfactory/tonsdk) |   Python       | `api/v2` |         This low-level Python library allows you to work with the TON blockchain.     |
 |[TonTools](https://github.com/yungwine/TonTools)| Python| `api/v2` |TonTools is a high-level OOP library for Python, which can be used to interact with TON Blockchain.|
 |[TonSdk.NET](https://github.com/continuation-team/TonSdk.NET)| C#| `api/v2`|Native C# SDK for The Open Network |

--- a/docs/develop/dapps/apis/toncenter.md
+++ b/docs/develop/dapps/apis/toncenter.md
@@ -18,8 +18,7 @@ You can connect to public [toncenter.com](https://toncenter.com) or run your own
 
 To work with public TonCenter API you need a key:
 
-* Get API key for mainnet: [@tonapibot](https://t.me/tonapibot)
-* Get API key for testnet: [@tontestnetapibot](https://t.me/tontestnetapibot)
+* Get API key for the Mainnet and the Testnet: [@tonapibot](https://t.me/tonapibot)
 
 ## RPC Nodes
 * [https://www.orbs.com/ton-access/](https://www.orbs.com/ton-access/) - HTTP API for The Open Network (TON). 

--- a/docs/develop/overview.mdx
+++ b/docs/develop/overview.mdx
@@ -36,6 +36,7 @@ The following resources provide valuable information for TON smart contract deve
 
 * [TON Hello World: Step-by-step guide for writing your first smart contract](https://ton-community.github.io/tutorials/02-contract/) - An accessible and concise explanation of the fundamentals with JS.
 * [How to work with wallet smart contracts](/develop/smart-contracts/tutorials/wallet) - Detailed and careful explanations of smart contract basics with the use of JS and GO.
+* [Learn Smart Contracts by examples](/develop/smart-contracts/examples) (FunC, Fift)
 
 
 ## Web and dApps development
@@ -53,15 +54,14 @@ Take your first steps in dApps development with a comprehensive dApps building g
 - [Telegram bot integration via TON Connect](/develop/dapps/ton-connect/tg-bot-integration)
 
 
-### Examples & SDK
+### SDKs and Examples
 
-* [Learn Smart Contracts by examples](/develop/smart-contracts/examples) (FunC, Fift)
-* [Learn by examples](/develop/dapps/#examples) (JS, Python, Go)
-* [SDK list](/develop/dapps/#most-popular-sdk) (JS, Python, Go, Kotlin)
-* [Telegram Web Apps (TWA) Development](/develop/dapps/#telegram-webapps-twa)
-* [TonLib SDK](/develop/dapps/#tonlib-sdk)
-* [List of APIs](/develop/dapps/#apis)
-* [Authorization SDK](/develop/dapps/#authorization-sdk)
+* [APIs](/develop/dapps/apis)
+* [SDKs](/develop/dapps/apis/sdk)
+* [Learn by examples](/develop/dapps/#examples)
+* [Learn Smart Contracts by examples](/develop/smart-contracts/examples)
+* [Telegram Web Apps (TWA) Development](https://docs.twa.dev/docs/introduction/about-platform)
+* [Authorization SDKs](/develop/dapps/ton-connect/developers)
 
 ## Frequently Asked Questions
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -147,7 +147,7 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'API & SDK',
+      label: 'APIs and SDKs',
       items: [
         'develop/dapps/apis/README',
         'develop/dapps/apis/toncenter',


### PR DESCRIPTION
* The Open Network SDKs references are updated in the documentation.
* References in the docs are unified and lead to the https://docs.ton.org/develop/dapps/apis/sdk page.