### PR TITLE
change link to tonapi rates documentarion

### DIFF
--- a/docs/develop/dapps/apis/README.md
+++ b/docs/develop/dapps/apis/README.md
@@ -22,7 +22,7 @@
 
 ### Toncoin rate APIs
 
-* https://tonapi.io/v2/rates?tokens=ton&currencies=ton%2Cusd%2Crub
+* https://docs.tonconsole.com/tonapi/rest-api/rates
 * https://coinmarketcap.com/api/documentation/v1/ 
 * https://apiguide.coingecko.com/getting-started
 


### PR DESCRIPTION
Replaced the link to a specific endpoint with a link to the relevant page in the tonapi documentation

## Why is it important?

This provides better context and comprehensive information compared to just an endpoint.
