### PR TITLE
docs: add `transfer` function

### DIFF
--- a/docs/develop/dapps/tutorials/collection-minting.md
+++ b/docs/develop/dapps/tutorials/collection-minting.md
@@ -1043,6 +1043,36 @@ msgBody.storeBit(0); // no forward_payload
 return msgBody.endCell();
 ```
 
+And create a transfer function to transfer the NFT.
+
+```ts
+static async transfer(
+    wallet: OpenedWallet,
+    nftAddress: Address,
+    newOwner: Address
+  ): Promise<number> {
+    const seqno = await wallet.contract.getSeqno();
+
+    await wallet.contract.sendTransfer({
+      seqno,
+      secretKey: wallet.keyPair.secretKey,
+      messages: [
+        internal({
+          value: "0.05",
+          to: nftAddress,
+          body: this.createTransferBody({
+            newOwner,
+            responseTo: wallet.contract.address,
+            forwardAmount: toNano("0.02"),
+          }),
+        }),
+      ],
+      sendMode: SendMode.IGNORE_ERRORS + SendMode.PAY_GAS_SEPARATELY,
+    });
+    return seqno;
+  }
+```
+
 Nice, now we can we are already very close to the end. Back to the `app.ts` and let's get address of our nft, that we want to put on sale:
 ```ts
 const nftToSaleAddress = await NftItem.getAddressByIndex(collection.address, 0);


### PR DESCRIPTION
The docs miss the `transfer` function in `NftItem.ts` when I try to run  the tutorial code

<!--- Provide a general summary of your changes in the Title above -->
add `transfer` function in [Transfer item](https://docs.ton.org/develop/dapps/tutorials/collection-minting#transfer-item) part

## Why is it important?

<!--- Describe your changes in detail -->
The docs miss the `transfer` function in `NftItem.ts` when I try to run  the tutorial code

## Related Issue

<!--- This project accepts pull requests related to open issues, if possible -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here, if possible: -->