### PR TITLE
Added Simplified Chinese version for Ton white paper translation

### DIFF
--- a/docs/learn/docs.md
+++ b/docs/learn/docs.md
@@ -31,4 +31,5 @@ Please note that here and later the code, comments and/or documentation may cont
 ## Translations
 
 * **\[RU]** [korolyow/ton_docs_ru](https://github.com/Korolyow/TON_docs_ru) — TON Whitepapers in Russian. (_this version made by community, TON Foundation can't guarantee quality of translation_)
-* **\[CN]** [awesome-doge/the-open-network-whitepaper](https://github.com/awesome-doge/TON_Paper/blob/main/zh_ton.pdf) — TON Whitepapers in Chinese. (_made by community, TON Foundation can't guarantee quality of translation_)
+* **\[Traditional CN]** [awesome-doge/the-open-network-whitepaper](https://github.com/awesome-doge/TON_Paper/blob/main/zh_ton.pdf) — TON Whitepapers in Traditional Chinese. (_made by community, TON Foundation can't guarantee quality of translation_)
+* **\[Simplified CN]** [kojhliang/Ton_White_Paper_SC](https://github.com/kojhliang/Ton_White_Paper_SC/blob/main/Ton%E5%8C%BA%E5%9D%97%E9%93%BE%E7%99%BD%E7%9A%AE%E4%B9%A6_%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87%E7%89%88.pdf) — TON Whitepapers in Simplified Chinese. (_made by community, TON Foundation can't guarantee quality of translation_)  


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
## Why is it important?
Currently, Ton White paper only has the Traditional Chinese version, For developers in the Chinese Mainland, simplified Chinese is used. Traditional Chinese and simplified Chinese are very different in many places.  
So I spent almost one month translating Ton's white paper into the Simplified Chinese version(I checked every word and sentence to ensure better translation), which will be convenient for people using Simplified Chinese to read it.

## Changes
<!--- Describe your changes in detail -->
I add a  link and description of the simplified Chinese version under the Traditional Chinese version on the Ton white paper - Overview page.

## Related Issue
None
<!--- This project accepts pull requests related to open issues, if possible -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here, if possible: -->