### PR TITLE
Fix transfer example for V5R1 wallet

### DIFF
--- a/docs/develop/dapps/cookbook.mdx
+++ b/docs/develop/dapps/cookbook.mdx
@@ -373,7 +373,7 @@ let seqno: number = await contract.getSeqno();
 await contract.sendTransfer({
   secretKey: keyPair.secretKey, 
   seqno,
-  sendMode: SendMode.PAY_GAS_SEPARATELY,
+  sendMode: SendMode.PAY_GAS_SEPARATELY + SendMode.IGNORE_ERRORS,
   messages: [
     internal({
       to: 'EQCD39VS5jcptHL8vMjEXrzGaRcCVYto7HUn4bpAOg8xqB2N',


### PR DESCRIPTION
## Why is it important?

https://github.com/ton-blockchain/wallet-contract-v5/blob/88557ebc33047a95207f6e47ac8aadb102dff744/contracts/wallet_v5.fc#L82

Transfer will fail without IGNORE_ERRORS flag with 137 exit code