### PR TITLE
update links for py examples in proofs article

### DIFF
--- a/docs/develop/data-formats/proofs.mdx
+++ b/docs/develop/data-formats/proofs.mdx
@@ -98,7 +98,7 @@ assert h_proof.refs[0].get_hash(0) == block_id.root_hash
 ```
 Now, we can trust all other data, this Cell contains
 
-_Checking Proof Examples:_ [Python](https://github.com/yungwine/tonpylib/blob/master/tonpylib/proof/check_proof.py#L33), [Kotlin](https://github.com/andreypfau/ton-kotlin/blob/b1edc4b134e89ccf252149f27c85fd530377cebe/ton-kotlin-liteclient/src/commonMain/kotlin/CheckProofUtils.kt#L15), [C++](https://github.com/ton-blockchain/ton/blob/24dc184a2ea67f9c47042b4104bbb4d82289fac1/crypto/block/check-proof.cpp#L34)
+_Checking Proof Examples:_ [Python](https://github.com/yungwine/pytoniq/blob/master/pytoniq/proof/check_proof.py#L33), [Kotlin](https://github.com/andreypfau/ton-kotlin/blob/b1edc4b134e89ccf252149f27c85fd530377cebe/ton-kotlin-liteclient/src/commonMain/kotlin/CheckProofUtils.kt#L15), [C++](https://github.com/ton-blockchain/ton/blob/24dc184a2ea67f9c47042b4104bbb4d82289fac1/crypto/block/check-proof.cpp#L34)
 
 ## Full Block
 
@@ -279,7 +279,7 @@ Now, let's deserialize the second Cell:
 
 Since we trust this Cell we can trust the Shard Block data (`ShardStateUnsplit` -> `custom` -> `shard_hashes` -> `0 (shrdblk wc)` -> `leaf`).
 
-_Checking Proof Examples:_ [Python](https://github.com/yungwine/tonpylib/blob/master/tonpylib/proof/check_proof.py#L43), [C++](https://github.com/ton-blockchain/ton/blob/24dc184a2ea67f9c47042b4104bbb4d82289fac1/crypto/block/check-proof.cpp#L104)
+_Checking Proof Examples:_ [Python](https://github.com/yungwine/pytoniq/blob/master/pytoniq/proof/check_proof.py#L43), [C++](https://github.com/ton-blockchain/ton/blob/24dc184a2ea67f9c47042b4104bbb4d82289fac1/crypto/block/check-proof.cpp#L104)
 
 ## Account State
 
@@ -564,7 +564,7 @@ And deserialize it according to the [Account](https://github.com/ton-blockchain/
 
 Now we can trust this account state data.
 
-_Checking Proof Examples:_ [Python](https://github.com/yungwine/tonpylib/blob/master/tonpylib/proof/check_proof.py#L87), [Kotlin](https://github.com/andreypfau/ton-kotlin/blob/b1edc4b134e89ccf252149f27c85fd530377cebe/ton-kotlin-liteclient/src/commonMain/kotlin/CheckProofUtils.kt#L37), [C++](https://github.com/ton-blockchain/ton/blob/24dc184a2ea67f9c47042b4104bbb4d82289fac1/crypto/block/check-proof.cpp#L161)
+_Checking Proof Examples:_ [Python](https://github.com/yungwine/pytoniq/blob/master/pytoniq/proof/check_proof.py#L87), [Kotlin](https://github.com/andreypfau/ton-kotlin/blob/b1edc4b134e89ccf252149f27c85fd530377cebe/ton-kotlin-liteclient/src/commonMain/kotlin/CheckProofUtils.kt#L37), [C++](https://github.com/ton-blockchain/ton/blob/24dc184a2ea67f9c47042b4104bbb4d82289fac1/crypto/block/check-proof.cpp#L161)
 
 ## Account transactions
 


### PR DESCRIPTION
I've changed the library name so the old links are not work now