### PR TITLE
feat: add standalone page for Tact

### DIFF
--- a/docs/v3/documentation/smart-contracts/overview.mdx
+++ b/docs/v3/documentation/smart-contracts/overview.mdx
@@ -2,7 +2,10 @@ import Button from '@site/src/components/button'
 
 # Introduction
 
-Smart contract creation, development, and deployment on TON Blockchain leverages the [FunC programming language](/v3/documentation/smart-contracts/overview#-func) and [TON Virtual Machine (TVM)](/v3/documentation/smart-contracts/overview#ton-virtual-machine-tvm).
+Smart contract creation, development, and deployment on TON Blockchain leverages the [TON Virtual Machine (TVM)](/v3/documentation/smart-contracts/overview#ton-virtual-machine-tvm) and one of the following programming languages:
+
+* [Tact](/v3/documentation/smart-contracts/overview#-tact)
+* [FunC](/v3/documentation/smart-contracts/overview#-func)
 
 ## Quick Start: Your First Smart Contract
 
@@ -144,8 +147,15 @@ View some of the selected projects: [Tact in production](https://github.com/tact
 
 [^1]: The "unique code" means that each contract in the data sample has at least one TVM instruction that differs from the other contracts, excluding many preprocessed wallets with everything inlined — even seqno and a public key for signature verification!
 
-<Button href="https://tact-lang.org/"
+<Button href="/v3/documentation/smart-contracts/tact"
         colorType={'primary'} sizeType={'sm'}>
+
+Read more
+
+</Button>
+
+<Button href="https://tact-lang.org/"
+        colorType={'secondary'} sizeType={'sm'}>
 
 Official Site
 

--- a/docs/v3/documentation/smart-contracts/tact.mdx
+++ b/docs/v3/documentation/smart-contracts/tact.mdx
@@ -1,0 +1,183 @@
+---
+title: Tact Language
+---
+
+import Button from '@site/src/components/button';
+
+# Tact Language
+
+Tact is a fresh programming language for TON Blockchain, focused on efficiency and ease of development. It is a good fit for complex smart contracts, quick onboarding and rapid prototyping.
+
+Developed by [TON Studio](https://tonstudio.io), powered by the community — at the start of 2025, the number of _unique code_[^1] contracts deployed on the mainnet reached almost 28 thousand, of which about 33% were written in Tact. You can view some selected projects here: [Tact in production](#tact-in-production).
+
+[^1]: The "unique code" means that each contract in the data sample has at least one TVM instruction that differs from the other contracts, excluding many preprocessed wallets with everything inlined — even seqno and a public key for signature verification!
+
+Tact has undergone a comprehensive security audit by [Trail of Bits](https://www.trailofbits.com), a leading Web3 security firm.
+
+<Button href="https://ide.ton.org/"
+        colorType={'primary'} sizeType={'sm'}>
+
+Try it online!
+
+</Button>
+
+<Button href="https://docs.tact-lang.org/"
+        colorType={'secondary'} sizeType={'sm'}>
+
+Tact Documentation
+
+</Button>
+
+<Button href="https://github.com/tact-lang/awesome-tact"
+        colorType="secondary" sizeType={'sm'}>
+
+Awesome Tact
+
+</Button>
+
+## Features
+
+The most prominent and distinctive features of Tact are:
+
+- Familiar and user-friendly TypeScript-like syntax.
+- Strong static type system with built-in [Structs], [Messages], and [maps], among others.
+- First-class [maps] support, with many methods and a convenient [`foreach` statement][foreach] for traversing.
+- Automatic (de)serialization of incoming messages and data structures.
+- Automatic routing of [internal, external, and bounced messages][recvfun].
+- Automatic handling of message types, including [binary, text, and fallback slices][recv].
+- No boilerplate functions for [sending messages] and deploying child contracts.
+- Reusable behaviors through [traits].
+- Support for low-level programming with [`asm` functions][asmfun].
+- Generation of [single-file TypeScript wrappers] for convenient interactions with compiled contracts, which include:
+  - Type definitions for [Structs] and [Messages] observable in the [compilation report].
+  - Corresponding `storeStructureName()` and `loadStructureName()` functions for (de)serialization.
+  - All global and contract-level constants.
+  - Bi-directional records of exit codes: from their names to numbers and vice versa.
+  - Opcodes of all [Messages].
+  - A contract wrapper class with various helper functions for initialization, deployment, and message exchange.
+- Rich [standard library][stdlib].
+- Extensive [documentation].
+- Robust [tooling](#tooling).
+- ...and there's much more to come!
+
+[Structs]: https://docs.tact-lang.org/book/structs-and-messages#structs
+[Messages]: https://docs.tact-lang.org/book/structs-and-messages#messages
+[maps]: https://docs.tact-lang.org/book/maps
+[foreach]: https://docs.tact-lang.org/book/statements#foreach-loop
+[recv]: https://docs.tact-lang.org/book/receive/
+[recvfun]: https://docs.tact-lang.org/book/contracts/#receiver-functions
+[sending messages]: https://docs.tact-lang.org/book/send/#message-sending-functions
+[traits]: https://docs.tact-lang.org/book/types/#traits
+[asmfun]: https://docs.tact-lang.org/book/assembly-functions/
+[single-file TypeScript wrappers]: https://docs.tact-lang.org/book/compile/#wrap
+[compilation report]: https://docs.tact-lang.org/book/compile/#report
+[stdlib]: https://docs.tact-lang.org/ref/
+[documentation]: https://docs.tact-lang.org/
+
+## Security
+
+- [Security audit of Tact by the Trail of Bits (2025, PDF)](https://github.com/trailofbits/publications/blob/master/reviews/2025-01-ton-studio-tact-compiler-securityreview.pdf)
+  - Backup link: [PDF Report](https://github.com/tact-lang/website/blob/416073ed4056034639de257cb1e2815227f497cb/pdfs/2025-01-ton-studio-tact-compiler-securityreview.pdf)
+
+## Tact in production
+
+Some selected software and applications based on contracts written in Tact, deployed in production, and consumed by end users:
+
+###### Open source or source available
+
+- [Proof of Capital](https://github.com/proof-of-capital/TON) - [Proof of Capital](https://proofofcapital.org/) is a market-making smart contract that protects interests of all holders.
+  - See the [security audit report](https://raw.githubusercontent.com/nowarp/public-reports/master/2025-01-proof-of-capital.pdf) by [Nowarp](https://nowarp.io).
+
+###### Closed source
+
+- [Tradoor](https://tradoor.io) - Fast and social DEX on TON.
+  - See the [security audit report](https://www.tonbit.xyz/reports/Tradoor-Smart-Contract-Audit-Report-Summary.pdf) by TonBit.
+- [PixelSwap](https://www.pixelswap.io) - First modular and upgradeable DEX on TON.
+  - See the [security audit report](https://github.com/trailofbits/publications/blob/master/reviews/2024-12-pixelswap-dex-securityreview.pdf) by Trail of Bits.
+- [GasPump](https://gaspump.tg) - TON memecoin launchpad and trading platform.
+
+See [Tact in production](https://github.com/tact-lang/awesome-tact#tact-in-production-) on the Awesome Tact list.
+
+## Installation
+
+### Compiler
+
+The Tact compiler is distributed as an [NPM package](https://www.npmjs.com/package/@tact-lang/compiler) bundled with the [Tact standard library](https://docs.tact-lang.org/ref/).
+
+The recommended Node.js version is 22 or higher, while the minimum version is 18.
+
+Use your favorite package manager to install it into a Node.js project:
+
+```bash
+# yarn is recommended, but not required
+yarn add @tact-lang/compiler
+
+# you can also use npm
+npm i @tact-lang/compiler@latest
+
+# or pnpm
+pnpm add @tact-lang/compiler
+
+# or bun
+bun add @tact-lang/compiler
+```
+
+Alternatively, you can install it globally as such:
+
+```bash
+npm i -g @tact-lang/compiler
+```
+
+It will make the `tact` compiler available on your PATH, as well as:
+
+- a convenient `unboc` disassembler of a contract's code compiled into a [Bag of Cells](/v3/documentation/data-formats/tlb/cell-boc#bag-of-cells) `.boc` format.
+- a formatter `tact-fmt`, which can format or check the formatting of individual Tact files and directories.
+
+### Tooling
+
+###### Extensions and plugins
+
+- [VS Code extension](https://marketplace.visualstudio.com/items?itemName=tonstudio.vscode-tact) - Powerful and feature-rich extension for Visual Studio Code (VSCode) and VSCode-based editors like VSCodium, Cursor, Windsurf, and others.
+  - Get it on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=tonstudio.vscode-tact).
+  - Get it on the [Open VSX Registry](https://open-vsx.org/extension/tonstudio/vscode-tact).
+  - Or install from the [`.vsix` files in nightly releases](https://github.com/tact-lang/tact-language-server/releases).
+- [Language Server (LSP Server)](https://github.com/tact-lang/tact-language-server) - Supports Sublime Text, (Neo)Vim, Helix, and other editors with LSP support.
+- [tact.vim](https://github.com/tact-lang/tact.vim) - Vim 8+ plugin.
+- [tact-sublime](https://github.com/tact-lang/tact-sublime) - Sublime Text 4 package.
+  - Get it on the [Package Control](https://packagecontrol.io/packages/Tact).
+
+###### Security
+
+- [Misti](https://github.com/nowarp/misti) - Static smart contract analyzer.
+- [TON Symbolic Analyzer (TSA)](https://github.com/espritoxyz/tsa) - Static smart contract analysis tool based on symbolic execution.
+
+###### Utility
+
+- Formatter (`tact-fmt`) — The official formatter. It ships with the Tact Language Server, VS Code extension, and as a standalone binary with the compiler. You can invoke it by running `npx tact-fmt` in your Tact projects.
+- BoC Disassembler (`unboc`) — Disassembler for [`.boc`](http://localhost:3000/v3/documentation/data-formats/tlb/cell-boc#bag-of-cells) files. Ships as a standalone binary with the compiler. You can invoke it by running `npx unboc` in your Tact projects.
+
+### Getting started
+
+For a quick start, read the ["Let's start!"](https://docs.tact-lang.org/#start) mini-guide in the Tact documentation. It uses the [Blueprint](https://github.com/ton-community/blueprint) development environment for writing, testing, and deploying smart contracts on TON Blockchain.
+
+If you want more manual control, use [tact-template](https://github.com/tact-lang/tact-template). It's a ready-to-use template with the development environment set up, including the Tact compiler with TypeScript + Jest, a local TON emulator, AI-based editor support, and examples of how to run tests.
+
+```shell
+git clone --depth 1 https://github.com/tact-lang/tact-template
+```
+
+## Community
+
+If you can’t find the answer in the [docs](https://docs.tact-lang.org), or you’ve tried to do some local testing and it still didn’t help — don’t hesitate to reach out to Tact’s flourishing community:
+
+- [`@tactlang` on Telegram](https://t.me/tactlang) - Main community chat and discussion group.
+- [`@tactlang_ru` on Telegram](https://t.me/tactlang_ru) _(Russian)_
+- [`@tact_kitchen` on Telegram](https://t.me/tact_kitchen) - Channel with updates from the team.
+- [`@tact_language` on X/Twitter](https://x.com/tact_language)
+- [`tact-lang` organization on GitHub](https://github.com/tact-lang)
+- [`@ton_studio` on Telegram](https://t.me/ton_studio)
+- [`@thetonstudio` on X/Twitter](https://x.com/thetonstudio)
+
+## Contributing
+
+Contributions are welcome! To help develop the compiler, see the [contributing guide](https://github.com/tact-lang/tact/blob/main/dev-docs/CONTRIBUTING.md).

--- a/docs/v3/documentation/smart-contracts/tact.mdx
+++ b/docs/v3/documentation/smart-contracts/tact.mdx
@@ -1,10 +1,10 @@
 ---
-title: Tact Language
+title: Tact language
 ---
 
 import Button from '@site/src/components/button';
 
-# Tact Language
+# Tact language
 
 Tact is a fresh programming language for TON Blockchain, focused on efficiency and ease of development. It is a good fit for complex smart contracts, quick onboarding and rapid prototyping.
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/v3/documentation/smart-contracts/overview.mdx
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/v3/documentation/smart-contracts/overview.mdx
@@ -2,7 +2,10 @@ import Button from '@site/src/components/button'
 
 # Введение
 
-Создание, разработка и деплой смарт-контрактов на блокчейне TON реализуется с помощью [языка программирования FunC](/v3/documentation/smart-contracts/overview#-func) и [виртуальной машины TON (TVM)](/v3/documentation/smart-contracts/overview#ton-virtual-machine-tvm).
+Создание, разработка и деплой смарт-контрактов на блокчейне TON реализуется с помощью [виртуальной машины TON (TVM)](/v3/documentation/smart-contracts/overview#ton-virtual-machine-tvm) и одного из следующих языков программирования:
+
+* [Tact](/v3/documentation/smart-contracts/overview#-tact)
+* [FunC](/v3/documentation/smart-contracts/overview#-func)
 
 ## Быстрый старт: ваш первый смарт-контракт
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/v3/documentation/smart-contracts/overview.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/v3/documentation/smart-contracts/overview.mdx
@@ -2,7 +2,10 @@ import Button from '@site/src/components/button'
 
 # 简介
 
-TON区块链上的智能合约创建、开发和部署利用[FunC编程语言](/v3/documentation/smart-contracts/overview#-func) 和 [TON虚拟机（TVM）](/v3/documentation/smart-contracts/overview#ton-virtual-machine-tvm)。
+TON区块链上的智能合约是利用[TON虚拟机（TVM）]（/v3/documentation/smart-contracts/overview#ton-virtual-machine-tvm）和以下编程语言之一创建、开发和部署的：
+
+* [Tact](/v3/documentation/smart-contracts/overview#-tact)
+* [FunC](/v3/documentation/smart-contracts/overview#-func)
 
 ## 快速开始：您的第一个智能合约
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
-    "spell": "cspell --show-suggestions",
+    "spell": "cspell '**/*.md' '**/.mdx' --show-suggestions --exclude build",
     "postinstall": "husky"
   },
   "dependencies": {

--- a/sidebars/documentation.js
+++ b/sidebars/documentation.js
@@ -64,11 +64,7 @@ module.exports = [
           'v3/documentation/smart-contracts/shards/infinity-sharding-paradigm',
         ],
       },
-      {
-        type: 'link',
-        label: 'Tact language',
-        href: 'https://docs.tact-lang.org',
-      },
+      'v3/documentation/smart-contracts/tact',
       {
         type: 'category',
         label: 'Tolk language',


### PR DESCRIPTION
## Description

<!-- Brief description of the changes introduced in this pull request. Include any relevant issue numbers or links. -->

Towards #983 — adds more visibility for Tact, but doesn't cover [Blueprint SDK](https://docs.ton.org/v3/documentation/smart-contracts/getting-started/javascript), [IDE Plugins](https://docs.ton.org/v3/documentation/smart-contracts/getting-started/ide-plugins), and other pages.

## Checklist

- [x] I have created an issue: #983
- [x] I am working on content that aligns with the [Style guide](https://docs.ton.org/v3/contribute/style-guide/).
- [x] I have reviewed and formatted the content according to [Content standardization](https://docs.ton.org/v3/contribute/content-standardization/).
- [x] I have reviewed and formatted the text in the article according to [Typography](https://docs.ton.org/v3/contribute/typography/).

## Preview

![image](https://github.com/user-attachments/assets/782c6314-383f-47b6-877d-8b9ee2dffcb4)
