### PR TITLE
Extend testnet links

### DIFF
--- a/docs/v3/documentation/smart-contracts/getting-started/testnet.md
+++ b/docs/v3/documentation/smart-contracts/getting-started/testnet.md
@@ -10,7 +10,7 @@ Coins in the test network have no value, and the network can be reset at any tim
 * Get free test coins from the [@test_giver_ton_bot](https://t.me/testgiver_ton_bot)
 * Check the testnet status in the Telegram channel: [@testnetstatus](https://t.me/testnetstatus)
 
-## Services
+### Core Services
 
 For convenience, nearly the entire mainnet infrastructure (wallets, APIs, bridges, etc.) has been replicated in the test network.
 
@@ -22,7 +22,31 @@ For convenience, nearly the entire mainnet infrastructure (wallets, APIs, bridge
 * Testnet bridge: https://bridge.ton.org/?testnet=true
 * Testnet dTON GraphQL: https://testnet.dton.io/
 
-## Some third parties
+## TON Ecosystem Services Testnet
 
+### Wallets
 * To switch to [Tonkeeper's testnet](https://tonkeeper.com/), tap the version 5 times in the settings.
 * Testnet CryptoBot: https://t.me/CryptoTestnetBot
+* Special link for TON Space Testnet: https://t.me/wallet/start?startapp=tonspace_settings
+* https://multisig.ton.org/?testnet=true
+
+### Explorers 
+
+* https://testnet.tonscan.org
+* https://testnet.tonviewer.com
+* https://test-explorer.toncoin.org
+* https://tonsandbox.com/explorer
+* https://testnet.ton.cx
+
+### Other Services
+* https://minter.ton.org/?testnet=true
+* https://dns.ton.org/?testnet=true
+* https://vesting.ton.org/?testnet=true
+
+* https://teststaking.xyz
+* https://testnet.getgems.io
+* https://app.hipo.finance/#/network=testnet/
+
+* https://testnet-elections.toncenter.com/getValidationCycles?limit=2&return_participants=true
+
+

--- a/docs/v3/guidelines/dapps/apis-sdks/api-types.md
+++ b/docs/v3/guidelines/dapps/apis-sdks/api-types.md
@@ -4,6 +4,11 @@
 
 - [TON HTTP API](/v3/guidelines/dapps/apis-sdks/ton-http-apis) — API that allows to work with the _indexed blockchain information_.
 - [TON ADNL API](/v3/guidelines/dapps/apis-sdks/ton-adnl-apis) — secure API to communicate with TON, based on ADNL protocol.
+  
+:::tip TON Infrastructure Status
+* [status.toncenter](https://status.toncenter.com/) - various statistics of nodes activity during the last hour.
+* [Tonstat.us](https://tonstat.us/) - a real-time Grafana, updated every 5 minutes.
+:::
 
 ## Toncenter APIs
 - [TON Index](https://toncenter.com/api/v3/) - TON Index collects data from a full node to PostgreSQL database and provides convenient API to an indexed blockchain.

--- a/docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.md
+++ b/docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.md
@@ -1,5 +1,10 @@
 # TON API by GetBlock
 
+:::tip TON Infrastructure Status
+* [status.toncenter](https://status.toncenter.com/) - various statistics of nodes activity during the last hour.
+* [Tonstat.us](https://tonstat.us/) - a real-time Grafana, updated every 5 minutes.
+  :::
+
 This guide will cover essential steps in acquiring and using private RPC endpoints by GetBlock to access the TON blockchain.
 
 :::info

--- a/docs/v3/guidelines/dapps/apis-sdks/overview.md
+++ b/docs/v3/guidelines/dapps/apis-sdks/overview.md
@@ -27,6 +27,12 @@ which dumps raw and decode data into S3 bucket __s3://ton-blockchain-public-data
 * If you need to track on-chain data in near real-time you can run your own [Ton Node](/v3/documentation/infra/nodes/node-types) and launch [ton-etl](https://github.com/re-doubt/ton-etl/blob/main/README.md) or [ton-index-worker](https://github.com/toncenter/ton-index-worker).
 * [chainbase](https://docs.chainbase.com/catalog/Ton/Overview) comes with a set of raw and decoded tables with TON data. It allows to run SQL queries and fetch results via API.
 
+## Infrastructure Status
+
+* [status.toncenter](https://status.toncenter.com/) - various statistics of nodes activity during the last hour.
+* [Tonstat.us](https://tonstat.us/) - a real-time Grafana, updated every 5 minutes.
+
+
 ## See Also
 
 * [SDKs](/v3/guidelines/dapps/apis-sdks/sdk)

--- a/docs/v3/guidelines/dapps/apis-sdks/ton-adnl-apis.md
+++ b/docs/v3/guidelines/dapps/apis-sdks/ton-adnl-apis.md
@@ -1,14 +1,11 @@
 # TON ADNL API
 
-:::tip
-
 There are different ways to connect to blockchain:
 1. RPC data provider or another API: in most cases, you have to *rely* on its stability and security.
 2. **ADNL connection**: you're connecting to a [liteserver](/v3/guidelines/nodes/running-nodes/liteserver-node). They might be inaccessible, but with a certain level of validation (implemented in the library), cannot lie.
 3. Tonlib binary: you're connecting to liteserver as well, so all benefits and downsides apply, but your application also contains a dynamic-loading library compiled outside.
 4. Offchain-only. Such SDKs allow to create and serialize cells, which you can then send to APIs.
 
-:::
 
 Clients connect directly to Liteservers (nodes) using a binary protocol.
 

--- a/docs/v3/guidelines/dapps/apis-sdks/ton-http-apis.md
+++ b/docs/v3/guidelines/dapps/apis-sdks/ton-http-apis.md
@@ -1,14 +1,11 @@
 # TON HTTP-based APIs
 
-:::tip
-
 There are different ways to connect to blockchain:
 1. **RPC data provider or another API**: in most cases, you have to *rely* on its stability and security.
 2. ADNL connection: you're connecting to a [liteserver](/v3/guidelines/nodes/running-nodes/liteserver-node). It may be inaccessible, but with a certain level of validation (implemented in the library), it cannot lie.
 3. Tonlib binary: you're also connecting to a liteserver, so all benefits and downsides apply, but your application includes a dynamically-loaded library compiled externally.
 4. Offchain-only. Such SDKs allow the creation and serialization of cells, which can then be sent to APIs.
 
-:::
 
 ## Pros & Cons
 
@@ -18,12 +15,14 @@ There are different ways to connect to blockchain:
 - ❌ Simplified. It's not possible to receive information where you need an indexed TON API.
 - ❌ HTTP-Middleware.  You can't fully trust server responses unless the server augments blockchain data with [Merkle proofs](/v3/documentation/data-formats/tlb/proofs) to validate its authenticity.
 
-## Monitoring
 
-* [status.toncenter](https://status.toncenter.com/) - shows all full network nodes and validators active during the last hour, along with various statistics.
-* [Tonstat.us](https://tonstat.us/) - provides a real-time Grafana-based dashboard displaying the status of all TON-related APIs, with data updated every 5 minutes.
 
 ## RPC Nodes
+
+:::tip TON Infrastructure Status
+* [status.toncenter](https://status.toncenter.com/) - various statistics of nodes activity during the last hour.
+* [Tonstat.us](https://tonstat.us/) - a real-time Grafana, updated every 5 minutes.
+:::
 
 * [QuickNode](https://www.quicknode.com/chains/ton?utm_source=ton-docs) - Leading blockchain node provider offering the fastest access with smart DNS routing for optimized global reach and load-balanced scalability.
 * [Chainstack](https://chainstack.com/build-better-with-ton/) — RPC nodes and indexer in multiple regions with geo and load balancing.


### PR DESCRIPTION
- Added Testnet Services Links for https://docs.ton.org/v3/documentation/smart-contracts/getting-started/testnet
- Highlighted TON Infrusrtucture dashboards for API and Nodes Monitor