### PR TITLE
Update compilation-instructions.md

### DIFF
--- a/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.md
+++ b/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.md
@@ -161,7 +161,7 @@ cmake --build . --target func
 To compile FunC smart contract:
 
 ```bash
-func -o output.fif -SPA source0.fc source1.fc ...
+./crypto/func -o output.fif -SPA source0.fc source1.fc ...
 ```
 
 ## Fift
@@ -175,7 +175,7 @@ cmake --build . --target fift
 To run Fift script:
 
 ```bash
-fift -s script.fif script_param0 script_param1 ..
+./crypto/fift -s script.fif script_param0 script_param1 ..
 ```
 
 ## Tonlib-cli
@@ -205,7 +205,7 @@ cmake --build . --target rldp-http-proxy
 The Proxy binary will be located as:
 
 ```bash
-rldp-http-proxy/rldp-http-proxy
+./rldp-http-proxy/rldp-http-proxy
 ```
 
 ## generate-random-id
@@ -219,7 +219,7 @@ cmake --build . --target generate-random-id
 The binary will be located as:
 
 ```bash
-utils/generate-random-id
+./utils/generate-random-id
 ```
 
 ## storage-daemon
@@ -233,7 +233,7 @@ cmake --build . --target storage-daemon storage-daemon-cli
 The binary will be located at:
 
 ```bash
-storage/storage-daemon/
+./storage/storage-daemon/
 ```
 
 # Compile old TON versions


### PR DESCRIPTION
There are inconsistent file names in the instructions for compiling binaries: fift and func are mentioned without a directory, while other executables include a directory. Sometimes the directory is prefixed with ./, and other times it’s not. I suggest consistently using the ./ notation, as it follows standard Unix conventions. 



## Why is it important?

This change would improve the consistency of the information, make it more reproducible, and speed up the process of mass adoption of the technology.

