### PR TITLE
Fix links in NFT deploy instruction

### DIFF
--- a/docs/develop/dapps/tutorials/collection-minting.md
+++ b/docs/develop/dapps/tutorials/collection-minting.md
@@ -1111,16 +1111,16 @@ Now we can launch our project and enjoy the process!
 ```
 yarn start
 ```
-Go to https://testnet.getgems.io/YOUR_COLLECTION_ADDRESS_HERE and look to this perfect ducks!
+Go to https://testnet.getgems.io/collection/<YOUR_COLLECTION_ADDRESS_HERE> and look to this perfect ducks!
 
 ## Conclusion 
 
-Today you have learned a lot of new things about TON and even created your own beautiful NFT collection in the testnet! If you still have any questions or have noticed an error - feel free to write to the author - [@coalus](https:/t.me/coalus)
+Today you have learned a lot of new things about TON and even created your own beautiful NFT collection in the testnet! If you still have any questions or have noticed an error - feel free to write to the author - [@coalus](https://t.me/coalus)
 
 ## References
 
-- [GetGems NFT-contracts](https:/github.com/getgems-io/nft-contracts)
+- [GetGems NFT-contracts](https://github.com/getgems-io/nft-contracts)
 - [NFT Standart](https://github.com/ton-blockchain/TEPs/blob/master/text/0062-nft-standard.md)
 
 ## About the author 
-- Coalus on [Telegram](https:/t.me/coalus) or [Github](https:/github.com/coalus)
+- Coalus on [Telegram](https://t.me/coalus) or [Github](https://github.com/coalus)


### PR DESCRIPTION
## Why is it important?

Because NFT deploy instruction is broken