### PR TITLE
Fix the ‘Tips’ note in the case 5

### DIFF
--- a/docs/v3/documentation/smart-contracts/message-management/message-modes-cookbook.mdx
+++ b/docs/v3/documentation/smart-contracts/message-management/message-modes-cookbook.mdx
@@ -95,7 +95,7 @@ In case of an error during [action phase](https://retracer.ton.org/?tx=e9dccba82
 State after transaction with error: Account A has 1 - ([total_fee](/v3/documentation/smart-contracts/transaction-fees/fees#basic-fees-formula) + `fwd_fee`) TON, Account B has 1 TON
 
 :::info tip
-If no errors the result is the same as [`mode = 1`](#4-send-a-regular-message-with-separate-fees).
+If no errors the result is the same as [`mode = 0, flag = 1`](#4-send-a-regular-message-with-separate-fees).
 :::
 
 ![](/img/docs/message-modes-cookbook/send_regular_message_pay_fee_separately_bounce_if_error.svg)


### PR DESCRIPTION
The case 5 is an extension of the case 4.
If no errors the result is the same as case 4.
However, the Mode and Flags parameter quoted in the text does not match Case 4. Correct to the same parameters as Case 4.

<!--- Provide a general summary of your changes in the Title above -->

## Why is it important?

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project accepts pull requests related to open issues, if possible -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here, if possible: -->