### PR TITLE
Redirect from /hacktonberfest

### DIFF
--- a/deployment/Docker/nginx.conf
+++ b/deployment/Docker/nginx.conf
@@ -2,7 +2,11 @@ server {
     server_name _;
 
     location / {
-        root   /app;
+        root /app;
         try_files $uri $uri/index.html $uri.html 404.html;
+    }
+
+    location /hacktonberfest {
+        return 301 https://society.ton.org/hack-ton-berfest-2023;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Updated nginx config to add a redirect from /hacktonberfest to the society.ton.org event page, ie, https://society.ton.org/hack-ton-berfest-2023.

## Why is it important?

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues, if possible -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here, if possible: -->