### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/develop/dapps/apis/sdk.mdx
+++ b/docs/develop/dapps/apis/sdk.mdx
@@ -23,7 +23,7 @@ There are different ways to connect to blockchain:
 ### Java
 | Library |	Blockchain connection |	Description |
 |---------|------------------|--------------|
-| [ton4js](https://github.com/neodix42/ton4j) | Tonlib binary | Java SDK for The Open Network (TON) |
+| [ton4j](https://github.com/neodix42/ton4j) | Tonlib binary | Java SDK for The Open Network (TON) |
 
 
 ### Python


### PR DESCRIPTION
The correct name for the java library is `ton4j`.