### PR TITLE
fix url example Python checking proof

### DIFF
--- a/docs/develop/data-formats/proofs.mdx
+++ b/docs/develop/data-formats/proofs.mdx
@@ -98,7 +98,7 @@ assert h_proof.refs[0].get_hash(0) == block_id.root_hash
 ```
 Now, we can trust all other data, this Cell contains
 
-_Checking Proof Examples:_ [Python](https://github.com/yungwine/pytoniq/blob/master/pytoniq/proof/check_proof.py#L33), [Kotlin](https://github.com/andreypfau/ton-kotlin/blob/b1edc4b134e89ccf252149f27c85fd530377cebe/ton-kotlin-liteclient/src/commonMain/kotlin/CheckProofUtils.kt#L15), [C++](https://github.com/ton-blockchain/ton/blob/24dc184a2ea67f9c47042b4104bbb4d82289fac1/crypto/block/check-proof.cpp#L34)
+_Checking Proof Examples:_ [Python](https://github.com/yungwine/pytoniq-core/blob/873a96aa2256db33b8f35fbe2ab8fe8cf8ae49c7/pytoniq_core/proof/check_proof.py#L19), [Kotlin](https://github.com/andreypfau/ton-kotlin/blob/b1edc4b134e89ccf252149f27c85fd530377cebe/ton-kotlin-liteclient/src/commonMain/kotlin/CheckProofUtils.kt#L15), [C++](https://github.com/ton-blockchain/ton/blob/24dc184a2ea67f9c47042b4104bbb4d82289fac1/crypto/block/check-proof.cpp#L34)
 
 ## Full Block
 


### PR DESCRIPTION
## Why is it important?

On page https://docs.ton.org/develop/data-formats/proofs#block-header url  https://github.com/yungwine/pytoniq/blob/master/pytoniq/proof/check_proof.py#L33 got 404
