### PR TITLE
Close issue in MintyTON rep.

### DIFF
--- a/docs/develop/dapps/tutorials/collection-minting.md
+++ b/docs/develop/dapps/tutorials/collection-minting.md
@@ -168,7 +168,7 @@ import { readdir } from "fs/promises";
 dotenv.config();
 
 async function init() {
-  const wallet = await openWallet(process.env.MNEMONIC!.split(" "), true);  
+  const wallet = await openWallet([process.env.MNEMONIC!], true);  
 }
 
 void init();


### PR DESCRIPTION

I fixed a bug that when trying to create a collection it always returned an error:
{
  "ok": false,
  "error": "LITE_SERVER_UNKNOWN: cannot apply external message to current state : Failed to unpack account state",
  "code": 500
}

## Why is it important?
Faced with this problem, I went to the ton-crypto and @ton\crypto and found out that you can’t split a mnemonic phrase. 

## Related Issue
https://github.com/coalus/MintyTON/issues/1