### PR TITLE
Fix broken code in "Writing comments: long strings in snake format"

### DIFF
--- a/docs/v3/guidelines/dapps/cookbook.mdx
+++ b/docs/v3/guidelines/dapps/cookbook.mdx
@@ -480,7 +480,7 @@ function writeStringTail(str, cell) {
 function readStringTail(slice) {
     const str = new TextDecoder('ascii').decode(slice.array); // decode uint8array to string
     if (cell.refs.length > 0) {
-        return str + readStringTail(cell.refs[0].beginParse()); // read next cell
+        return str + readStringTail(slice.refs[0]); // read next cell
     } else {
         return str;
     }


### PR DESCRIPTION
## Updated code for current version tonweb@0.0.66