### PR TITLE
Update ton-blockchain.md

### DIFF
--- a/docs/learn/overviews/ton-blockchain.md
+++ b/docs/learn/overviews/ton-blockchain.md
@@ -63,7 +63,7 @@ If you want to customize rules of the group of Shardchains, you could create a *
 
 Theoretically, everyone in community can create own workchain. In fact, it's pretty complicated task to build it, after that to pay (expensive) price of creating it and receive 2/3 of votes from validators to approve creation of your Workchain.
 
-TON allows creating up to `2^30` workchains, each subdivided to up to `2^60` shards.
+TON allows creating up to `2^32` workchains, each subdivided to up to `2^60` shards.
 
 Nowadays, there are only 2 workchains in TON: MasterChain and BaseChain.
 


### PR DESCRIPTION
Under the workchain ID of the page - Smart Contract Addresses - https://docs.ton.org/learn/overviews/addresses#workchain-id-and-account-id

It explain as we have 32 bit workchain_id there is a possibility of 2^32 unique workchains, but this page says 2^30, which I felt is a typo(human error). 

If not a error can you please add some description to justify the delta in these numbers.

<!--- Provide a general summary of your changes in the Title above -->

## Why is it important?

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues, if possible -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here, if possible: -->