### PR TITLE
Update web.mdx to include validUntil in transaction object

### DIFF
--- a/docs/v3/guidelines/ton-connect/frameworks/web.mdx
+++ b/docs/v3/guidelines/ton-connect/frameworks/web.mdx
@@ -123,6 +123,7 @@ const tonConnectUI = new TonConnectUI({ //connect application
 });
 
 const transaction = {
+    validUntil: Math.floor(new Date() / 1000) + 360,
     messages: [
         {
             address: "EQABa48hjKzg09hN_HjxOic7r8T1PleIy1dRd8NvZ3922MP0", // destination address


### PR DESCRIPTION
In the "Sending Messages" example, the transaction object requires a "validUntil" field, which is not mentioned on this page, but is mentioned here https://docs.ton.org/v3/guidelines/ton-connect/guidelines/sending-messages

## Why is it important?

You can't send any transactions without this required field. If you're reading the documentation, you might not notice the difference between the examples on these two pages. I had to look into the ton-connect source code to figure out what was going wrong.