### PR TITLE
Fix TL schema links on proofs verifying page

### DIFF
--- a/docs/v3/documentation/data-formats/tlb/proofs.mdx
+++ b/docs/v3/documentation/data-formats/tlb/proofs.mdx
@@ -25,7 +25,7 @@ Let's say we know a Block ID:
 ```json
 <TL BlockIdExt [wc=-1, shard=-9223372036854775808, seqno=31220993, root_hash=51ed3b9e728e7c548b15a5e5ce988b4a74984c3f8374f3f1a52c7b1f46c26406, file_hash=d4fcdc692de1a252deb379cd25774842b733e6a96525adf82b8ffc41da667bf5] >
 ```
-And we ask a Liteserver for a Header for this block. Liteserver [response](https://github.com/ton-blockchain/ton/blob/24dc184a2ea67f9c47042b4104bbb4d82289fac1/tl/generate/scheme/lite_api.tl#L35)
+And we ask a Liteserver for a Header for this block. Liteserver [response](https://github.com/ton-blockchain/ton/blob/v2025.03/tl/generate/scheme/lite_api.tl#L36)
 contains a `header_proof` boc.
 
 <details>
@@ -283,7 +283,7 @@ Since we trust this Cell we can trust the Shard Block data (`ShardStateUnsplit` 
 
 Let's prove state of account `EQBvW8Z5huBkMJYdnfAEM5JqTNkuWX3diqYENkWsIL0XggGG` for the same Masterchain block we started with in the article beginning.
 
-Liteserver [response](https://github.com/ton-blockchain/ton/blob/24dc184a2ea67f9c47042b4104bbb4d82289fac1/tl/generate/scheme/lite_api.tl#L37) contains masterchain block id _(must be the same we sent to ls)_, shard block id and `shard_proof` boc which we should check as described above,
+Liteserver [response](https://github.com/ton-blockchain/ton/blob/v2025.03/tl/generate/scheme/lite_api.tl#L38) contains masterchain block id _(must be the same we sent to ls)_, shard block id and `shard_proof` boc which we should check as described above,
 `proof` boc, and `state` boc.
 
 
@@ -564,7 +564,7 @@ Now we can trust this account state data.
 
 ## Account transactions
 
-For [liteServer.getTransactions](https://github.com/ton-blockchain/ton/blob/24dc184a2ea67f9c47042b4104bbb4d82289fac1/tl/generate/scheme/lite_api.tl#L71) request we must provide `lt` and `hash` of the transaction to start from.
+For [liteServer.getTransactions](https://github.com/ton-blockchain/ton/blob/v2025.03/tl/generate/scheme/lite_api.tl#L94) request we must provide `lt` and `hash` of the transaction to start from.
 If we want to get last account transactions we can get them from `ShardAccount` (described above) and trust these `lt` and `hash`.
 
 When we receive transactions from the Liteserver we get boc with amount of transactions we asked roots. Each root is a Cell, which we should deserialize according to the [Transaction](https://github.com/ton-blockchain/ton/blob/24dc184a2ea67f9c47042b4104bbb4d82289fac1/crypto/block/block.tlb#L263-L269) TLB Scheme.
@@ -708,8 +708,8 @@ you check proofs similar but in that case you really need to compare hashes.
 
 ## Config
 
-Let's ask a Liteserver for 1, 4, 5, 7, 8 and 15 [Config params](https://github.com/ton-blockchain/ton/blob/master/tl/generate/scheme/lite_api.tl#L101) (for [liteServer.getConfigAll](https://github.com/ton-blockchain/ton/blob/master/tl/generate/scheme/lite_api.tl#L100) where you get all params, the proof verifying is the same).
-The [response](https://github.com/ton-blockchain/ton/blob/master/tl/generate/scheme/lite_api.tl#L54) contains `state_proof` and `config_proof`.
+Let's ask a Liteserver for 1, 4, 5, 7, 8 and 15 [Config params](https://github.com/ton-blockchain/ton/blob/v2025.03/tl/generate/scheme/lite_api.tl#L101) (for [liteServer.getConfigAll](https://github.com/ton-blockchain/ton/blob/v2025.03/tl/generate/scheme/lite_api.tl#L100) where you get all params, the proof verifying is the same).
+The [response](https://github.com/ton-blockchain/ton/blob/v2025.03/tl/generate/scheme/lite_api.tl#L54) contains `state_proof` and `config_proof`.
 
 First, let's deserialize the `state_proof` Cell:
 

--- a/docs/v3/documentation/data-formats/tlb/proofs.mdx
+++ b/docs/v3/documentation/data-formats/tlb/proofs.mdx
@@ -573,7 +573,7 @@ For the first transaction cell we should check that its hash matches with `last_
 ## Block transactions
 
 Let's ask a Liteserver for transactions belong to the block we started with in the article beginning.
-LiteServer [response](https://github.com/ton-blockchain/ton/blob/master/tl/generate/scheme/lite_api.tl#L46) contains `ids` field with transactions and `proof` boc. First, let's deserialize the `proof`:
+LiteServer [response](https://github.com/ton-blockchain/ton/blob/v2025.03/tl/generate/scheme/lite_api.tl#L47) contains `ids` field with transactions and `proof` boc. First, let's deserialize the `proof`:
 
 ```json
 280[0351ED3B9E728E7C548B15A5E5CE988B4A74984C3F8374F3F1A52C7B1F46C264060016] -> {
@@ -701,15 +701,15 @@ assert block_tr.get_hash(0) == tr['hash']
 :::note
 
 In this example it was unnecessary to check `ids` field, we could just take transactions from the account block.
-But when you request the [liteServer.listBlockTransactionsExt](https://github.com/ton-blockchain/ton/blob/master/tl/generate/scheme/lite_api.tl#L80) method
+But when you request the [liteServer.listBlockTransactionsExt](https://github.com/ton-blockchain/ton/blob/v2025.03/tl/generate/scheme/lite_api.tl#L48) method
 you check proofs similar but in that case you really need to compare hashes.
 
 :::
 
 ## Config
 
-Let's ask a Liteserver for 1, 4, 5, 7, 8 and 15 [Config params](https://github.com/ton-blockchain/ton/blob/master/tl/generate/scheme/lite_api.tl#L83) (for [liteServer.getConfigAll](https://github.com/ton-blockchain/ton/blob/master/tl/generate/scheme/lite_api.tl#L82) where you get all params, the proof verifying is the same).
-The [response](https://github.com/ton-blockchain/ton/blob/master/tl/generate/scheme/lite_api.tl#L53) contains `state_proof` and `config_proof`.
+Let's ask a Liteserver for 1, 4, 5, 7, 8 and 15 [Config params](https://github.com/ton-blockchain/ton/blob/master/tl/generate/scheme/lite_api.tl#L101) (for [liteServer.getConfigAll](https://github.com/ton-blockchain/ton/blob/master/tl/generate/scheme/lite_api.tl#L100) where you get all params, the proof verifying is the same).
+The [response](https://github.com/ton-blockchain/ton/blob/master/tl/generate/scheme/lite_api.tl#L54) contains `state_proof` and `config_proof`.
 
 First, let's deserialize the `state_proof` Cell:
 

--- a/docs/v3/documentation/data-formats/tlb/proofs.mdx
+++ b/docs/v3/documentation/data-formats/tlb/proofs.mdx
@@ -13,10 +13,10 @@ This article describes advanced examples of verifying proofs from Liteservers.
 
 It's important to check any data you receive from a node for trustless interaction with the blockchain.
 However, the article covers only part of trustless communication with Liteserver,
-because its assumed that you verified the Block hash you received from a Liteserver (or from anyone else).
+because it's assumed that you verified the Block hash you received from a Liteserver (or from anyone else).
 Block hash verifying is more advanced, because you need to sync key blocks and (or) check block signatures,
-and will be described in the other article in the future. But anyway even using only these examples
-you're decreasing probability that Liteserver will send you the wrong data that you will believe.
+and will be described in another article in the future. But anyway even using only these examples
+you're decreasing the probability that Liteserver will send you the wrong data that you will believe.
 
 
 ## Block Header
@@ -39,7 +39,7 @@ b5ee9c72010207010001470009460351ed3b9e728e7c548b15a5e5ce988b4a74984c3f8374f3f1a5
 ```
 </details>
 
-After boc deserialization, we got Cell:
+After boc deserialization, we get a Cell:
 
 ```json
 280[0351ED3B9E728E7C548B15A5E5CE988B4A74984C3F8374F3F1A52C7B1F46C264060016] -> {
@@ -53,7 +53,7 @@ After boc deserialization, we got Cell:
 	}
 }
 ```
-that we should deserialize according to the Block [Tlb scheme](https://github.com/ton-blockchain/ton/blob/24dc184a2ea67f9c47042b4104bbb4d82289fac1/crypto/block/block.tlb#L442):
+that we should deserialize according to the Block [TLB scheme](https://github.com/ton-blockchain/ton/blob/24dc184a2ea67f9c47042b4104bbb4d82289fac1/crypto/block/block.tlb#L442):
 
 ```python
 {
@@ -833,7 +833,7 @@ We need to compare Hash_1 of this Merkle Proof only reference with the hash we g
 ```python
 state_hash = check_block_header_proof(state_proof[0], block.root_hash, True)
 if config_proof[0].get_hash(0) != state_hash:
-    raise LiteClientError('hashes mismach')
+    raise LiteClientError('hashes mismatch')
 ```
 
 Now, let's deserialize the Cell according to the `ShardStateUnsplit` scheme:


### PR DESCRIPTION
## Description

Some Github TL schema links on the "Proofs verifying" page had the wrong line numbers because they link to the master branch, which changes continuously. Change all references on this page to the latest v2025.v3 tag and fix line number references.

Closes #1073.

## Checklist

- [x] I have created an issue.
- [x] I am working on content that aligns with the [Style guide](https://docs.ton.org/v3/contribute/style-guide/).
- [x] I have reviewed and formatted the content according to [Content standardization](https://docs.ton.org/v3/contribute/content-standardization/).
- [x] I have reviewed and formatted the text in the article according to [Typography](https://docs.ton.org/v3/contribute/typography/).
