### PR TITLE
docs: update the toncenter api bot link

### DIFF
--- a/docs/develop/dapps/tutorials/collection-minting.md
+++ b/docs/develop/dapps/tutorials/collection-minting.md
@@ -693,12 +693,12 @@ Great! Now we can comeback to `NftItem.ts`. All we have to do is just send messa
 ```ts
 import { internal, SendMode } from "ton-core";
 import { OpenedWallet } from "utils";
-import { Collection, mintParams } from "./NftCollection";
+import { NftCollection, mintParams } from "./NftCollection";
 
 export class NftItem {
-  private collection: Collection;
+  private collection: NftCollection;
 
-  constructor(collection: Collection) {
+  constructor(collection: NftCollection) {
     this.collection = collection;
   }
 

--- a/docs/develop/dapps/tutorials/collection-minting.md
+++ b/docs/develop/dapps/tutorials/collection-minting.md
@@ -104,7 +104,7 @@ PINATA_API_SECRET=your_secret_api_key
 MNEMONIC=word1 word2 word3 word4
 TONCENTER_API_KEY=aslfjaskdfjasasfas
 ```
-You can get toncenter api key from [@tontestnetapibot](https://t.me/@tontestnetapibot) ([@tonapibot](https://t.me/@tonapibot) for mainnet). In `MNEMONIC` variable store 24 words of collection owner wallet seed phrase.
+You can get toncenter api key from [@tonapibot](https://t.me/tonapibot) and choose mainnet or testnet. In `MNEMONIC` variable store 24 words of collection owner wallet seed phrase.
 
 Great! Now we are ready to start writing code for our project.
 

--- a/docs/develop/dapps/tutorials/collection-minting.md
+++ b/docs/develop/dapps/tutorials/collection-minting.md
@@ -478,7 +478,7 @@ commonContentUrl | Base url for NFT items metadata
 Firstly let's write private method, that will return cell with code of our collection. 
 
 ```ts
-export class Collection {
+export class NftCollection {
   private collectionData: collectionData;
 
   constructor(collectionData: collectionData) {


### PR DESCRIPTION
update the toncenter api bot link in [Setup development environment](https://docs.ton.org/develop/dapps/tutorials/collection-minting#-setup-development-environment)

<!--- Provide a general summary of your changes in the Title above -->

## Why is it important?

<!--- Describe your changes in detail -->
when I click  `@tontestnetapibot` and `@tonapibot` in [Setup development environment](https://docs.ton.org/develop/dapps/tutorials/collection-minting#-setup-development-environment) , they don't switch 
correctly. 

`@tontestnetapibot` may be banned, but I have checked the docs and find we can use `@tonapibot` to create testnet or mainnet API

refer link: https://toncenter.com/

## Related Issue

<!--- This project accepts pull requests related to open issues, if possible -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here, if possible: -->