### PR TITLE
Fix script path for MyTonCtrl uninstallation

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -314,11 +314,24 @@
     "zerostate",
     "decentralised",
     "colour",
-    "analyse"
+    "analyse",
     "ensurepip",
     "Buildx",
     "underperforming",
-    "blackhole"
+    "blackhole",
+    "NVME",
+    "Gbit",
+    "Mbit",
+    "tulpn",
+    "Gbps",
+    "xlarge",
+    "adduser",
+    "usermod",
+    "mytonctrl",
+    "liteservers",
+    "liteserver",
+    "mytonctrl",
+    "mytoncore"
   ],
   "ignoreRegExpList": [
     "\\(#.*\\)",

--- a/docs/v3/guidelines/nodes/running-nodes/full-node.mdx
+++ b/docs/v3/guidelines/nodes/running-nodes/full-node.mdx
@@ -171,14 +171,14 @@ Otherwise, [check troubleshooting section](/v3/guidelines/nodes/nodes-troublesho
 
 Please wait until the `Local validator out of sync` status is less than 20 seconds.
 
-When a new node is started, even from a dump, it is important to wait up to 3 hours before the *out of sync* number begins to decrease. This delay occurs because the node must establish its place in the network and propagate its addresses through the DHT tables, among other processes.
+When a new node is started, even from a dump, it is important to wait up to 3 hours before the _out of sync_ number begins to decrease. This delay occurs because the node must establish its place in the network and propagate its addresses through the DHT tables, among other processes.
 
 ### Uninstall mytonctrl
 
 Download script and run it:
 
 ```bash
-sudo bash /usr/src/mytonctrl/uninstall.sh
+sudo bash /usr/src/mytonctrl/scripts/uninstall.sh
 ```
 
 ### Check mytonctrl owner


### PR DESCRIPTION
## Description

A small fix addition for uninstall.sh path => https://docs.ton.org/v3/guidelines/nodes/running-nodes/full-node

Closes https://github.com/ton-community/ton-docs/issues/1135.

## Checklist

- [X] I have created an issue.
- [X] I am working on content that aligns with the [Style guide](https://docs.ton.org/v3/contribute/style-guide/).
- [X] I have reviewed and formatted the content according to [Content standardization](https://docs.ton.org/v3/contribute/content-standardization/).
- [X] I have reviewed and formatted the text in the article according to [Typography](https://docs.ton.org/v3/contribute/typography/).
