### PR TITLE
feat: Code blocks theme update

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,10 +1,6 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
-const lightCodeTheme = require('prism-react-renderer/themes/github')
-const darkCodeTheme = require('prism-react-renderer/themes/dracula')
-
-
 // function to get current year
 function getCurrentYear() {
   const now = new Date();
@@ -456,8 +452,8 @@ const config = {
         // copyright: `Copyright © ${new Date().getFullYear()} TON Foundation`,
       },
       prism: {
-        // theme: darkCodeTheme,
-        // darkTheme: darkCodeTheme,
+        theme: require('./prism-theme'),
+        darkTheme: require('./prism-theme'),
         additionalLanguages: [
           'java',
           'python',

--- a/prism-theme.js
+++ b/prism-theme.js
@@ -1,0 +1,100 @@
+// Based on palenight, default code highlighting theme of Docusaurus
+// See: https://github.com/FormidableLabs/prism-react-renderer/blob/master/packages/prism-react-renderer/src/themes/palenight.ts
+
+const theme = {
+  plain: {
+    color: "#bfc7d5",
+    backgroundColor: "#292d3e",
+  },
+  styles: [
+    {
+      types: ["comment"],
+      style: {
+        color: "rgb(105, 112, 152)",
+        fontStyle: "italic",
+      },
+    },
+    {
+      types: ["string", "inserted", "char"],
+      style: {
+        color: "rgb(195, 232, 141)",
+      },
+    },
+    {
+      types: ["number"],
+      style: {
+        color: "rgb(247, 140, 108)",
+      },
+    },
+    {
+      types: ["builtin", "function"],
+      style: {
+        color: "rgb(130, 170, 255)",
+      },
+    },
+    {
+      types: ["variable"],
+      style: {
+        color: "rgb(191, 199, 213)",
+      },
+    },
+    {
+      types: ["class-name", "attr-name"],
+      style: {
+        color: "rgb(255, 203, 107)",
+      },
+    },
+    {
+      types: ["tag", "deleted"],
+      style: {
+        color: "rgb(255, 85, 114)",
+      },
+    },
+    {
+      types: ["operator"],
+      style: {
+        color: "rgb(137, 221, 255)",
+      },
+    },
+    {
+      types: ["boolean"],
+      style: {
+        color: "rgb(235, 88, 116)",
+      },
+    },
+    {
+      types: ["constant"],
+      style: {
+        color: "rgb(245, 110, 88)",
+      },
+    },
+    {
+      types: ["keyword"],
+      style: {
+        color: "rgb(199, 146, 234)",
+      },
+    },
+    {
+      types: ["doctype"],
+      style: {
+        color: "rgb(199, 146, 234)",
+        fontStyle: "italic",
+      },
+    },
+    {
+      types: ["namespace", "punctuation", "selector"],
+      style: {
+        color: "rgb(178, 204, 214)",
+      },
+    },
+    {
+      types: ["url"],
+      style: {
+        color: "rgb(221, 221, 221)",
+      },
+    },
+  ],
+}
+
+// CommonJS format, DON'T convert to ESM
+module.exports = theme;


### PR DESCRIPTION
A slightly tweaked code highlighting theme for Prism.js, based on the default theme of Docusaurus engine — Palenight.

## Why is it important?

It's clear now which colors are used for each particular token, as opposed to the previous situation where defaults were used implicitly, without any info in the ton-docs repo itself.

## Related Issue

Made as a bonus to [TON Footstep 288](https://github.com/ton-society/ton-footsteps/issues/288). Details and reasoning were provided there: [comment](https://github.com/ton-society/ton-footsteps/issues/288#issuecomment-1700824860).