### PR TITLE
fix: Python examples - provider close

### DIFF
--- a/docs/v3/guidelines/dapps/cookbook.mdx
+++ b/docs/v3/guidelines/dapps/cookbook.mdx
@@ -442,7 +442,7 @@ async def main():
     }
 
     await wallet.transfer(**transfer)
-	await provider.close_all()
+    await provider.close_all()
 
 asyncio.run(main())
 ```
@@ -606,7 +606,7 @@ async def main():
                                                    stack=[begin_cell().store_address(USER_ADDRESS).end_cell().begin_parse()])
     jetton_wallet = result_stack[0].load_address()
     print(f"Jetton wallet address for {USER_ADDRESS}: {jetton_wallet.to_str(1, 1, 1)}")
-	await provider.close_all()
+    await provider.close_all()
 
 asyncio.run(main())
 ```
@@ -862,7 +862,7 @@ async def main():
                     .end_cell())
 
     await wallet.transfer(destination=USER_JETTON_WALLET, amount=int(0.05*1e9), body=transfer_cell)
-	await provider.close_all()
+    await provider.close_all()
 
 asyncio.run(main())
 ```

--- a/docs/v3/guidelines/dapps/cookbook.mdx
+++ b/docs/v3/guidelines/dapps/cookbook.mdx
@@ -442,7 +442,7 @@ async def main():
     }
 
     await wallet.transfer(**transfer)
-	await client.close_all()
+	await provider.close_all()
 
 asyncio.run(main())
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/develop/dapps/cookbook.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/develop/dapps/cookbook.md
@@ -330,7 +330,7 @@ async def main():
 
 
     await wallet.transfer(destination=DESTINATION_ADDRESS, amount=int(0.05*1e9), body="转账示例内容")
-	await client.close_all()
+	await provider.close_all()
 
 asyncio.run(main())
 ```
@@ -597,7 +597,7 @@ async def main():
                     .end_cell())
 
     await wallet.transfer(destination=USER_JETTON_WALLET, amount=int(0.05*1e9), body=transfer_cell)
-	await client.close_all()
+	await provider.close_all()
 
 asyncio.run(main())
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/develop/dapps/cookbook.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/develop/dapps/cookbook.md
@@ -330,7 +330,7 @@ async def main():
 
 
     await wallet.transfer(destination=DESTINATION_ADDRESS, amount=int(0.05*1e9), body="转账示例内容")
-	await provider.close_all()
+    await provider.close_all()
 
 asyncio.run(main())
 ```
@@ -444,7 +444,7 @@ async def main():
                                                    stack=[begin_cell().store_address(USER_ADDRESS).end_cell().begin_parse()])
     jetton_wallet = result_stack[0].load_address()
     print(f"用户{USER_ADDRESS}的Jetton钱包地址: {jetton_wallet.to_str(1, 1, 1)}")
-	await provider.close_all()
+    await provider.close_all()
 
 asyncio.run(main())
 ```
@@ -597,7 +597,7 @@ async def main():
                     .end_cell())
 
     await wallet.transfer(destination=USER_JETTON_WALLET, amount=int(0.05*1e9), body=transfer_cell)
-	await provider.close_all()
+    await provider.close_all()
 
 asyncio.run(main())
 ```


### PR DESCRIPTION
Some of the Python examples currently fail to close the client due to a wrong variable name.
It causes exception and the provider is left open.
The fix allows to close the provider and avoid the exception.

In addition, standardizing indentation from tabs to spaces.
Currently, mixed indentation causes some examples to break.