### PR TITLE
fix bridge.ton.org link 

### DIFF
--- a/docs/develop/dapps/asset-processing/usdt.md
+++ b/docs/develop/dapps/asset-processing/usdt.md
@@ -4,7 +4,7 @@ import Button from '@site/src/components/button'
 
 ## Tether
 
-Stablecoins are a type of cryptocurrency whose value is 1:1 pegged to another asset, such as a fiat currency or gold, to maintain a stable price. Until recently, there was a jUSDT token, which is a wrapped ERC-20 from the Ethereum token bridged with [bridge.ton.org](bridge.ton.org). But on [18.04.2023](https://t.me/toncoin/824) the public launch of **native** USD₮ token issued by the company [Tether](https://tether.to/en/) was happened. After launching USD₮, the jUSDT has moved to the second priority token but is still used in services as an alternative or addition to USD₮.
+Stablecoins are a type of cryptocurrency whose value is 1:1 pegged to another asset, such as a fiat currency or gold, to maintain a stable price. Until recently, there was a jUSDT token, which is a wrapped ERC-20 from the Ethereum token bridged with <a href="https://bridge.ton.org" target="_blank">bridge.ton.org</a>. But on [18.04.2023](https://t.me/toncoin/824) the public launch of **native** USD₮ token issued by the company <a href="https://tether.to/en/" target="_blank">Tether</a> was happened. After launching USD₮, the jUSDT has moved to the second priority token but is still used in services as an alternative or addition to USD₮.
 
 In TON Blockchain USD₮ supported as a [Jetton Asset](/develop/dapps/asset-processing/jettons).
 


### PR DESCRIPTION
and open external links to bridge.ton.org and tether.io in new page

## Why is it important?

Fixes a link to bridge.ton.org that is broken because it winds up as a relative (an uncle instead of a brother... lol)

The default web rule is to open new tabs on external links. - This has bee like that even in 2012...
See https://uxmovement.com/navigation/why-external-links-should-open-in-new-tabs/
I thought TON was supposed to advance the web, not make it worse... (no hate, though)


## Related Issue

<!--- This project accepts pull requests related to open issues, if possible -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here, if possible: -->