### PR TITLE
Update instructions how to access web console in Telegram desktop

### DIFF
--- a/docs/develop/dapps/telegram-apps/testing-apps.mdx
+++ b/docs/develop/dapps/telegram-apps/testing-apps.mdx
@@ -29,11 +29,13 @@ Use these tools to find app-specific issues in your Mini App:
 - Choose *Enable WebView Debug* in the Debug Settings.
 - Connect your phone to your computer and open chrome://inspect/#devices in Chrome – you will see your Mini App there when you launch it on your phone.
 
-### Telegram Desktop on Windows and Linux
+### Telegram Desktop on Windows, Linux and macOS
 
-- Download and launch the [Beta Version](https://desktop.telegram.org/changelog#beta-version) of Telegram Desktop on **Windows** or **Linux** (not supported on Telegram Desktop for macOS yet).
+- Download and launch the latest version of Telegram Desktop on **Windows**, **Linux** or **macOS** (as the writing of this version 5.0.1 is available)
 - Go to *Settings > Advanced > Experimental settings > Enable webview inspection*.
-- Right click in the WebView and choose *Inspect*.
+- on Windows and Linux, right-click in the WebView and choose *Inspect*.
+- On macOS, you need to access the Inspect through [Safari Developer menu](https://support.apple.com/en-gb/guide/safari/sfri20948/mac)
+  and Inspect is not available through the right-click context menu
 
 ### Telegram macOS
 


### PR DESCRIPTION
## Why is it important?

Instructions were outdated
- Beta no longer needed
- macOS is supported

