### PR TITLE
Adding Tatum under RPC Nodes provider

### DIFF
--- a/docs/develop/dapps/apis/toncenter.md
+++ b/docs/develop/dapps/apis/toncenter.md
@@ -26,6 +26,7 @@ There are different ways to connect to blockchain:
 
 ## RPC Nodes
 
+* [Tatum](https://docs.tatum.io/reference/rpc-ton) — Access TON RPC nodes and powerful developer tools in one simple-to-use platform.
 * [GetBlock Nodes](https://getblock.io/nodes/ton/) — connect and test your dApps using GetBlocks Nodes
 * [TON Access](https://www.orbs.com/ton-access/) - HTTP API for The Open Network (TON).
 * [Toncenter](https://toncenter.com/api/v2/) — community-hosted project for Quick Start with API. (Get an API key [@tonapibot](https://t.me/tonapibot))


### PR DESCRIPTION
Adding Tatum under RPC Nodes provider as Tatum provides TON RPC Nodes and whole infrastructure to run Web3 Apps.

<!--- Provide a general summary of your changes in the Title above --> Adding Tatum under RPC Nodes provider since Tatum provides TON RPC nodes

## Why is it important?

<!--- Describe your changes in detail --> Adding Tatum under Nodes provider as another provider of TON rpc nodes

## Related Issue

<!--- This project accepts pull requests related to open issues, if possible --> 
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here, if possible: -->