### PR TITLE
fix instructions page crash due to outdated searchBy key

### DIFF
--- a/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/archive/tvm-instructions.mdx
+++ b/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/archive/tvm-instructions.mdx
@@ -52,7 +52,7 @@ Fift 是一种基于栈的编程语言，旨在管理 TON 智能合约。Fift �
 
 <SearchField
   data={opcodes}
-  searchBy="doc_opcode"
+  searchBy="doc_fift"
   placeholder="搜索操作码"
   showKeys={[
     { key: 'doc_opcode', name: '操作码', isGrouped: true },

--- a/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/tvm-instructions/instructions.mdx
+++ b/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/tvm-instructions/instructions.mdx
@@ -59,7 +59,7 @@ TVM 指令的每个章节都包括一个内置的搜索组件，用于查找特�
 
 <SearchField
   data={opcodes}
-  searchBy="doc_opcode"
+  searchBy="doc_fift"
   placeholder="Search for an opcode"
   showKeys={[
     { key: 'doc_opcode', name: 'Opcode', isGrouped: true },

--- a/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/tvm-instructions/instructions/app-specific.mdx
+++ b/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/tvm-instructions/instructions/app-specific.mdx
@@ -10,7 +10,7 @@ import { appSpecificOpcodes as opcodes } from '@site/src/data/opcodes';
 
 <SearchField
   data={opcodes}
-  searchBy="doc_opcode"
+  searchBy="doc_fift"
   placeholder="搜索操作码"
   showKeys={[
     { key: 'doc_opcode', name: '操作码', isGrouped: true },

--- a/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/tvm-instructions/instructions/arithmetic.mdx
+++ b/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/tvm-instructions/instructions/arithmetic.mdx
@@ -10,7 +10,7 @@ import { arithmeticOpcodes as opcodes } from '@site/src/data/opcodes';
 
 <SearchField
   data={opcodes}
-  searchBy="doc_opcode"
+  searchBy="doc_fift"
   placeholder="搜索操作码"
   showKeys={[
     { key: 'doc_opcode', name: '操作码', isGrouped: true },

--- a/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/tvm-instructions/instructions/cell-manipulation.mdx
+++ b/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/tvm-instructions/instructions/cell-manipulation.mdx
@@ -10,7 +10,7 @@ import { cellManipulationOpcodes as opcodes } from '@site/src/data/opcodes';
 
 <SearchField
   data={opcodes}
-  searchBy="doc_opcode"
+  searchBy="doc_fift"
   placeholder="搜索操作码"
   showKeys={[
     { key: 'doc_opcode', name: '操作码', isGrouped: true },

--- a/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/tvm-instructions/instructions/constant.mdx
+++ b/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/tvm-instructions/instructions/constant.mdx
@@ -10,7 +10,7 @@ import { constantOpcodes as opcodes } from '@site/src/data/opcodes';
 
 <SearchField
   data={opcodes}
-  searchBy="doc_opcode"
+  searchBy="doc_fift"
   placeholder="搜索操作码"
   showKeys={[
     { key: 'doc_opcode', name: '操作码', isGrouped: true },

--- a/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/tvm-instructions/instructions/control-flow.mdx
+++ b/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/tvm-instructions/instructions/control-flow.mdx
@@ -10,7 +10,7 @@ import { continuationOpcodes as opcodes } from '@site/src/data/opcodes';
 
 <SearchField
   data={opcodes}
-  searchBy="doc_opcode"
+  searchBy="doc_fift"
   placeholder="搜索操作码"
   showKeys={[
     { key: 'doc_opcode', name: '操作码', isGrouped: true },

--- a/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/tvm-instructions/instructions/data-comparison.mdx
+++ b/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/tvm-instructions/instructions/data-comparison.mdx
@@ -10,7 +10,7 @@ import { comparisonOpcodes as opcodes } from '@site/src/data/opcodes';
 
 <SearchField
   data={opcodes}
-  searchBy="doc_opcode"
+  searchBy="doc_fift"
   placeholder="搜索操作码"
   showKeys={[
     { key: 'doc_opcode', name: '操作码', isGrouped: true },

--- a/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/tvm-instructions/instructions/dictionary-manipulation.mdx
+++ b/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/tvm-instructions/instructions/dictionary-manipulation.mdx
@@ -12,7 +12,7 @@ import { dictionaryManipulationOpcodes as opcodes } from '@site/src/data/opcodes
 
 <SearchField
   data={opcodes}
-  searchBy="doc_opcode"
+  searchBy="doc_fift"
   placeholder="搜索操作码"
   showKeys={[
     { key: 'doc_opcode', name: '操作码', isGrouped: true },

--- a/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/tvm-instructions/instructions/exception-gen-and-handling.mdx
+++ b/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/tvm-instructions/instructions/exception-gen-and-handling.mdx
@@ -10,7 +10,7 @@ import { exceptionOpcodes as opcodes } from '@site/src/data/opcodes';
 
 <SearchField
   data={opcodes}
-  searchBy="doc_opcode"
+  searchBy="doc_fift"
   placeholder="搜索操作码"
   showKeys={[
     { key: 'doc_opcode', name: '操作码', isGrouped: true },

--- a/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/tvm-instructions/instructions/miscellaneous.mdx
+++ b/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/tvm-instructions/instructions/miscellaneous.mdx
@@ -16,7 +16,7 @@ import { miscellaneousOpcodes as opcodes } from '@site/src/data/opcodes';
 
 <SearchField
   data={opcodes}
-  searchBy="doc_opcode"
+  searchBy="doc_fift"
   placeholder="搜索操作码"
   showKeys={[
     { key: 'doc_opcode', name: '操作码', isGrouped: true },

--- a/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/tvm-instructions/instructions/stack-manipulation.mdx
+++ b/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/tvm-instructions/instructions/stack-manipulation.mdx
@@ -12,7 +12,7 @@ import { stackManipulationOpcodes as opcodes } from '@site/src/data/opcodes';
 
 <SearchField
   data={opcodes}
-  searchBy="doc_opcode"
+  searchBy="doc_fift"
   placeholder="搜索操作码"
   showKeys={[
     { key: 'doc_opcode', name: '操作码', isGrouped: true },

--- a/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/tvm-instructions/instructions/tuple-list-null.mdx
+++ b/i18n/zh-Hans/docusaurus-plugin-content-pages/learn/tvm-instructions/instructions/tuple-list-null.mdx
@@ -10,7 +10,7 @@ import { tupleOpcodes as opcodes } from '@site/src/data/opcodes';
 
 <SearchField
   data={opcodes}
-  searchBy="doc_opcode"
+  searchBy="doc_fift"
   placeholder="搜索操作码"
   showKeys={[
     { key: 'doc_opcode', name: '操作码', isGrouped: true },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Why is it important?

The current https://docs.ton.org/zh-Hans/learn/tvm-instructions/instructions page crashes due to the Mandarin translation is based on a earlier version TON docs with outdated `searchBy` key.

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/ton-community/ton-docs/issues/509
<!--- This project accepts pull requests related to open issues, if possible -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here, if possible: -->