### PR TITLE
Update docs for Tolk v0.10

### DIFF
--- a/docs/v3/documentation/smart-contracts/tolk/changelog.md
+++ b/docs/v3/documentation/smart-contracts/tolk/changelog.md
@@ -3,6 +3,16 @@
 When new versions of Tolk are released, they will be mentioned here.
 
 
+## v0.10
+
+1. Fixed-width integers: `int32`, `uint64`, etc. [Details](https://github.com/ton-blockchain/ton/pull/1559)
+2. Type `coins` and function `ton("0.05")`
+3. `bytesN` and `bitsN` types (backed by slices at TVM level)
+4. Replace `"..."c` postfixes with `stringCrc32("...")` functions
+5. Support `0b...` number literals along with `0x...`
+6. Trailing comma support
+
+
 ## v0.9
 
 1. Nullable types `int?`, `cell?`, etc.; null safety

--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx
@@ -313,6 +313,120 @@ fun send(msg: cell) {
 
 
 <h3 className="cmp-func-tolk-header">
+  ✅ String postfixes removed, compile-time functions introduced
+</h3>
+
+Tolk removes the old FunC-style string postfixes (`"..."c`, etc.) in favor of a **clearer and more flexible approach**.
+
+<table className="cmp-func-tolk-table">
+    <thead>
+    <tr>
+        <th>FunC</th>
+        <th>Tolk</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td><code>{'"..."c'}</code></td>
+        <td><code>{'stringCrc32("...")'}</code></td>
+    </tr>
+    <tr>
+        <td>—</td>
+        <td><code>{'stringCrc16("...")'}</code></td>
+    </tr>
+    <tr>
+        <td><code>{'"..."H'}</code></td>
+        <td><code>{'stringSha256("...")'}</code></td>
+    </tr>
+    <tr>
+        <td><code>{'"..."h'}</code></td>
+        <td><code>{'stringSha256_32("...")'}</code></td>
+    </tr>
+    <tr>
+        <td><code>{'"..."a'}</code></td>
+        <td><code>{'stringAddressToSlice("...")'}</code></td>
+    </tr>
+    <tr>
+        <td><code>{'"..."s'}</code></td>
+        <td><code>{'stringHexToSlice("...")'}</code></td>
+    </tr>
+    <tr>
+        <td><code>{'"..."u'}</code></td>
+        <td><code>{'stringToBase256("...")'}</code></td>
+    </tr>
+    </tbody>
+</table>
+
+These functions:
+* compile-time only
+* for constant strings only
+* can be used in constant initialization
+
+```tolk
+// type will be `slice`
+const BASIC_ADDR = stringAddressToSlice("EQDKbjIcfM6ezt8KjKJJLshZJJSqX7XOA4ff-W72r5gqPrHF");
+
+// return type will be `int`
+fun minihashDemo() {
+    return stringSha256_32("transfer(slice, int)");
+}
+```
+
+The naming highlights, that these functions have "arrived" from string postfixes and operate on string values.
+Remember, that at runtime, there are no strings, only slices.
+
+
+<h3 className="cmp-func-tolk-header">
+  ✅ Trailing comma support
+</h3>
+
+Tolk now supports trailing commas in the following contexts:
+* tensors
+* tuples
+* function calls
+* function parameters
+
+```tolk
+var items = (
+    totalSupply,
+    verifiedCode,
+    validatorsList,
+);
+```
+
+Note, that `(5)` is not a tensor, it's just integer `5` in parentheses.
+With a trailing comma `(5,)` it's still `(5)`.
+
+
+<h3 className="cmp-func-tolk-header">
+  ✅ Function `ton("...")` for human-readable amounts of toncoins
+</h3>
+
+<table className="cmp-func-tolk-table">
+    <thead>
+    <tr>
+        <th>FunC</th>
+        <th>Tolk</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td><code>{'int cost = 50000000;'}</code></td>
+        <td><code>{'val cost = ton("0.05");'}</code></td>
+    </tr>
+    <tr>
+        <td><code>{'const ONE_TON = 1000000000;'}</code></td>
+        <td><code>{'const ONE_TON = ton("1");'}</code></td>
+    </tr>
+    </tbody>
+</table>
+
+Function `ton()` only accepts constant values (e.g., `ton(some_var)` is invalid).
+Its type is `coins` (not `int`!), although it's still a regular `int` from the TVM point of view.
+Arithmetic over `coins` degrade to `int` (for example, `cost << 1` is valid, `cost + ton("0.02")` also).
+
+
+<h3 className="cmp-func-tolk-header">
   ✅ Changes in the type system
 </h3>
 
@@ -328,6 +442,9 @@ We have the following types:
 - tensor `(T1, T2, ...)`
 - callables `(TArgs) -> TResult`
 - nullable types `T?`, compile-time null safety
+- `coins` and function `ton("0.05")`
+- `int32`, `uint64`, and other fixed-width integers (just int at TVM) [details](https://github.com/ton-blockchain/ton/pull/1559)
+- `bytesN` and `bitsN`, similar to `intN` (backed by slices at TVM)
 - `void` (more canonical to be named `unit`, but `void` is more reliable)
 - `self`, to make chainable methods, described below; actually it's not a type, it can only occur instead of return type of a function
 - `never` (an always-throwing function returns `never`, for example; an "impossible type" is also `never`)

--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.md
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.md
@@ -41,6 +41,7 @@ get currentCounter(): int { ... }
     - `do ... until (cond)` → `do ... while (!cond)`
     - `elseif` → `else if`
     - `ifnot (cond)` → `if (!cond)`
+    - `"..."c` → `stringCrc32("...")` (and other postfixes also)
 7. A function can be called even if declared below; forward declarations not needed; the compiler at first does parsing, and then it does symbol resolving; there is now an AST representation of source code
 8. stdlib functions renamed to ~~verbose~~ clear names, camelCase style; it's now embedded, not downloaded from GitHub; it's split into several files; common functions available always, more specific available with `import "@stdlib/tvm-dicts"`, IDE will suggest you; here is [a mapping](/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib)
 9. No `~` tilda methods; `cs.loadInt(32)` modifies a slice and returns an integer; `b.storeInt(x, 32)` modifies a builder; `b = b.storeInt()` also works, since it not only modifies, but returns; chained methods work identically to JS, they return `self`; everything works exactly as expected, similar to JS; no runtime overhead, exactly same Fift instructions; custom methods are created with ease; tilda `~` does not exist in Tolk at all; [more details here](/v3/documentation/smart-contracts/tolk/tolk-vs-func/mutability)
@@ -48,6 +49,7 @@ get currentCounter(): int { ... }
 11. `bool` type support
 12. Indexed access `tensorVar.0` and `tupleVar.0` support
 13. Nullable types `T?`, null safety, smart casts, operator `!`
+14. Trailing comma is supported
 
 #### Tooling around
 - JetBrains plugin exists

--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.md
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.md
@@ -54,7 +54,7 @@ or they were very uncommon in practice.
 | block_lt                 | getCurrentBlockLogicalTime              |                 |
 | cell_hash                | cellHash                                |                 |
 | slice_hash               | sliceHash                               |                 |
-| string_hash              | stringHash                              |                 |
+| string_hash              | sliceBitsHash                           |                 |
 | check_signature          | isSignatureValid                        |                 |
 | check_data_signature     | isSliceSignatureValid                   |                 |
 | compute_data_size        | calculateCellSizeStrict                 |                 |


### PR DESCRIPTION
## Description

Update documentation for Tolk Language according to changes in Tolk v0.10.

Main PR to ton-blockchain: https://github.com/ton-blockchain/ton/pull/1559

Closes #1039

### Notable changes in Tolk v0.10:

1. Fixed-size integer types: `int32`, `uint64`, etc.
2. Type `coins` and function `ton("0.05")`
3. Types `bytesN` and `bitsN` (backed by slices at TVM level)
4. Replace `"..."c` postfixes with `stringCrc32("...")` functions
5. Support `0b...` number literals along with `0x...`
6. Trailing comma support

## Checklist

- [x] I have created an issue.
- [x] I am working on content that aligns with the [Style guide](https://docs.ton.org/v3/contribute/style-guide/).
- [x] I have reviewed and formatted the content according to [Content standardization](https://docs.ton.org/v3/contribute/content-standardization/).
- [x] I have reviewed and formatted the text in the article according to [Typography](https://docs.ton.org/v3/contribute/typography/).
