### PR TITLE
SearchField hasMarkdown instead of isGrouped, dynamic table layout, fix typos

### DIFF
--- a/docs/learn/tvm-instructions/instructions.csv
+++ b/docs/learn/tvm-instructions/instructions.csv
@@ -636,7 +636,7 @@ c4 POP",x -,26,"Sets the “global data root'' cell reference, thus allowing mod
 SETCONTCTR,,#ED6 i:uint4,cont_registers,ED6i,"c[i] SETCONT
 c[i] SETCONTCTR",x c - c',26,"Stores `x` into the savelist of continuation `c` as `c(i)`, and returns the resulting continuation `c'`. Almost all operations with continuations may be expressed in terms of `SETCONTCTR`, `POPCTR`, and `PUSHCTR`."
 SETRETCTR,,#ED7 i:uint4,cont_registers,ED7i,c[i] SETRETCTR,x - ,26,Equivalent to `c0 PUSHCTR` `c[i] SETCONTCTR` `c0 POPCTR`.
-SETALTCTR,,#ED8 i:uint4,cont_registers,ED8i,c[i] SETALTCTR,x - ,26,Equivalent to `c1 PUSHCTR` `c[i] SETCONTCTR` `c0 POPCTR`.
+SETALTCTR,,#ED8 i:uint4,cont_registers,ED8i,c[i] SETALTCTR,x - ,26,Equivalent to `c1 PUSHCTR` `c[i] SETCONTCTR` `c1 POPCTR`.
 POPSAVE,,#ED9 i:uint4,cont_registers,ED9i,"c[i] POPSAVE
 c[i] POPCTRSAVE",x -,26,"Similar to `c[i] POPCTR`, but also saves the old value of `c[i]` into continuation `c0`.
 Equivalent (up to exceptions) to `c[i] SAVECTR` `c[i] POPCTR`."
@@ -645,7 +645,7 @@ c[i] SAVECTR",,26,"Saves the current value of `c(i)` into the savelist of contin
 SAVEALT,,#EDB i:uint4,cont_registers,EDBi,"c[i] SAVEALT
 c[i] SAVEALTCTR",,26,"Similar to `c[i] SAVE`, but saves the current value of `c[i]` into the savelist of `c1`, not `c0`."
 SAVEBOTH,,#EDC i:uint4,cont_registers,EDCi,"c[i] SAVEBOTH
-c[i] SAVEBOTHCTR",,26,Equivalent to `DUP` `c[i] SAVE` `c[i] SAVEALT`.
+c[i] SAVEBOTHCTR",,26,Equivalent to `c[i] SAVE` `c[i] SAVEALT`.
 PUSHCTRX,,#EDE0,cont_registers,EDE0,PUSHCTRX,i - x,26,"Similar to `c[i] PUSHCTR`, but with `i`, `0 <= i <= 255`, taken from the stack.
 Notice that this primitive is one of the few “exotic'' primitives, which are not polymorphic like stack manipulation primitives, and at the same time do not have well-defined types of parameters and return values, because the type of `x` depends on `i`."
 POPCTRX,,#EDE1,cont_registers,EDE1,POPCTRX,x i - ,26,"Similar to `c[i] POPCTR`, but with `0 <= i <= 255` from the stack."

--- a/src/components/SearchField/index.tsx
+++ b/src/components/SearchField/index.tsx
@@ -4,7 +4,6 @@ import React, {
   HTMLAttributes,
   useCallback,
   useEffect,
-  useMemo,
   useState,
   useRef
 } from 'react';
