### PR TITLE
fix wrong word

### DIFF
--- a/docs/develop/smart-contracts/compile/README.md
+++ b/docs/develop/smart-contracts/compile/README.md
@@ -78,7 +78,7 @@ ton-compiler --input ./wallet.fc --output ./wallet.cell
 # Compile to fift (useful for debuging)
 ton-compiler --input ./wallet.fc --output-fift ./wallet.fif
 
-# Compile to fift and fift
+# Compile to binary form and fift
 ton-compiler --input ./wallet.fc --output ./wallet.cell --output-fift ./wallet.fif
 
 # Disable stdlib


### PR DESCRIPTION
it should be written 'binary form' due to './wallet.cell' output but it's written 'fift'

<!--- Provide a general summary of your changes in the Title above -->

## Why is it important?

It's considered a typo, it's not vital.

## Related Issue

<!--- This project accepts pull requests related to open issues, if possible -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here, if possible: -->