### PR TITLE
Missing full link in red_stone.mdx for price_manager.fc

### DIFF
--- a/docs/develop/oracles/red_stone.mdx
+++ b/docs/develop/oracles/red_stone.mdx
@@ -18,7 +18,7 @@ To learn more about RedStone oracles design go to the [RedStone docs](https://do
 
 ### price_manager.fc
 
-- Sample oracle contract that consumes RedStone oracles data [price_manager.fc](price_manager.fc) written in
+- Sample oracle contract that consumes RedStone oracles data [price_manager.fc](https://github.com/redstone-finance/redstone-oracles-monorepo/blob/main/packages/ton-connector/contracts/price_manager.fc) written in
   FunC. It requires [TVM Upgrade 2023.07](https://docs.ton.org/learn/tvm-instructions/tvm-upgrade-2023-07).
 
 #### initial data


### PR DESCRIPTION
Just added one missed link to https://github.com/redstone-finance/redstone-oracles-monorepo