### PR TITLE
Add Chainstack as node & indexer provider

### DIFF
--- a/docs/develop/dapps/apis/toncenter.md
+++ b/docs/develop/dapps/apis/toncenter.md
@@ -26,6 +26,7 @@ There are different ways to connect to blockchain:
 
 ## RPC Nodes
 
+* [Chainstack](https://chainstack.com/build-better-with-ton/) — RPC nodes and indexer in multiple regions with geo and load balancing.
 * [Tatum](https://docs.tatum.io/reference/rpc-ton) — Access TON RPC nodes and powerful developer tools in one simple-to-use platform.
 * [GetBlock Nodes](https://getblock.io/nodes/ton/) — connect and test your dApps using GetBlocks Nodes
 * [TON Access](https://www.orbs.com/ton-access/) - HTTP API for The Open Network (TON).


### PR DESCRIPTION
Adding Chainstack as the RPC nodes (v2) & indexer provider (v3) to the list of TON node providers.