### PR TITLE
Refactored page about node types

### DIFF
--- a/docs/participate/nodes/node-types.md
+++ b/docs/participate/nodes/node-types.md
@@ -2,15 +2,25 @@ import Button from '@site/src/components/button'
 
 # TON Node Types
 
-In *simplified terms*, a blockchain `node` is **one of the computers** that **collectively run the blockchain's software**. It enables the blockchain to search and optionally validate transactions and keep the network secure ensuring that the network remains **decentralized**.
+**Blockchain node** is a device, usually a computer, that runs the TON blockchain's software - and therefore, participates in the blockchain operation.
+In general, nodes ensure decentralisation of the TON network.
 
-When diving into the world of The Open Network (TON), understanding the distinct node types and their functionalities is crucial. This article breaks down each node type to provide clarity for developers wishing to engage with the TON blockchain.
+Nodes perform different functions within the TON protocol:
+
+- **Full** and **archive nodes** maintain the blockchain block and transaction history, enable users and client applications to look for blocks and transactions, as well as to send new transations into the blockchain;
+- **Validator nodes** verify transactions ensuring the blockchain security.
+
+Below, you will find more detailed information about each of these node types, as well as about interaction of full and archive nodes with client applications.
 
 ## Full Node
 
-A `Full Node` in TON is a node that **maintains synchronization** with the blockchain.
+**Full node** is a basic node type within the TON blockchain.
+They serve as a backbone of the TON blockchain by keeping its block history - in other words, its _current state_.
 