@@ -14,7 +13,7 @@ import Markdown from "markdown-to-jsx";
 type DataKey<Key> = {
   key: Key;
   name: string;
-  isGrouped?: boolean;
+  hasMarkdown?: boolean;
 }
 
 type Props<DataItem> = {
@@ -74,9 +73,6 @@ export const SearchField = <T extends Record<string, string>>({ data, searchBy, 
     clearTimeout(timeout.current);
   }, [timeout.current])
 
-  const groupedKeys = useMemo(() => showKeys.filter((key) => key.isGrouped), [showKeys]);
-  const separateKeys = useMemo(() => showKeys.filter((key) => !key.isGrouped), [showKeys])
-
   return (
     <>
       <input
@@ -91,18 +87,16 @@ export const SearchField = <T extends Record<string, string>>({ data, searchBy, 
       <table>
         <thead>
           <tr>
-            <th style={{ textAlign: "left" }}>Opcode</th>
-            <th style={{ textAlign: "left" }}>Fift syntax</th>
-            <th style={{ textAlign: "left" }}>Stack</th>
-            <th style={{ textAlign: "left" }}>Gas</th>
-            <th style={{ textAlign: "left" }}>Description</th>
+            {showKeys.map((keyEntity) => (
+              <th style={{textAlign: "left"}} key={keyEntity.name}>{keyEntity.name}</th>
+            ))}
           </tr>
         </thead>
 
         <tbody>
           {debouncedValue.length === 0 && (
             <tr>
-              <td colSpan={groupedKeys.length + separateKeys.length}>
+              <td colSpan={showKeys.length}>
                 Please enter a search query
               </td>
             </tr>
@@ -110,7 +104,7 @@ export const SearchField = <T extends Record<string, string>>({ data, searchBy, 
 
           {filteredData.length === 0 && (
             <tr>
-              <td colSpan={groupedKeys.length + separateKeys.length}>
+              <td colSpan={showKeys.length}>
                 No results found
               </td>
             </tr>
@@ -118,16 +112,15 @@ export const SearchField = <T extends Record<string, string>>({ data, searchBy, 
 
           {filteredData.length !== 0 && filteredData.map((item, index) => (
             <tr key={index}>
-              {groupedKeys.map((keyEntity) => (
-                <td key={keyEntity.name}>
-                  {item[keyEntity.key] && <code>{item[keyEntity.key]}</code>}
-                </td>
-              ))}
-              {separateKeys.map((keyEntity) => (
-                <td key={keyEntity.name}>
-                  {item[keyEntity.key] && (<Markdown>{item[keyEntity.key]}</Markdown>)}
-                </td>
-              ))}
+              {showKeys.map((keyEntity) => {
+                const value = item[keyEntity.key];
+
+                return (
+                  <td key={keyEntity.name}>
+                    {keyEntity.hasMarkdown ? <Markdown>{value}</Markdown> : <code>{value}</code>}
+                  </td>
+                )
+              })}
             </tr>
           ))}
         </tbody>

--- a/src/data/opcodes/continuation.json
+++ b/src/data/opcodes/continuation.json
@@ -943,7 +943,7 @@
     "doc_fift": "c[i] SETALTCTR",
     "doc_stack": "x -",
     "doc_gas": 26,
-    "doc_description": "Equivalent to `c1 PUSHCTR` `c[i] SETCONTCTR` `c0 POPCTR`."
+    "doc_description": "Equivalent to `c1 PUSHCTR` `c[i] SETCONTCTR` `c1 POPCTR`."
   },
   {
     "name": "POPSAVE",
@@ -987,7 +987,7 @@
     "doc_fift": "c[i] SAVEBOTH\nc[i] SAVEBOTHCTR",
     "doc_stack": "",
     "doc_gas": 26,
-    "doc_description": "Equivalent to `DUP` `c[i] SAVE` `c[i] SAVEALT`."
+    "doc_description": "Equivalent to `c[i] SAVE` `c[i] SAVEALT`."
   },
   {
     "name": "PUSHCTRX",

--- a/src/data/opcodes/opcodes.json
+++ b/src/data/opcodes/opcodes.json
@@ -5464,7 +5464,7 @@
     "doc_fift": "c[i] SETALTCTR",
     "doc_stack": "x -",
     "doc_gas": 26,
-    "doc_description": "Equivalent to `c1 PUSHCTR` `c[i] SETCONTCTR` `c0 POPCTR`."
+    "doc_description": "Equivalent to `c1 PUSHCTR` `c[i] SETCONTCTR` `c1 POPCTR`."
   },
   {
     "name": "POPSAVE",
@@ -5508,7 +5508,7 @@
     "doc_fift": "c[i] SAVEBOTH\nc[i] SAVEBOTHCTR",
     "doc_stack": "",
     "doc_gas": 26,
-    "doc_description": "Equivalent to `DUP` `c[i] SAVE` `c[i] SAVEALT`."
+    "doc_description": "Equivalent to `c[i] SAVE` `c[i] SAVEALT`."
   },
   {
     "name": "PUSHCTRX",

--- a/src/pages/learn/archive/tvm-instructions.mdx
+++ b/src/pages/learn/archive/tvm-instructions.mdx
@@ -55,11 +55,11 @@ Feel free to use the search field below to find a specific instruction:
   searchBy="doc_fift"
   placeholder="Search for an opcode"
   showKeys={[
-    { key: 'doc_opcode', name: 'Opcode', isGrouped: true },
-    { key: 'doc_fift', name: 'Fift syntax', isGrouped: true },
-    { key: 'doc_stack', name: 'Stack', isGrouped: true },
-    { key: 'doc_gas', name: 'Gas', isGrouped: true },
-    { key: 'doc_description', name: 'Description' },
+    { key: 'doc_opcode', name: 'Opcode' },
+    { key: 'doc_fift', name: 'Fift syntax' },
+    { key: 'doc_stack', name: 'Stack' },
+    { key: 'doc_description', name: 'Description', hasMarkdown: true },
+    { key: 'doc_gas', name: 'Gas' },
   ]}
 />
 
@@ -639,11 +639,11 @@ Here `s"` is the [fee for moving stack elements between continuations](#11-gas-p
 | **`ED54`** | `c4 POPCTR`<br/>`c4 POP` | _`x -`_ | Sets the “global data root'' cell reference, thus allowing modification of persistent smart-contract data. | `26` |
 | **`ED6i`** | `c[i] SETCONT`<br/>`c[i] SETCONTCTR` | _`x c - c'`_ | Stores `x` into the savelist of continuation `c` as `c(i)`, and returns the resulting continuation `c'`. Almost all operations with continuations may be expressed in terms of [`SETCONTCTR`](#instr-setcontctr), [`POPCTR`](#instr-popctr), and [`PUSHCTR`](#instr-pushctr). | `26` |
 | **`ED7i`** | `c[i] SETRETCTR` | _`x - `_ | Equivalent to [`c0 PUSHCTR`](#instr-pushctr) [`c[i] SETCONTCTR`](#instr-setcontctr) [`c0 POPCTR`](#instr-popctr). | `26` |
-| **`ED8i`** | `c[i] SETALTCTR` | _`x - `_ | Equivalent to [`c1 PUSHCTR`](#instr-pushctr) [`c[i] SETCONTCTR`](#instr-setcontctr) [`c0 POPCTR`](#instr-popctr). | `26` |
+| **`ED8i`** | `c[i] SETALTCTR` | _`x - `_ | Equivalent to [`c1 PUSHCTR`](#instr-pushctr) [`c[i] SETCONTCTR`](#instr-setcontctr) [`c1 POPCTR`](#instr-popctr). | `26` |
 | **`ED9i`** | `c[i] POPSAVE`<br/>`c[i] POPCTRSAVE` | _`x -`_ | Similar to [`c[i] POPCTR`](#instr-popctr), but also saves the old value of `c[i]` into continuation `c0`.<br/>Equivalent (up to exceptions) to [`c[i] SAVECTR`](#instr-save) [`c[i] POPCTR`](#instr-popctr). | `26` |
 | **`EDAi`** | `c[i] SAVE`<br/>`c[i] SAVECTR` |  | Saves the current value of `c(i)` into the savelist of continuation `c0`. If an entry for `c[i]` is already present in the savelist of `c0`, nothing is done. Equivalent to [`c[i] PUSHCTR`](#instr-pushctr) [`c[i] SETRETCTR`](#instr-setretctr). | `26` |
 | **`EDBi`** | `c[i] SAVEALT`<br/>`c[i] SAVEALTCTR` |  | Similar to [`c[i] SAVE`](#instr-save), but saves the current value of `c[i]` into the savelist of `c1`, not `c0`. | `26` |
-| **`EDCi`** | `c[i] SAVEBOTH`<br/>`c[i] SAVEBOTHCTR` |  | Equivalent to [`DUP`](#instr-dup) [`c[i] SAVE`](#instr-save) [`c[i] SAVEALT`](#instr-savealt). | `26` |
+| **`EDCi`** | `c[i] SAVEBOTH`<br/>`c[i] SAVEBOTHCTR` |  | Equivalent to [`c[i] SAVE`](#instr-save) [`c[i] SAVEALT`](#instr-savealt). | `26` |
 | **`EDE0`** | `PUSHCTRX` | _`i - x`_ | Similar to [`c[i] PUSHCTR`](#instr-pushctr), but with `i`, `0 <= i <= 255`, taken from the stack.<br/>Notice that this primitive is one of the few “exotic'' primitives, which are not polymorphic like stack manipulation primitives, and at the same time do not have well-defined types of parameters and return values, because the type of `x` depends on `i`. | `26` |
 | **`EDE1`** | `POPCTRX` | _`x i - `_ | Similar to [`c[i] POPCTR`](#instr-popctr), but with `0 <= i <= 255` from the stack. | `26` |
 | **`EDE2`** | `SETCONTCTRX` | _`x c i - c'`_ | Similar to [`c[i] SETCONTCTR`](#instr-setcontctr), but with `0 <= i <= 255` from the stack. | `26` |

--- a/src/pages/learn/tvm-instructions/instructions.mdx
+++ b/src/pages/learn/tvm-instructions/instructions.mdx
@@ -64,11 +64,11 @@ Feel free to use the search field below to find a specific instruction:
   searchBy="doc_fift"
   placeholder="Search for an opcode"
   showKeys={[
-    { key: 'doc_opcode', name: 'Opcode', isGrouped: true },
-    { key: 'doc_fift', name: 'Fift syntax', isGrouped: true },
-    { key: 'doc_stack', name: 'Stack', isGrouped: true },
-    { key: 'doc_gas', name: 'Gas', isGrouped: true },
-    { key: 'doc_description', name: 'Description' },
+    { key: 'doc_opcode', name: 'Opcode' },
+    { key: 'doc_fift', name: 'Fift syntax' },
+    { key: 'doc_stack', name: 'Stack' },
+    { key: 'doc_description', name: 'Description', hasMarkdown: true },
+    { key: 'doc_gas', name: 'Gas' },
   ]}
 />
 

--- a/src/pages/learn/tvm-instructions/instructions/app-specific.mdx
+++ b/src/pages/learn/tvm-instructions/instructions/app-specific.mdx
@@ -8,19 +8,6 @@ import { appSpecificOpcodes as opcodes } from '@site/src/data/opcodes';
 
 # Application-Specific Primitives
 
-<SearchField
-  data={opcodes}
-  searchBy="doc_fift"
-  placeholder="Search for an opcode"
-  showKeys={[
-    { key: 'doc_opcode', name: 'Opcode' },
-    { key: 'doc_fift', name: 'Fift syntax' },
-    { key: 'doc_stack', name: 'Stack' },
-    { key: 'doc_description', name: 'Description', hasMarkdown: true },
-    { key: 'doc_gas', name: 'Gas' },
-  ]}
-/>
-
 ### TVM Instructions Content List
 
 * [Overview](/learn/tvm-instructions/instructions)
@@ -38,6 +25,19 @@ import { appSpecificOpcodes as opcodes } from '@site/src/data/opcodes';
 
 ...
 * [Exit From TVM Instruction Full Screen Mode](/learn/tvm-instructions/tvm-overview)
+
+<SearchField
+  data={opcodes}
+  searchBy="doc_fift"
+  placeholder="Search for an opcode"
+  showKeys={[
+    { key: 'doc_opcode', name: 'Opcode' },
+    { key: 'doc_fift', name: 'Fift syntax' },
+    { key: 'doc_stack', name: 'Stack' },
+    { key: 'doc_description', name: 'Description', hasMarkdown: true },
+    { key: 'doc_gas', name: 'Gas' },
+  ]}
+/>
 
 ## Application-Specific Primitives
 ### Gas-related primitives

--- a/src/pages/learn/tvm-instructions/instructions/app-specific.mdx
+++ b/src/pages/learn/tvm-instructions/instructions/app-specific.mdx
@@ -13,11 +13,11 @@ import { appSpecificOpcodes as opcodes } from '@site/src/data/opcodes';
   searchBy="doc_fift"
   placeholder="Search for an opcode"
   showKeys={[
-    { key: 'doc_opcode', name: 'Opcode', isGrouped: true },
-    { key: 'doc_fift', name: 'Fift syntax', isGrouped: true },
-    { key: 'doc_stack', name: 'Stack', isGrouped: true },
-    { key: 'doc_gas', name: 'Gas', isGrouped: true },
-    { key: 'doc_description', name: 'Description' },
+    { key: 'doc_opcode', name: 'Opcode' },
+    { key: 'doc_fift', name: 'Fift syntax' },
+    { key: 'doc_stack', name: 'Stack' },
+    { key: 'doc_description', name: 'Description', hasMarkdown: true },
+    { key: 'doc_gas', name: 'Gas' },
   ]}
 />
 

--- a/src/pages/learn/tvm-instructions/instructions/arithmetic.mdx
+++ b/src/pages/learn/tvm-instructions/instructions/arithmetic.mdx
@@ -8,19 +8,6 @@ import { arithmeticOpcodes as opcodes } from '@site/src/data/opcodes';
 
 # Arithmetic primitives
 
-<SearchField
-  data={opcodes}
-  searchBy="doc_fift"
-  placeholder="Search for an opcode"
-  showKeys={[
-    { key: 'doc_opcode', name: 'Opcode' },
-    { key: 'doc_fift', name: 'Fift syntax' },
-    { key: 'doc_stack', name: 'Stack' },
-    { key: 'doc_description', name: 'Description', hasMarkdown: true },
-    { key: 'doc_gas', name: 'Gas' },
-  ]}
-/>
-
 ### TVM Instructions Content List
 
 * [Overview](/learn/tvm-instructions/instructions)
@@ -35,6 +22,19 @@ import { arithmeticOpcodes as opcodes } from '@site/src/data/opcodes';
 * [Dictionary Manipulation](/learn/tvm-instructions/instructions/dictionary-manipulation)
 * [Application-specific Primitives](/learn/tvm-instructions/instructions/app-specific)
 * [Miscellaneous](/learn/tvm-instructions/instructions/miscellaneous)
+
+<SearchField
+  data={opcodes}
+  searchBy="doc_fift"
+  placeholder="Search for an opcode"
+  showKeys={[
+    { key: 'doc_opcode', name: 'Opcode' },
+    { key: 'doc_fift', name: 'Fift syntax' },
+    { key: 'doc_stack', name: 'Stack' },
+    { key: 'doc_description', name: 'Description', hasMarkdown: true },
+    { key: 'doc_gas', name: 'Gas' },
+  ]}
+/>
 
 ## Arithmetic primitives
 ### Addition, subtraction, multiplication

--- a/src/pages/learn/tvm-instructions/instructions/arithmetic.mdx
+++ b/src/pages/learn/tvm-instructions/instructions/arithmetic.mdx
@@ -13,11 +13,11 @@ import { arithmeticOpcodes as opcodes } from '@site/src/data/opcodes';
   searchBy="doc_fift"
   placeholder="Search for an opcode"
   showKeys={[
-    { key: 'doc_opcode', name: 'Opcode', isGrouped: true },
-    { key: 'doc_fift', name: 'Fift syntax', isGrouped: true },
-    { key: 'doc_stack', name: 'Stack', isGrouped: true },
-    { key: 'doc_gas', name: 'Gas', isGrouped: true },
-    { key: 'doc_description', name: 'Description' },
+    { key: 'doc_opcode', name: 'Opcode' },
+    { key: 'doc_fift', name: 'Fift syntax' },
+    { key: 'doc_stack', name: 'Stack' },
+    { key: 'doc_description', name: 'Description', hasMarkdown: true },
+    { key: 'doc_gas', name: 'Gas' },
   ]}
 />
 

--- a/src/pages/learn/tvm-instructions/instructions/cell-manipulation.mdx
+++ b/src/pages/learn/tvm-instructions/instructions/cell-manipulation.mdx
@@ -13,11 +13,11 @@ import { cellManipulationOpcodes as opcodes } from '@site/src/data/opcodes';
   searchBy="doc_fift"
   placeholder="Search for an opcode"
   showKeys={[
-    { key: 'doc_opcode', name: 'Opcode', isGrouped: true },
-    { key: 'doc_fift', name: 'Fift syntax', isGrouped: true },
-    { key: 'doc_stack', name: 'Stack', isGrouped: true },
-    { key: 'doc_gas', name: 'Gas', isGrouped: true },
-    { key: 'doc_description', name: 'Description' },
+    { key: 'doc_opcode', name: 'Opcode' },
+    { key: 'doc_fift', name: 'Fift syntax' },
+    { key: 'doc_stack', name: 'Stack' },
+    { key: 'doc_description', name: 'Description', hasMarkdown: true },
+    { key: 'doc_gas', name: 'Gas' },
   ]}
 />
 

--- a/src/pages/learn/tvm-instructions/instructions/cell-manipulation.mdx
+++ b/src/pages/learn/tvm-instructions/instructions/cell-manipulation.mdx
@@ -8,19 +8,6 @@ import { cellManipulationOpcodes as opcodes } from '@site/src/data/opcodes';
 
 # Cell Primitives
 
-<SearchField
-  data={opcodes}
-  searchBy="doc_fift"
-  placeholder="Search for an opcode"
-  showKeys={[
-    { key: 'doc_opcode', name: 'Opcode' },
-    { key: 'doc_fift', name: 'Fift syntax' },
-    { key: 'doc_stack', name: 'Stack' },
-    { key: 'doc_description', name: 'Description', hasMarkdown: true },
-    { key: 'doc_gas', name: 'Gas' },
-  ]}
-/>
-
 ### TVM Instructions Content List
 
 * [Overview](/learn/tvm-instructions/instructions)
@@ -35,6 +22,19 @@ import { cellManipulationOpcodes as opcodes } from '@site/src/data/opcodes';
 * [Dictionary Manipulation](/learn/tvm-instructions/instructions/dictionary-manipulation)
 * [Application-specific Primitives](/learn/tvm-instructions/instructions/app-specific)
 * [Miscellaneous](/learn/tvm-instructions/instructions/miscellaneous)
+
+<SearchField
+  data={opcodes}
+  searchBy="doc_fift"
+  placeholder="Search for an opcode"
+  showKeys={[
+    { key: 'doc_opcode', name: 'Opcode' },
+    { key: 'doc_fift', name: 'Fift syntax' },
+    { key: 'doc_stack', name: 'Stack' },
+    { key: 'doc_description', name: 'Description', hasMarkdown: true },
+    { key: 'doc_gas', name: 'Gas' },
+  ]}
+/>
 
 ## Cell Primitives
 ### Cell serialization primitives

--- a/src/pages/learn/tvm-instructions/instructions/constant.mdx
+++ b/src/pages/learn/tvm-instructions/instructions/constant.mdx
@@ -13,11 +13,11 @@ import { constantOpcodes as opcodes } from '@site/src/data/opcodes';
   searchBy="doc_fift"
   placeholder="Search for an opcode"
   showKeys={[
-    { key: 'doc_opcode', name: 'Opcode', isGrouped: true },
-    { key: 'doc_fift', name: 'Fift syntax', isGrouped: true },
-    { key: 'doc_stack', name: 'Stack', isGrouped: true },
-    { key: 'doc_gas', name: 'Gas', isGrouped: true },
-    { key: 'doc_description', name: 'Description' },
+    { key: 'doc_opcode', name: 'Opcode' },
+    { key: 'doc_fift', name: 'Fift syntax' },
+    { key: 'doc_stack', name: 'Stack' },
+    { key: 'doc_description', name: 'Description', hasMarkdown: true },
+    { key: 'doc_gas', name: 'Gas' },
   ]}
 />
 

--- a/src/pages/learn/tvm-instructions/instructions/constant.mdx
+++ b/src/pages/learn/tvm-instructions/instructions/constant.mdx
@@ -8,19 +8,6 @@ import { constantOpcodes as opcodes } from '@site/src/data/opcodes';
 
 # Constant or Literal Primitives
 
-<SearchField
-  data={opcodes}
-  searchBy="doc_fift"
-  placeholder="Search for an opcode"
-  showKeys={[
-    { key: 'doc_opcode', name: 'Opcode' },
-    { key: 'doc_fift', name: 'Fift syntax' },
-    { key: 'doc_stack', name: 'Stack' },
-    { key: 'doc_description', name: 'Description', hasMarkdown: true },
-    { key: 'doc_gas', name: 'Gas' },
-  ]}
-/>
-
 ### TVM Instructions Content List
 
 * [Overview](/learn/tvm-instructions/instructions)
@@ -35,6 +22,19 @@ import { constantOpcodes as opcodes } from '@site/src/data/opcodes';
 * [Dictionary Manipulation](/learn/tvm-instructions/instructions/dictionary-manipulation)
 * [Application-specific Primitives](/learn/tvm-instructions/instructions/app-specific)
 * [Miscellaneous](/learn/tvm-instructions/instructions/miscellaneous)
+
+<SearchField
+  data={opcodes}
+  searchBy="doc_fift"
+  placeholder="Search for an opcode"
+  showKeys={[
+    { key: 'doc_opcode', name: 'Opcode' },
+    { key: 'doc_fift', name: 'Fift syntax' },
+    { key: 'doc_stack', name: 'Stack' },
+    { key: 'doc_description', name: 'Description', hasMarkdown: true },
+    { key: 'doc_gas', name: 'Gas' },
+  ]}
+/>
 
 ## Constant or Literal Primitives
 ### Integer and Boolean Constants

--- a/src/pages/learn/tvm-instructions/instructions/control-flow.mdx
+++ b/src/pages/learn/tvm-instructions/instructions/control-flow.mdx
@@ -13,11 +13,11 @@ import { continuationOpcodes as opcodes } from '@site/src/data/opcodes';
   searchBy="doc_fift"
   placeholder="Search for an opcode"
   showKeys={[
-    { key: 'doc_opcode', name: 'Opcode', isGrouped: true },
-    { key: 'doc_fift', name: 'Fift syntax', isGrouped: true },
-    { key: 'doc_stack', name: 'Stack', isGrouped: true },
-    { key: 'doc_gas', name: 'Gas', isGrouped: true },
-    { key: 'doc_description', name: 'Description' },
+    { key: 'doc_opcode', name: 'Opcode' },
+    { key: 'doc_fift', name: 'Fift syntax' },
+    { key: 'doc_stack', name: 'Stack' },
+    { key: 'doc_description', name: 'Description', hasMarkdown: true },
+    { key: 'doc_gas', name: 'Gas' },
   ]}
 />
 
@@ -154,11 +154,11 @@ Here `s"` is the [fee for moving stack elements between continuations](#11-gas-p
 | **`ED54`** | `c4 POPCTR`<br/>`c4 POP` | _`x -`_ | Sets the “global data root'' cell reference, thus allowing modification of persistent smart-contract data. | `26` |
 | **`ED6i`** | `c[i] SETCONT`<br/>`c[i] SETCONTCTR` | _`x c - c'`_ | Stores `x` into the savelist of continuation `c` as `c(i)`, and returns the resulting continuation `c'`. Almost all operations with continuations may be expressed in terms of [`SETCONTCTR`](#instr-setcontctr), [`POPCTR`](#instr-popctr), and [`PUSHCTR`](#instr-pushctr). | `26` |
 | **`ED7i`** | `c[i] SETRETCTR` | _`x - `_ | Equivalent to [`c0 PUSHCTR`](#instr-pushctr) [`c[i] SETCONTCTR`](#instr-setcontctr) [`c0 POPCTR`](#instr-popctr). | `26` |
-| **`ED8i`** | `c[i] SETALTCTR` | _`x - `_ | Equivalent to [`c1 PUSHCTR`](#instr-pushctr) [`c[i] SETCONTCTR`](#instr-setcontctr) [`c0 POPCTR`](#instr-popctr). | `26` |
+| **`ED8i`** | `c[i] SETALTCTR` | _`x - `_ | Equivalent to [`c1 PUSHCTR`](#instr-pushctr) [`c[i] SETCONTCTR`](#instr-setcontctr) [`c1 POPCTR`](#instr-popctr). | `26` |
 | **`ED9i`** | `c[i] POPSAVE`<br/>`c[i] POPCTRSAVE` | _`x -`_ | Similar to [`c[i] POPCTR`](#instr-popctr), but also saves the old value of `c[i]` into continuation `c0`.<br/>Equivalent (up to exceptions) to [`c[i] SAVECTR`](#instr-save) [`c[i] POPCTR`](#instr-popctr). | `26` |
 | **`EDAi`** | `c[i] SAVE`<br/>`c[i] SAVECTR` |  | Saves the current value of `c(i)` into the savelist of continuation `c0`. If an entry for `c[i]` is already present in the savelist of `c0`, nothing is done. Equivalent to [`c[i] PUSHCTR`](#instr-pushctr) [`c[i] SETRETCTR`](#instr-setretctr). | `26` |
 | **`EDBi`** | `c[i] SAVEALT`<br/>`c[i] SAVEALTCTR` |  | Similar to [`c[i] SAVE`](#instr-save), but saves the current value of `c[i]` into the savelist of `c1`, not `c0`. | `26` |
-| **`EDCi`** | `c[i] SAVEBOTH`<br/>`c[i] SAVEBOTHCTR` |  | Equivalent to [`DUP`](#instr-dup) [`c[i] SAVE`](#instr-save) [`c[i] SAVEALT`](#instr-savealt). | `26` |
+| **`EDCi`** | `c[i] SAVEBOTH`<br/>`c[i] SAVEBOTHCTR` |  | Equivalent to [`c[i] SAVE`](#instr-save) [`c[i] SAVEALT`](#instr-savealt). | `26` |
 | **`EDE0`** | `PUSHCTRX` | _`i - x`_ | Similar to [`c[i] PUSHCTR`](#instr-pushctr), but with `i`, `0 <= i <= 255`, taken from the stack.<br/>Notice that this primitive is one of the few “exotic'' primitives, which are not polymorphic like stack manipulation primitives, and at the same time do not have well-defined types of parameters and return values, because the type of `x` depends on `i`. | `26` |
 | **`EDE1`** | `POPCTRX` | _`x i - `_ | Similar to [`c[i] POPCTR`](#instr-popctr), but with `0 <= i <= 255` from the stack. | `26` |
 | **`EDE2`** | `SETCONTCTRX` | _`x c i - c'`_ | Similar to [`c[i] SETCONTCTR`](#instr-setcontctr), but with `0 <= i <= 255` from the stack. | `26` |

--- a/src/pages/learn/tvm-instructions/instructions/control-flow.mdx
+++ b/src/pages/learn/tvm-instructions/instructions/control-flow.mdx
@@ -8,19 +8,6 @@ import { continuationOpcodes as opcodes } from '@site/src/data/opcodes';
 
 # Continuation and control flow primitives
 
-<SearchField
-  data={opcodes}
-  searchBy="doc_fift"
-  placeholder="Search for an opcode"
-  showKeys={[
-    { key: 'doc_opcode', name: 'Opcode' },
-    { key: 'doc_fift', name: 'Fift syntax' },
-    { key: 'doc_stack', name: 'Stack' },
-    { key: 'doc_description', name: 'Description', hasMarkdown: true },
-    { key: 'doc_gas', name: 'Gas' },
-  ]}
-/>
-
 ### TVM Instructions Content List
 
 * [Overview](/learn/tvm-instructions/instructions)
@@ -35,6 +22,19 @@ import { continuationOpcodes as opcodes } from '@site/src/data/opcodes';
 * [Dictionary Manipulation](/learn/tvm-instructions/instructions/dictionary-manipulation)
 * [Application-specific Primitives](/learn/tvm-instructions/instructions/app-specific)
 * [Miscellaneous](/learn/tvm-instructions/instructions/miscellaneous)
+
+<SearchField
+  data={opcodes}
+  searchBy="doc_fift"
+  placeholder="Search for an opcode"
+  showKeys={[
+    { key: 'doc_opcode', name: 'Opcode' },
+    { key: 'doc_fift', name: 'Fift syntax' },
+    { key: 'doc_stack', name: 'Stack' },
+    { key: 'doc_description', name: 'Description', hasMarkdown: true },
+    { key: 'doc_gas', name: 'Gas' },
+  ]}
+/>
 
 ## Continuation and control flow primitives
 ### Unconditional control flow primitives

--- a/src/pages/learn/tvm-instructions/instructions/data-comparison.mdx
+++ b/src/pages/learn/tvm-instructions/instructions/data-comparison.mdx
@@ -8,19 +8,6 @@ import { comparisonOpcodes as opcodes } from '@site/src/data/opcodes';
 
 # Comparison Primitives
 
-<SearchField
-  data={opcodes}
-  searchBy="doc_fift"
-  placeholder="Search for an opcode"
-  showKeys={[
-    { key: 'doc_opcode', name: 'Opcode' },
-    { key: 'doc_fift', name: 'Fift syntax' },
-    { key: 'doc_stack', name: 'Stack' },
-    { key: 'doc_description', name: 'Description', hasMarkdown: true },
-    { key: 'doc_gas', name: 'Gas' },
-  ]}
-/>
-
 ### TVM Instructions Content List
 
 * [Overview](/learn/tvm-instructions/instructions)
@@ -35,6 +22,19 @@ import { comparisonOpcodes as opcodes } from '@site/src/data/opcodes';
 * [Dictionary Manipulation](/learn/tvm-instructions/instructions/dictionary-manipulation)
 * [Application-specific Primitives](/learn/tvm-instructions/instructions/app-specific)
 * [Miscellaneous](/learn/tvm-instructions/instructions/miscellaneous)
+
+<SearchField
+  data={opcodes}
+  searchBy="doc_fift"
+  placeholder="Search for an opcode"
+  showKeys={[
+    { key: 'doc_opcode', name: 'Opcode' },
+    { key: 'doc_fift', name: 'Fift syntax' },
+    { key: 'doc_stack', name: 'Stack' },
+    { key: 'doc_description', name: 'Description', hasMarkdown: true },
+    { key: 'doc_gas', name: 'Gas' },
+  ]}
+/>
 
 ## Comparison Primitives
 ### Integer comparison

--- a/src/pages/learn/tvm-instructions/instructions/data-comparison.mdx
+++ b/src/pages/learn/tvm-instructions/instructions/data-comparison.mdx
@@ -13,11 +13,11 @@ import { comparisonOpcodes as opcodes } from '@site/src/data/opcodes';
   searchBy="doc_fift"
   placeholder="Search for an opcode"
   showKeys={[
-    { key: 'doc_opcode', name: 'Opcode', isGrouped: true },
-    { key: 'doc_fift', name: 'Fift syntax', isGrouped: true },
-    { key: 'doc_stack', name: 'Stack', isGrouped: true },
-    { key: 'doc_gas', name: 'Gas', isGrouped: true },
-    { key: 'doc_description', name: 'Description' },
+    { key: 'doc_opcode', name: 'Opcode' },
+    { key: 'doc_fift', name: 'Fift syntax' },
+    { key: 'doc_stack', name: 'Stack' },
+    { key: 'doc_description', name: 'Description', hasMarkdown: true },
+    { key: 'doc_gas', name: 'Gas' },
   ]}
 />
 

--- a/src/pages/learn/tvm-instructions/instructions/dictionary-manipulation.mdx
+++ b/src/pages/learn/tvm-instructions/instructions/dictionary-manipulation.mdx
@@ -10,19 +10,6 @@ import { dictionaryManipulationOpcodes as opcodes } from '@site/src/data/opcodes
 
 The gas consumption of most dictionary operations is not fixed, it depends on the contents of the given dictionary.
 
-<SearchField
-  data={opcodes}
-  searchBy="doc_fift"
-  placeholder="Search for an opcode"
-  showKeys={[
-    { key: 'doc_opcode', name: 'Opcode' },
-    { key: 'doc_fift', name: 'Fift syntax' },
-    { key: 'doc_stack', name: 'Stack' },
-    { key: 'doc_description', name: 'Description', hasMarkdown: true },
-    { key: 'doc_gas', name: 'Gas' },
-  ]}
-/>
-
 ### TVM Instructions Content List
 
 * [Overview](/learn/tvm-instructions/instructions)
@@ -37,6 +24,19 @@ The gas consumption of most dictionary operations is not fixed, it depends on th
 * [Dictionary Manipulation](/learn/tvm-instructions/instructions/dictionary-manipulation)
 * [Application-specific Primitives](/learn/tvm-instructions/instructions/app-specific)
 * [Miscellaneous](/learn/tvm-instructions/instructions/miscellaneous)
+
+<SearchField
+  data={opcodes}
+  searchBy="doc_fift"
+  placeholder="Search for an opcode"
+  showKeys={[
+    { key: 'doc_opcode', name: 'Opcode' },
+    { key: 'doc_fift', name: 'Fift syntax' },
+    { key: 'doc_stack', name: 'Stack' },
+    { key: 'doc_description', name: 'Description', hasMarkdown: true },
+    { key: 'doc_gas', name: 'Gas' },
+  ]}
+/>
 
 ##  Dictionary Manipulation Primitives
 

--- a/src/pages/learn/tvm-instructions/instructions/dictionary-manipulation.mdx
+++ b/src/pages/learn/tvm-instructions/instructions/dictionary-manipulation.mdx
@@ -15,11 +15,11 @@ The gas consumption of most dictionary operations is not fixed, it depends on th
   searchBy="doc_fift"
   placeholder="Search for an opcode"
   showKeys={[
-    { key: 'doc_opcode', name: 'Opcode', isGrouped: true },
-    { key: 'doc_fift', name: 'Fift syntax', isGrouped: true },
-    { key: 'doc_stack', name: 'Stack', isGrouped: true },
-    { key: 'doc_gas', name: 'Gas', isGrouped: true },
-    { key: 'doc_description', name: 'Description' },
+    { key: 'doc_opcode', name: 'Opcode' },
+    { key: 'doc_fift', name: 'Fift syntax' },
+    { key: 'doc_stack', name: 'Stack' },
+    { key: 'doc_description', name: 'Description', hasMarkdown: true },
+    { key: 'doc_gas', name: 'Gas' },
   ]}
 />
 

--- a/src/pages/learn/tvm-instructions/instructions/exception-gen-and-handling.mdx
+++ b/src/pages/learn/tvm-instructions/instructions/exception-gen-and-handling.mdx
@@ -8,19 +8,6 @@ import { exceptionOpcodes as opcodes } from '@site/src/data/opcodes';
 
 # Exception Generating and Handling
 
-<SearchField
-  data={opcodes}
-  searchBy="doc_fift"
-  placeholder="Search for an opcode"
-  showKeys={[
-    { key: 'doc_opcode', name: 'Opcode' },
-    { key: 'doc_fift', name: 'Fift syntax' },
-    { key: 'doc_stack', name: 'Stack' },
-    { key: 'doc_description', name: 'Description', hasMarkdown: true },
-    { key: 'doc_gas', name: 'Gas' },
-  ]}
-/>
-
 ### TVM Instructions Content List
 
 * [Overview](/learn/tvm-instructions/instructions)
@@ -35,6 +22,19 @@ import { exceptionOpcodes as opcodes } from '@site/src/data/opcodes';
 * [Dictionary Manipulation](/learn/tvm-instructions/instructions/dictionary-manipulation)
 * [Application-specific Primitives](/learn/tvm-instructions/instructions/app-specific)
 * [Miscellaneous](/learn/tvm-instructions/instructions/miscellaneous)
+
+<SearchField
+  data={opcodes}
+  searchBy="doc_fift"
+  placeholder="Search for an opcode"
+  showKeys={[
+    { key: 'doc_opcode', name: 'Opcode' },
+    { key: 'doc_fift', name: 'Fift syntax' },
+    { key: 'doc_stack', name: 'Stack' },
+    { key: 'doc_description', name: 'Description', hasMarkdown: true },
+    { key: 'doc_gas', name: 'Gas' },
+  ]}
+/>
 
 ## Exception Generating and Handling
 

--- a/src/pages/learn/tvm-instructions/instructions/exception-gen-and-handling.mdx
+++ b/src/pages/learn/tvm-instructions/instructions/exception-gen-and-handling.mdx
@@ -13,11 +13,11 @@ import { exceptionOpcodes as opcodes } from '@site/src/data/opcodes';
   searchBy="doc_fift"
   placeholder="Search for an opcode"
   showKeys={[
-    { key: 'doc_opcode', name: 'Opcode', isGrouped: true },
-    { key: 'doc_fift', name: 'Fift syntax', isGrouped: true },
-    { key: 'doc_stack', name: 'Stack', isGrouped: true },
-    { key: 'doc_gas', name: 'Gas', isGrouped: true },
-    { key: 'doc_description', name: 'Description' },
+    { key: 'doc_opcode', name: 'Opcode' },
+    { key: 'doc_fift', name: 'Fift syntax' },
+    { key: 'doc_stack', name: 'Stack' },
+    { key: 'doc_description', name: 'Description', hasMarkdown: true },
+    { key: 'doc_gas', name: 'Gas' },
   ]}
 />
 

--- a/src/pages/learn/tvm-instructions/instructions/miscellaneous.mdx
+++ b/src/pages/learn/tvm-instructions/instructions/miscellaneous.mdx
@@ -20,11 +20,11 @@ Other primitives listed here have opcodes from the same set. When debug is enabl
   searchBy="doc_fift"
   placeholder="Search for an opcode"
   showKeys={[
-    { key: 'doc_opcode', name: 'Opcode', isGrouped: true },
-    { key: 'doc_fift', name: 'Fift syntax', isGrouped: true },
-    { key: 'doc_stack', name: 'Stack', isGrouped: true },
-    { key: 'doc_gas', name: 'Gas', isGrouped: true },
-    { key: 'doc_description', name: 'Description' },
+    { key: 'doc_opcode', name: 'Opcode' },
+    { key: 'doc_fift', name: 'Fift syntax' },
+    { key: 'doc_stack', name: 'Stack' },
+    { key: 'doc_description', name: 'Description', hasMarkdown: true },
+    { key: 'doc_gas', name: 'Gas' },
   ]}
 />
 

--- a/src/pages/learn/tvm-instructions/instructions/miscellaneous.mdx
+++ b/src/pages/learn/tvm-instructions/instructions/miscellaneous.mdx
@@ -15,6 +15,21 @@ However, when invoked in a TVM instance with debug mode enabled, these primitive
 [`DEBUG`](#instr-debug) and [`DEBUGSTR`](#instr-debugstr) are the two debug primitives, they cover all opcodes that start with `FE`.
 Other primitives listed here have opcodes from the same set. When debug is enabled, they have their specified effects. When debug is disabled, they behave as [`NOP`](#instr-nop).
 
+### TVM Instructions Content List
+
+* [Overview](/learn/tvm-instructions/instructions)
+* [Stack Manipulation](/learn/tvm-instructions/instructions/stack-manipulation)
+* [Tuple, List and Null](/learn/tvm-instructions/instructions/tuple-list-null)
+* [Constants and Literals](/learn/tvm-instructions/instructions/constant)
+* [Arithmetic Operations](/learn/tvm-instructions/instructions/arithmetic)
+* [Data Comparison](/learn/tvm-instructions/instructions/data-comparison)
+* [Cell Manipulation](/learn/tvm-instructions/instructions/cell-manipulation)
+* [Continuation and Control Flow](/learn/tvm-instructions/instructions/control-flow)
+* [Exception Generation and Handling](/learn/tvm-instructions/instructions/exception-gen-and-handling)
+* [Dictionary Manipulation](/learn/tvm-instructions/instructions/dictionary-manipulation)
+* [Application-specific Primitives](/learn/tvm-instructions/instructions/app-specific)
+* [Miscellaneous](/learn/tvm-instructions/instructions/miscellaneous)
+
 <SearchField
   data={opcodes}
   searchBy="doc_fift"

--- a/src/pages/learn/tvm-instructions/instructions/stack-manipulation.mdx
+++ b/src/pages/learn/tvm-instructions/instructions/stack-manipulation.mdx
@@ -15,11 +15,11 @@ Here `0 <= i,j,k <= 15` if not stated otherwise.
   searchBy="doc_fift"
   placeholder="Search for an opcode"
   showKeys={[
-    { key: 'doc_opcode', name: 'Opcode', isGrouped: true },
-    { key: 'doc_fift', name: 'Fift syntax', isGrouped: true },
-    { key: 'doc_stack', name: 'Stack', isGrouped: true },
-    { key: 'doc_gas', name: 'Gas', isGrouped: true },
-    { key: 'doc_description', name: 'Description' },
+    { key: 'doc_opcode', name: 'Opcode' },
+    { key: 'doc_fift', name: 'Fift syntax' },
+    { key: 'doc_stack', name: 'Stack' },
+    { key: 'doc_description', name: 'Description', hasMarkdown: true },
+    { key: 'doc_gas', name: 'Gas' },
   ]}
 />
 

--- a/src/pages/learn/tvm-instructions/instructions/stack-manipulation.mdx
+++ b/src/pages/learn/tvm-instructions/instructions/stack-manipulation.mdx
@@ -10,19 +10,6 @@ import { stackManipulationOpcodes as opcodes } from '@site/src/data/opcodes';
 
 Here `0 <= i,j,k <= 15` if not stated otherwise.
 
-<SearchField
-  data={opcodes}
-  searchBy="doc_fift"
-  placeholder="Search for an opcode"
-  showKeys={[
-    { key: 'doc_opcode', name: 'Opcode' },
-    { key: 'doc_fift', name: 'Fift syntax' },
-    { key: 'doc_stack', name: 'Stack' },
-    { key: 'doc_description', name: 'Description', hasMarkdown: true },
-    { key: 'doc_gas', name: 'Gas' },
-  ]}
-/>
-
 ### TVM Instructions Content List
 
 * [Overview](/learn/tvm-instructions/instructions)
@@ -38,6 +25,18 @@ Here `0 <= i,j,k <= 15` if not stated otherwise.
 * [Application-specific Primitives](/learn/tvm-instructions/instructions/app-specific)
 * [Miscellaneous](/learn/tvm-instructions/instructions/miscellaneous)
 
+<SearchField
+  data={opcodes}
+  searchBy="doc_fift"
+  placeholder="Search for an opcode"
+  showKeys={[
+    { key: 'doc_opcode', name: 'Opcode' },
+    { key: 'doc_fift', name: 'Fift syntax' },
+    { key: 'doc_stack', name: 'Stack' },
+    { key: 'doc_description', name: 'Description', hasMarkdown: true },
+    { key: 'doc_gas', name: 'Gas' },
+  ]}
+/>
 
 ### Basic stack manipulation primitives
 

--- a/src/pages/learn/tvm-instructions/instructions/tuple-list-null.mdx
+++ b/src/pages/learn/tvm-instructions/instructions/tuple-list-null.mdx
@@ -8,20 +8,6 @@ import { tupleOpcodes as opcodes } from '@site/src/data/opcodes';
 
 # Tuple, List, and Null primitives
 
-<SearchField
-  data={opcodes}
-  searchBy="doc_fift"
-  placeholder="Search for an opcode"
-  showKeys={[
-    { key: 'doc_opcode', name: 'Opcode' },
-    { key: 'doc_fift', name: 'Fift syntax' },
-    { key: 'doc_stack', name: 'Stack' },
-    { key: 'doc_description', name: 'Description', hasMarkdown: true },
-    { key: 'doc_gas', name: 'Gas' },
-  ]}
-/>
-
-
 ### TVM Instructions Content List
 
 * [Overview](/learn/tvm-instructions/instructions)
@@ -36,6 +22,19 @@ import { tupleOpcodes as opcodes } from '@site/src/data/opcodes';
 * [Dictionary Manipulation](/learn/tvm-instructions/instructions/dictionary-manipulation)
 * [Application-specific Primitives](/learn/tvm-instructions/instructions/app-specific)
 * [Miscellaneous](/learn/tvm-instructions/instructions/miscellaneous)
+
+<SearchField
+  data={opcodes}
+  searchBy="doc_fift"
+  placeholder="Search for an opcode"
+  showKeys={[
+    { key: 'doc_opcode', name: 'Opcode' },
+    { key: 'doc_fift', name: 'Fift syntax' },
+    { key: 'doc_stack', name: 'Stack' },
+    { key: 'doc_description', name: 'Description', hasMarkdown: true },
+    { key: 'doc_gas', name: 'Gas' },
+  ]}
+/>
 
 ### Tuple, List, and Null primitives
 

--- a/src/pages/learn/tvm-instructions/instructions/tuple-list-null.mdx
+++ b/src/pages/learn/tvm-instructions/instructions/tuple-list-null.mdx
@@ -13,11 +13,11 @@ import { tupleOpcodes as opcodes } from '@site/src/data/opcodes';
   searchBy="doc_fift"
   placeholder="Search for an opcode"
   showKeys={[
-    { key: 'doc_opcode', name: 'Opcode', isGrouped: true },
-    { key: 'doc_fift', name: 'Fift syntax', isGrouped: true },
-    { key: 'doc_stack', name: 'Stack', isGrouped: true },
-    { key: 'doc_gas', name: 'Gas', isGrouped: true },
-    { key: 'doc_description', name: 'Description' },
+    { key: 'doc_opcode', name: 'Opcode' },
+    { key: 'doc_fift', name: 'Fift syntax' },
+    { key: 'doc_stack', name: 'Stack' },
+    { key: 'doc_description', name: 'Description', hasMarkdown: true },
+    { key: 'doc_gas', name: 'Gas' },
   ]}
 />
 


### PR DESCRIPTION
Replace `isGrouped` with `hasMarkdown` for `showKeys` items in SearchField. Fix typos in `SETALTCTR` and `SAVEBOTHCTR` opcodes description. Dynamic table layout in `SearchField`