### PR TITLE
Fix typo in cell serialization example

### DIFF
--- a/docs/develop/data-formats/cell-boc.mdx
+++ b/docs/develop/data-formats/cell-boc.mdx
@@ -112,7 +112,7 @@ Now let's add the refs indexes:
 And put it all together:
 ```json
 0201 C0     0201  
-0101 AA     02
+0101 FF     02
 0006 0AAAAA 
 ```
 


### PR DESCRIPTION
Value of second cell is FF, not AA. That was cell `7[FE]` padded to FF.
