### PR TITLE
fix: error with github action syntax caused with mis-matched indent

### DIFF
--- a/docs/develop/dapps/telegram-apps/app-examples.mdx
+++ b/docs/develop/dapps/telegram-apps/app-examples.mdx
@@ -204,7 +204,7 @@ jobs:
         with:
           node-version: 18
           cache: 'npm'
-	  cache-dependency-path: './'
+          cache-dependency-path: './'
       - name: Install dependencies
         run: npm install
       - name: Build


### PR DESCRIPTION
There's a mis-matched indent in github action workflow file, and would cause github action fail. Just make it to the correct indent.

## Why is it important?

Changing hardtab (maybe, just my assumption) to spaces to match the yaml indent syntax. Otherwise, github action would complaint with error:
```
Check failure on line 30 in .github/workflows/static.yml

GitHub Actions/ .github/workflows/static.yml
Invalid workflow file
You have an error in your yaml syntax on line 30
```

