### PR TITLE
feat(docs): add pyth to ton docs

### DIFF
--- a/docs/develop/oracles/about_blockchain_oracles.md
+++ b/docs/develop/oracles/about_blockchain_oracles.md
@@ -56,5 +56,6 @@ It is difficult to generate random numbers in smart contracts because all operat
 
 ## List of oracles in TON
 
+* [Pyth Network](/develop/oracles/pyth_network)
 * [RedStone Oracles](/develop/oracles/red_stone)
 

--- a/docs/develop/oracles/pyth_network.mdx
+++ b/docs/develop/oracles/pyth_network.mdx
@@ -1,0 +1,109 @@
+# Pyth Network
+
+## How Pyth oracles work with TON
+
+import { Tabs } from "nextra/components";
+
+## How to Use Real-Time Data in TON Contracts
+
+This guide explains how to use real-time Pyth data in TON applications.
+
+## Install the Pyth SDK
+
+Install the Pyth TON SDK and other necessary dependencies using npm:
+
+<Tabs items={["npm", "yarn"]}>
+  <Tabs.Tab>
+    ```sh copy
+    npm install @pythnetwork/pyth-ton-js @pythnetwork/hermes-client
+    @ton/core @ton/ton @ton/crypto
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```sh copy
+    yarn add @pythnetwork/pyth-ton-js @pythnetwork/hermes-client
+    @ton/core @ton/ton @ton/crypto
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+## Write Client Code
+
+The following code snippet demonstrates how to fetch price updates, interact with the Pyth contract on TON, and update price feeds:
+
+```typescript copy
+import { TonClient, Address, WalletContractV4 } from "@ton/ton";
+import { toNano } from "@ton/core";
+import { mnemonicToPrivateKey } from "@ton/crypto";
+import { HermesClient } from "@pythnetwork/hermes-client";
+import {
+  PythContract,
+  PYTH_CONTRACT_ADDRESS_TESTNET,
+} from "@pythnetwork/pyth-ton-js";
+const BTC_PRICE_FEED_ID =
+  "0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43";
+async function main() {
+  // Initialize TonClient
+  const client = new TonClient({
+    endpoint: "https://testnet.toncenter.com/api/v2/jsonRPC",
+    apiKey: "your-api-key-here", // Optional
+  });
+  // Create PythContract instance
+  const contractAddress = Address.parse(PYTH_CONTRACT_ADDRESS_TESTNET);
+  const contract = client.open(PythContract.createFromAddress(contractAddress));
+  // Get current guardian set index
+  const guardianSetIndex = await contract.getCurrentGuardianSetIndex();
+  console.log("Guardian Set Index:", guardianSetIndex);
+  // Get BTC price from TON contract
+  const price = await contract.getPriceUnsafe(BTC_PRICE_FEED_ID);
+  console.log("BTC Price from TON contract:", price);
+  // Fetch latest price updates from Hermes
+  const hermesEndpoint = "https://hermes.pyth.network";
+  const hermesClient = new HermesClient(hermesEndpoint);
+  const priceIds = [BTC_PRICE_FEED_ID];
+  const latestPriceUpdates = await hermesClient.getLatestPriceUpdates(
+    priceIds,
+    { encoding: "hex" }
+  );
+  console.log("Hermes BTC price:", latestPriceUpdates.parsed?.[0].price);
+  // Prepare update data
+  const updateData = Buffer.from(latestPriceUpdates.binary.data[0], "hex");
+  console.log("Update data:", updateData);
+  // Get update fee
+  const updateFee = await contract.getUpdateFee(updateData);
+  console.log("Update fee:", updateFee);
+  // Update price feeds
+  const mnemonic = "your mnemonic here";
+  const key = await mnemonicToPrivateKey(mnemonic.split(" "));
+  const wallet = WalletContractV4.create({
+    publicKey: key.publicKey,
+    workchain: 0,
+  });
+  const provider = client.open(wallet);
+  await contract.sendUpdatePriceFeeds(
+    provider.sender(key.secretKey),
+    updateData,
+    156000000n + BigInt(updateFee) // 156000000 = 390000 (estimated gas used for the transaction, this is defined in (contracts/common/gas.fc)[https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/ton/contracts/common/gas.fc] as UPDATE_PRICE_FEEDS_GAS) * 400 (current settings in basechain are as follows: 1 unit of gas costs 400 nanotons)
+  );
+  console.log("Price feeds updated successfully.");
+}
+main().catch(console.error);
+```
+
+This code snippet does the following:
+
+1. Initializes a `TonClient` and creates a `PythContract` instance.
+2. Retrieves the current guardian set index and BTC price from the TON contract.
+3. Fetches the latest price updates from Hermes.
+4. Prepares the update data and calculates the update fee.
+5. Updates the price feeds on the TON contract.
+
+## Additional Resources
+
+You may find these additional resources helpful for developing your TON application:
+
+- [TON Documentation](https://ton.org/docs/)
+- [Pyth Price Feed IDs](https://pyth.network/developers/price-feed-ids)
+- [Pyth TON Contract](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/ton/contracts)
+- [Pyth TON SDK](https://github.com/pyth-network/pyth-crosschain/tree/main/target_chains/ton/sdk)
+- [Pyth TON Example](https://github.com/pyth-network/pyth-examples/tree/main/price_feeds/ton/sdk_js_usage)


### PR DESCRIPTION
Hi all, Mario from Pyth here. 

Would like to add Pyth oracle to the TON docs, all details are attached in the files

## Why is it important?

To allow users and developers in TON to leverage the Pyth oracle and receive access to 500+ price feeds

## Related Issue

N/A