### PR TITLE
docs: add Russian language in menu

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,7 +8,7 @@ const getEnvLangConfig = () => {
 
   const langArray = process.env.TARGET_LANGS
     ? process.env.TARGET_LANGS.split(",")
-   : ["mandarin"];
+    : ["mandarin", "ru"];
   // : ["mandarin", "ru", "ko", "pl", "uk", "ja"];
 
   const locales = Array.from(new Set([defaultLocale, ...langArray]));


### PR DESCRIPTION
## Description

Add Ru in menu without env config

Closes issue: https://github.com/ton-community/ton-docs/issues/1098

## Checklist

- [x] I have created an issue.
- [x] I am working on content that aligns with the [Style guide](https://docs.ton.org/v3/contribute/style-guide/).
- [x] I have reviewed and formatted the content according to [Content standardization](https://docs.ton.org/v3/contribute/content-standardization/).
- [x] I have reviewed and formatted the text in the article according to [Typography](https://docs.ton.org/v3/contribute/typography/).
