### PR TITLE
Delete public proxy and C++ compile page

### DIFF
--- a/docs/participate/web3/how-to-open-any-ton-site.md
+++ b/docs/participate/web3/how-to-open-any-ton-site.md
@@ -26,14 +26,6 @@ Currently, TON Proxy is already available in [MyTonWallet](https://mytonwallet.i
 
 This method is also pretty easy, but you need to install an extension in your browser to make it work. It will be suitable for most users.
 
-### Connect to a public proxy
-
-If you don't want to install any extensions or if you are using mobile device, you can use this method. You'll have to configure something on your device to connect to the proxy.
-
-This method is described here:
-
--   [Connect with TON Proxy](/participate/web3/setting-proxy/)
-
 ## 🤓 Advanced methods
 
 ### Using Tonutils-Proxy

--- a/docs/participate/web3/setting-proxy.md
+++ b/docs/participate/web3/setting-proxy.md
@@ -1,13 +1,5 @@
 # Connect with TON Proxy
 
-## Public entry TON Proxies
-
-You can use one of the public entry TON Proxies:
-
-* `in1.ton.org` port `8080`
-* `in2.ton.org` port `8080`
-* `in3.ton.org` port `8080`
-
 TON Proxy is compatible with a regular HTTP proxy, so you can use it directly in your browser or operating system settings.
 
 ## Google Chrome

--- a/docs/participate/web3/sites-and-proxy.md
+++ b/docs/participate/web3/sites-and-proxy.md
@@ -4,7 +4,7 @@ The aim of this document is to provide a gentle introduction into TON Sites, whi
 
 From the technical perspective, TON Sites are very much like standard websites, but they are accessed through the [TON Network](/learn/networking/overview) (which is an overlay network inside the Internet) instead of the Internet. More specifically, they have an [ADNL](/learn/networking/adnl) Address (instead of a more customary IPv4 or IPv6 address) and they accept HTTP queries via a [RLDP](/learn/networking/rldp) protocol (which is a higher-level RPC protocol built upon ADNL, the main protocol of TON Network) instead of the usual TCP/IP. All encryption is handled by ADNL, so there is no need to use HTTPS (i.e. TLS) in case the entry proxy is hosted locally on the user's device.
 
-In order to access existing sites and create new TON, Sites one needs special gateways between the "ordinary" internet and the TON Network. Essentially, TON Sites are accessed with the aid of a HTTP->RLDP proxy running locally on the client's machine and they are created by means of a reverse RLDP->HTTP proxy running on a remote web server.
+In order to access existing sites and create new TON Sites one needs special gateways between the "ordinary" internet and the TON Network. Essentially, TON Sites are accessed with the aid of a HTTP->RLDP proxy running locally on the client's machine and they are created by means of a reverse RLDP->HTTP proxy running on a remote web server.
 
 [Read more about TON Sites, WWW, and Proxy](https://blog.ton.org/ton-sites)
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -725,7 +725,6 @@ const sidebars = {
       'items': [
         'participate/web3/setting-proxy',
         'participate/web3/how-to-open-any-ton-site',
-        'participate/web3/sites-and-proxy',
         'develop/dapps/tutorials/how-to-run-ton-site',
         'participate/web3/site-management',
       ],


### PR DESCRIPTION
- participate/web3/sites-and-proxy
- public proxy

<!--- Provide a general summary of your changes in the Title above -->

## Why is it important?

PP are obsolete, GO is preferred method for TON Sites and Proxies 
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues, if possible -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here, if possible: -->