### PR TITLE
Add .NET ton_proof demo

### DIFF
--- a/docs/develop/dapps/ton-connect/sign.mdx
+++ b/docs/develop/dapps/ton-connect/sign.mdx
@@ -212,6 +212,7 @@ The signature must be verified by public key:
 * [JS demo app](https://github.com/liketurbo/demo-dapp-backend-js)
 * [Python example](https://github.com/XaBbl4/pytonconnect/blob/main/examples/check_proof.py)
 * [PHP example](https://github.com/vladimirfokingithub/Ton-Connect-Proof-Php-Check)
+* [C# demo app](https://github.com/WinoGarcia/TonProof.NET)
 
 ## See Also
 


### PR DESCRIPTION
I have developed a [library for verifying ton_proof](https://github.com/WinoGarcia/TonProof.NET) in .NET. This [NuGet package](https://www.nuget.org/packages/TonProof) is production-ready.
I want to add it to the documentation. The repository has a [demo project](https://github.com/WinoGarcia/TonProof.NET?tab=readme-ov-file#usage) with usage examples.

Resolves #722 