### PR TITLE
removed legacy SDKs from "ADNL based SDKs" list

### DIFF
--- a/docs/develop/dapps/apis/sdk.mdx
+++ b/docs/develop/dapps/apis/sdk.mdx
@@ -32,8 +32,6 @@ The data provider is a [Liteserver](/participate/run-nodes/liteserver), which ca
 |[tonlib-java](https://github.com/ton-blockchain/tonlib-java)	| Java |	Tonlib bin	 | JVM wrapper for TonLib that can be used with Java/Scala/Kotlin/etc.|
 |[justdmitry/TonLib.NET](https://github.com/justdmitry/TonLib.NET) | C# | Tonlib bin | .NET SDK for The Open Network|
 | [tonlib-rs](https://github.com/ston-fi/tonlib-rs) |	Rust	| Tonlib bin	| Rust SDK for The Open Network|
-|[pytonlib](https://github.com/toncenter/pytonlib)| Python |Tonlib bin | This is standalone Python library based on libtonlibjson |
-| [example/cpp](https://github.com/ton-blockchain/ton/tree/master/example/cpp) |	C++	| Tonlib | Tonlib C++ basic usage examples|
 |[getgems-io/ton-grpc](https://github.com/getgems-io/ton-grpc)| Rust | Tonlib | Rust bindings for tonlibjson and services built on top of it |
 
 


### PR DESCRIPTION
removed lines found below in "Legacy TonLib SDK" list