### PR TITLE
Update tl-b-language.mdx

### DIFF
--- a/docs/develop/data-formats/tl-b-language.mdx
+++ b/docs/develop/data-formats/tl-b-language.mdx
@@ -107,7 +107,7 @@ tag_a$10 val:(## 32) = A;
 tag_b$00 val(## 64) = A;
 ```
 
-If we parse `1000000000000000000000000000000001` (1 and 33 zeroes and 1) in TLB type `A` - firstly we need to get first
+If we parse `1000000000000000000000000000000001` (1 and 32 zeroes and 1) in TLB type `A` - firstly we need to get first
 two bits to define tag. In this example `10` is two first bits and they represent `tag_a`. So now we know that next 32
 bits are `val` variable, `1` in our example. Some "parsed" pseudocode variables may look like:
 


### PR DESCRIPTION
Fix typo, should be `32 zeroes` instead of `33 zeroes`, because 1 zero for constructor definition and val's dimension is 32 bits.

<!--- Provide a general summary of your changes in the Title above -->

## Why is it important?

Found typo in documentation

## Related Issue

<!--- This project accepts pull requests related to open issues, if possible -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here, if possible: -->