-It retains the _current state_ of the blockchain and can house either the entire block history or parts of it. This makes it the backbone of the TON blockchain, facilitating the network's decentralization and security.
+In comparison with **archive nodes**, full nodes keep only the latest part of the blockchain state vital for ensuring the network stability and operation of client applications.
+Full nodes _prune_ the state of the TON blockchain kept by them - that means, earlier blocks that become unnecessary for the network, are automatically removed by the full node to effectively manage its data volume.
+
+To allow client applications to look for blocks and transactions, as well as to send new transactions into the TON blockchain, full nodes are equipped with the liteserver functionality: see [Interacting with TON nodes](#interacting-with-ton-nodes) below.
 
 ````mdx-code-block 
 <Button href="/participate/run-nodes/full-node"
@@ -23,9 +33,12 @@ Running a Full Node
 
 ## Archive Node
 
-If `Full node` archives the **entire block history** it's called `Archive Node`.
+**Archive node** is a full node that keeps the entire block history of the TON blockchain.
+Such nodes act as the decentralised point of truth in terms of ensuring consistency of the whole blockchain history.
+They serve as a backend for blockchain explorers and other applicaitons relying on deep transaction history.
 
-Such nodes are indispensable for creating blockchain explorers or other tools that necessitate a full blockchain history.
+Archive nodes do not prune the blockchain state which elevates their system requirements, especially in terms of storage.
+According to the latest estimations, while full nodes and validator nodes require about 1 TB disk space, archive nodes would require about 8 TB to store the complete block history.
 
 <Button href="/participate/run-nodes/archive-node"
 colorType="primary" sizeType={'sm'}>
@@ -34,60 +47,51 @@ Running an Archive Node
 
 ## Validator Node
 
-TON operates on a **Proof-of-Stake** mechanism, where `validators` are pivotal in maintaining network functionality. `Validators` are [rewarded in Toncoin](/participate/network-maintenance/staking-incentives) for their contributions, incentivizing network participation and ensuring network security.
+**Validator nodes** or **validators** are TON network participants that propose new blocks and verify transactions in them according to the TON's _Proof-of-Stake_ mechanism.
+In this way, validators contribute to the overall blockchain security.
 
-If `full node` holds a **necessary amount of Toncoin** as a **stake**, it can be used as `Validator Node`.
+For successful participation in the validation process, validators get [rewards in TON](/participate/network-maintenance/staking-incentives).
+
+To be entitled to propose and validate blocks, validators are elected by other participants according to amount of TON being held with them - in other words, their _stake_: the more TON is staked with a validator, the more is its chance to be elected, validate blocks for the network and acquire rewards.
+As a rule, validator operators motivate other TON holders to stake with them to get passive income from resulting rewards.
+In this way, validators ensure network stability, security and contribute to its growth.
 
 <Button href="/participate/run-nodes/enable-liteserver-node"
 colorType="primary" sizeType={'sm'}>
 Running a Validator Node
 </Button>
 
-## Liteserver
+## Interacting with TON nodes
 
-`Full Node` can be used as `Liteserver`. This node type can field and respond to requests from `Lite Clients`, allowing to seamlessly interact with the TON Blockchain.
+TON nodes are equipped with a _Liteserver_ functionality allowing external applications (in other words, _lite clients_) to interact with the TON blockchain via them.
+As a rule, the liteserver mode is used with full and archive nodes while validator nodes do not enable it to increase validation performance.
 
-`Liteservers` enable swift communication with Lite Clients, facilitating tasks like retrieving balance or submitting transactions without necessitating the full block history.
+The liteserver mode allows lite clients to send transactoins via TON nodes, as well as to retrieve information about blocks and transactions with them - for instance, to fetch and update wallet balances.
 
-Actually, there are two public `Liteservers` configs both for mainnet and testnet, that already have been provided by the TON Foundation. They are accessible for universal use. But it's not recommended to use public `Liteservers` in production since they are not stable because of permanent high load.
+You have two options to allow your lite client application to interact with the TON blockchain:
 
-- [Public Liteserver Configurations - mainnet](https://ton.org/global-config.json)
-- [Public Liteserver Configurations - testnet](https://ton.org/testnet-global.config.json)
+1. To have a stable connection, you can run your own full or archive node with a Liteserver mode enabled in your node configuration file.
+2. In case you have no opportunity to set up your own TON node with a Liteserver, you can use the mesh of public Liteservers provided by the TON foundation. For this purpose, use following configuraiton files:
+    - [Public Liteserver Configurations - mainnet](https://ton.org/global-config.json)
+    - [Public Liteserver Configurations - testnet](https://ton.org/testnet-global.config.json)
 
-These endpoints, such as those used by standard wallets, ensure that even without setting up a personal liteserver, interaction with the TON Blockchain remains possible.
-
-If you want to have more stable _connection_, you can run your own `Liteserver`. To run a `full node` as a `Liteserver`, simply enable the `Liteserver` mode in your node's configuration file.
+:::caution Usage of public Liteservers in production
+Because of a permanent high load on public Liteservers, the majority of them is rate limited, that is why it is not recomended to use them in production.
+This may drive to instability of your your lite client application.
+:::
 
 <Button href="/participate/run-nodes/full-node#enable-liteserver-mode"
 colorType="primary" sizeType={'sm'}>
 Enable Liteserver in your Node
 </Button>
 
-## Lite Clients: the SDKs to interact with TON
+To interact with Liteservers, you can use following tools:
 
-Each SDK which supports ADNL protocol can be used as a `Lite Client` with `config.json` file (find how to download it [here](/participate/nodes/node-types#troubleshooting)). The `config.json` file contains a list of endpoints that can be used to connect to the TON Blockchain.
-
-Each SDK without ADNL support usually uses HTTP middleware to connect to the TON Blockchain. It's less secure and slower than ADNL, but it's easier to use.
+- TON [ADNL API](/develop/dapps/apis/adnl) as the most low-level way to communicate with the blockchain;
+- TON [SDKs](/develop/dapps/apis/sdk) provided for various programming languages;
+- TON [HTTP-based APIs](/develop/dapps/toncenter) providing the REST API middleware between your application and a Liteserver.
 
 <Button href="/develop/dapps/apis/sdk"
 colorType="primary" sizeType={'sm'}>
 Choose a TON SDK
 </Button>
-
-### Troubleshooting
-
-Below you can find approaches how to fix common nowed issues with `light clients`
-
-### Timed out after 3 seconds
-
-If you see this error this means that the liteserver you are trying to connect to is not available. The correct way to solve this issue for public liteservers is as follows:
-
-1. Download the config.json file from the tontech link:
-
-```bash
-wget https://api.tontech.io/ton/wallet-mainnet.autoconf.json -O /usr/bin/ton/global.config.json
-```
-
-It removes slow liteservers from the configuration file.
-
-2. Use the downloaded config.json file in your application with [TON SDK](/develop/dapps/apis/sdk).


### PR DESCRIPTION
## Why is it important?

This refactoring makes the page about node types more consistent and readable. It now may serve as a basis for the entire section underneath (to be delivered in next PRs if this one is approved).