### PR TITLE
fix: standardize "Toncenter" to "TON Center" across documentation

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -314,7 +314,7 @@
     "zerostate",
     "decentralised",
     "colour",
-    "analyse"
+    "analyse",
     "ensurepip",
     "Buildx",
     "underperforming",

--- a/docs/v3/guidelines/dapps/apis-sdks/api-keys.mdx
+++ b/docs/v3/guidelines/dapps/apis-sdks/api-keys.mdx
@@ -1,6 +1,6 @@
-import Feedback from '@site/src/components/Feedback';
+import Feedback from "@site/src/components/Feedback";
 
-# How to retrieve a Toncenter API key
+# How to retrieve a TON Center API key
 
 ## Overview
 
@@ -32,7 +32,6 @@ To update your subscription plan, follow these steps:
 
 ## Troubleshooting
 
-If the Toncenter mini app does not work properly, your Telegram app may be outdated. Try updating Telegram and try again.
+If the TON Center mini app does not work properly, your Telegram app may be outdated. Try updating Telegram and try again.
 
 <Feedback />
-

--- a/docs/v3/guidelines/dapps/apis-sdks/api-keys.mdx
+++ b/docs/v3/guidelines/dapps/apis-sdks/api-keys.mdx
@@ -1,4 +1,4 @@
-import Feedback from "@site/src/components/Feedback";
+import Feedback from '@site/src/components/Feedback';
 
 # How to retrieve a TON Center API key
 

--- a/docs/v3/guidelines/dapps/apis-sdks/api-types.md
+++ b/docs/v3/guidelines/dapps/apis-sdks/api-types.md
@@ -12,7 +12,7 @@ import Feedback from '@site/src/components/Feedback';
 * [Tonstat.us](https://tonstat.us/) - A real-time Grafana dashboard, updated every 5 minutes.
 :::
 
-## Toncenter APIs
+## TON Center APIs
 - [TON Index](https://toncenter.com/api/v3/) - Collects data from a full node into a PostgreSQL database and provides a convenient API for accessing indexed blockchain data.
 - [toncenter/v2](https://toncenter.com/) - Enables HTTP access to TON Blockchain, allowing developers to retrieve account and wallet information, look up blocks and transactions, send messages to the blockchain, call smart contract methods, and more.
 

--- a/docs/v3/guidelines/dapps/apis-sdks/ton-http-apis.md
+++ b/docs/v3/guidelines/dapps/apis-sdks/ton-http-apis.md
@@ -30,15 +30,15 @@ There are different ways to connect to TON Blockchain:
 * [Tatum](https://docs.tatum.io/reference/rpc-ton) — Offers TON RPC node access and developer tools in a simple interface.
 * [GetBlock nodes](https://getblock.io/nodes/ton/) — Enables developers to connect and test DApps using GetBlock’s nodes.
 * [TON access](https://www.orbs.com/ton-access/) - A public HTTP API for The Open Network (TON).
-* [Toncenter](https://toncenter.com/api/v2/) — A community-hosted project for quick API access. (Get an API key [@tonapibot](https://t.me/tonapibot))
-* [ton-node-docker](https://github.com/fmira21/ton-node-docker) - A Docker Full Node and Toncenter API.
+* [TON Center](https://toncenter.com/api/v2/) — A community-hosted project for quick API access. (Get an API key [@tonapibot](https://t.me/tonapibot))
+* [ton-node-docker](https://github.com/fmira21/ton-node-docker) - A Docker Full Node and TON Center API.
 * [toncenter/ton-http-api](https://github.com/toncenter/ton-http-api) — Allows you to run your own RPC node.
 * [nownodes.io](https://nownodes.io/nodes) — Provides full nodes and blockbook explorers via API.
 * [Chainbase](https://chainbase.com/chainNetwork/TON) — A node API and data infrastructure for TON.
 
 ## Indexer
 
-### Toncenter TON index
+### TON Center TON index
 
 Indexers allow you to list jetton wallets, NFTs, and transactions using filters, rather than retrieving only specific ones.
 

--- a/docs/v3/guidelines/dapps/asset-processing/jettons.md
+++ b/docs/v3/guidelines/dapps/asset-processing/jettons.md
@@ -137,7 +137,7 @@ This method returns the following data:
 | `jetton_wallet_code` | `cell`  |                      |
 
 
-You can also use the [Toncenter API](https://toncenter.com/api/v3/#/default/get_jetton_masters_api_v3_jetton_masters_get) `/jetton/masters` method to retrieve already decoded jetton data and metadata. We have also developed methods for (js) [tonweb](https://github.com/toncenter/tonweb/blob/master/src/contract/token/ft/JettonMinter.js#L85) and (js) [ton-core/ton](https://github.com/ton-core/ton/blob/master/src/jetton/jettonMaster.ts#L28), (go) [tongo](https://github.com/tonkeeper/tongo/blob/master/liteapi/jetton.go#L48) and (go) [tonutils-go](https://github.com/xssnick/tonutils-go/blob/33fd62d754d3a01329ed5c904db542ab4a11017b/ton/jetton/jetton.go#L79), (python) [pytonlib](https://github.com/toncenter/pytonlib/blob/d96276ec8a46546638cb939dea23612876a62881/pytonlib/client.py#L742), and many other [SDK](/v3/guidelines/dapps/apis-sdks/sdk).
+You can also use the [TON Center API](https://toncenter.com/api/v3/#/default/get_jetton_masters_api_v3_jetton_masters_get) `/jetton/masters` method to retrieve already decoded jetton data and metadata. We have also developed methods for (js) [tonweb](https://github.com/toncenter/tonweb/blob/master/src/contract/token/ft/JettonMinter.js#L85) and (js) [ton-core/ton](https://github.com/ton-core/ton/blob/master/src/jetton/jettonMaster.ts#L28), (go) [tongo](https://github.com/tonkeeper/tongo/blob/master/liteapi/jetton.go#L48) and (go) [tonutils-go](https://github.com/xssnick/tonutils-go/blob/33fd62d754d3a01329ed5c904db542ab4a11017b/ton/jetton/jetton.go#L79), (python) [pytonlib](https://github.com/toncenter/pytonlib/blob/d96276ec8a46546638cb939dea23612876a62881/pytonlib/client.py#L742), and many other [SDK](/v3/guidelines/dapps/apis-sdks/sdk).
 
 The example of using [Tonweb](https://github.com/toncenter/tonweb) to run a get method and get url for off-chain metadata:
 
@@ -179,7 +179,7 @@ To get the `address` of a `jetton wallet` using the `owner address` (the TON wal
 <Tabs groupId="retrieve-wallet-address">
 <TabItem value="api" label="API">
 
-> Run `get_wallet_address(slice owner_address)` through `/runGetMethod` method from the [Toncenter API](https://toncenter.com/api/v3/#/default/run_get_method_api_v3_runGetMethod_post). In real cases (not test ones) it is important to always check that wallet indeed is attributed to desired jetton Master. Check the code example for more.
+> Run `get_wallet_address(slice owner_address)` through `/runGetMethod` method from the [TON Center API](https://toncenter.com/api/v3/#/default/run_get_method_api_v3_runGetMethod_post). In real cases (not test ones) it is important to always check that wallet indeed is attributed to desired jetton Master. Check the code example for more.
 
 </TabItem>
 <TabItem value="js" label="js">
@@ -226,7 +226,7 @@ This method returns the following data:
 <Tabs groupId="retrieve-jetton-wallet-data">
 <TabItem value="api" label="API">
 
-> Use the `/jetton/wallets` get method from the [Toncenter API](https://toncenter.com/api/v3/#/default/get_jetton_wallets_api_v3_jetton_wallets_get) to retrieve previously decoded jetton wallet data.
+> Use the `/jetton/wallets` get method from the [TON Center API](https://toncenter.com/api/v3/#/default/get_jetton_wallets_api_v3_jetton_wallets_get) to retrieve previously decoded jetton wallet data.
 
 </TabItem>
 
@@ -358,8 +358,7 @@ This should not be confused with the `sender` field in the [body](/v3/guidelines
 
 1. Get the jetton master address for the new jetton wallet by [retrieving the wallet data] (/v3/guidelines/dapps/asset-processing/jettons#retrieving-data-for-a-specific-jetton-wallet).
 2. Get the jetton wallet address for your wallet address (as the owner) using the jetton master contract: [How to get the jetton wallet address for a given user](#retrieving-jetton-wallet-addresses-for-a-given-user)
-3. Compare the address returned by the master contract and the actual wallet token address.
-If they match, that's perfect. If not, you've probably received a scam token that's counterfeit.
+3. Compare the address returned by the master contract and the actual wallet token address. If they match, that's perfect. If not, you've probably received a scam token that's counterfeit.
 4. Retrieve jetton metadata: [How to retrieve jetton metadata](#retrieving-jetton-data).
 5. Check the `symbol` and `name` fields for signs of fraud. Warn the user if necessary. [Adding new jettons for asset processing and initial verification](#adding-new-jettons-for-asset-processing-and-initial-verification).
 
@@ -397,20 +396,13 @@ Tonweb examples:
 1. Download the list of accepted jettons.
 2. [Retrieve the jetton wallet address](#retrieving-jetton-wallet-addresses-for-a-given-user) for your deployed hot wallet.
 3. Retrieve the jetton master address for each jetton wallet using [retrieving wallet data](/v3/guidelines/dapps/asset-processing/jettons#retrieving-data-for-a-specific-jetton-wallet).
-4. Compare the jetton master contract addresses from step 1. and step 3 (immediately above).
-If the addresses do not match, you should report an address validation error to jetton.
-5. Retrieve the list of recent unprocessed transactions using the hot wallet account and
-repeat (sorting each transaction one at a time). See: [Check contract transactions](/v3/guidelines/dapps/asset-processing/payments-processing#check-contracts-transactions).
+4. Compare the jetton master contract addresses from step 1. and step 3 (immediately above). If the addresses do not match, you should report an address validation error to jetton.
+5. Retrieve the list of recent unprocessed transactions using the hot wallet account and repeat (sorting each transaction one at a time). See: [Check contract transactions](/v3/guidelines/dapps/asset-processing/payments-processing#check-contracts-transactions).
 6. Check the input message (in_msg) for transactions and extract the source address from the input message. [Tonweb example](https://github.com/toncenter/examples/blob/9f20f7104411771793dfbbdf07f0ca4860f12de2/deposits-jettons-single-wallet.js#L84)
-7. If the source address matches the address in the jetton wallet, then the transaction should be processed further.
-If not, then skip the transaction processing and check the next transaction.
-8. Make sure the message body is not empty and that the first 32 bits of the message match the `transfer notification` opcode `0x7362d09c`.
-[Tonweb example](https://github.com/toncenter/examples/blob/9f20f7104411771793dfbbdf07f0ca4860f12de2/deposits-jettons-single-wallet.js#L91)
-If the message body is empty or the opcode is invalid, skip the transaction.
-9. Read other message body data, including `query_id`, `amount`, `sender`, `forward_payload`.
-[jetton contract message layouts](/v3/guidelines/dapps/asset-processing/jettons#message-layouts), [Tonweb example](https://github.com/toncenter/examples/blob/9f20f7104411771793dfbbdf07f0ca4860f12de2/deposits-jettons-single-wallet.js#L105)
-10. Try extracting text comments from the `forward_payload` data. The first 32 bits should correspond to the text comment opcode `0x00000000`, and the rest to the UTF-8 encoded text.
-[Tonweb example](https://github.com/toncenter/examples/blob/9f20f7104411771793dfbbdf07f0ca4860f12de2/deposits-jettons-single-wallet.js#L110)
+7. If the source address matches the address in the jetton wallet, then the transaction should be processed further. If not, then skip the transaction processing and check the next transaction.
+8. Make sure the message body is not empty and that the first 32 bits of the message match the `transfer notification` opcode `0x7362d09c`. [Tonweb example](https://github.com/toncenter/examples/blob/9f20f7104411771793dfbbdf07f0ca4860f12de2/deposits-jettons-single-wallet.js#L91) If the message body is empty or the opcode is invalid, skip the transaction.
+9. Read other message body data, including `query_id`, `amount`, `sender`, `forward_payload`. [jetton contract message layouts](/v3/guidelines/dapps/asset-processing/jettons#message-layouts), [Tonweb example](https://github.com/toncenter/examples/blob/9f20f7104411771793dfbbdf07f0ca4860f12de2/deposits-jettons-single-wallet.js#L105)
+10. Try extracting text comments from the `forward_payload` data. The first 32 bits should correspond to the text comment opcode `0x00000000`, and the rest to the UTF-8 encoded text. [Tonweb example](https://github.com/toncenter/examples/blob/9f20f7104411771793dfbbdf07f0ca4860f12de2/deposits-jettons-single-wallet.js#L110)
 11. If the `forward_payload` data is empty or the operation code is invalid - skip the transaction.
 12. Compare the received comment with the saved notes. If there is a match (user identification is always possible) - make the transfer.
 13. Restart from step 5 and repeat the process until you have gone through the entire list of transactions.
@@ -536,7 +528,7 @@ processes the message, after which the wallet will no longer accept the message)
 11. Get a list of the latest unprocessed transactions in the hot wallet account and retry it.
 Learn more here: [Check contract transactions](/v3/guidelines/dapps/asset-processing/payments-processing#check-contracts-transactions),
 [Tonweb example](https://github.com/toncenter/examples/blob/9f20f7104411771793dfbbdf07f0ca4860f12de2/deposits-single-wallet.js#L43) or
-use the Toncenter API method `/getTransactions`.
+use the TON Center API method `/getTransactions`.
 12. View the outgoing messages in the account.
 13. If there is a message with the `transfer` operation code, it should be decoded to obtain the `query_id` value.
 The received `query_id` should be marked as successfully sent.

--- a/docs/v3/guidelines/dapps/asset-processing/nft-processing/nfts.md
+++ b/docs/v3/guidelines/dapps/asset-processing/nft-processing/nfts.md
@@ -125,7 +125,7 @@ The process varies based on whether the collection is ordered or unordered.
 
 ### Ordered collections
 Retrieving all NFTs in an ordered collection is relatively simple, since the number of NFTs to retrieve is already known and their addresses are easy to obtain. To complete this process, you need to perform the following steps in this order:
-1. Call the `get_collection_data` method using the TonCenter API on the collection contract and retrieve the `next_item_index` value from the response.
+1. Call the `get_collection_data` method using the Ton Center API on the collection contract and retrieve the `next_item_index` value from the response.
 2. Use the `get_nft_address_by_index` method, passing in the `i` index value (initially set to 0) to retrieve the address of the first NFT in the collection.
 3. Retrieve the NFT item data using the address obtained in the previous step. Then check that the initial NFT collection smart contract matches the NFT collection smart contract reported by the NFT item itself (to ensure that the collection has not appropriated another user's NFT smart contract).
 4. Call the `get_nft_content` method with `i` and `individual_content` from the previous step.

--- a/docs/v3/guidelines/dapps/tutorials/nft-minting-guide.md
+++ b/docs/v3/guidelines/dapps/tutorials/nft-minting-guide.md
@@ -135,7 +135,7 @@ PINATA_API_SECRET=your_secret_api_key
 MNEMONIC=word1 word2 word3 word4
 TONCENTER_API_KEY=aslfjaskdfjasasfas
 ```
-You can get a toncenter API key from [@tonapibot](https://t.me/tonapibot) and choose mainnet or testnet. Store the 24-word seed phrase of the collection owner’s wallet in the MNEMONIC variable.
+You can get a TON Center API key from [@tonapibot](https://t.me/tonapibot) and choose mainnet or testnet. Store the 24-word seed phrase of the collection owner’s wallet in the MNEMONIC variable.
 
 Great! Now we are ready to start writing code for our project.
 

--- a/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx
+++ b/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx
@@ -1,7 +1,7 @@
-import Feedback from '@site/src/components/Feedback';
+import Feedback from "@site/src/components/Feedback";
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 # How to use a single nominator pool
 
@@ -111,7 +111,7 @@ $ npm run test
 
 ### Create a single nominator pool
 
-1. Obtain a Toncenter API key from [@tonapibot](https://t.me/tonapibot) on Telegram.
+1. Obtain a TON Center API key from [@tonapibot](https://t.me/tonapibot) on Telegram.
 2. Set environment variables:
 
 ```bash
@@ -236,25 +236,31 @@ Alternatively, create and send the transaction manually:
 <TabItem value="toncore" label="JS (@ton)">
 
 ```js
-import { Address, beginCell, internal, storeMessageRelaxed, toNano } from "@ton/core";
+import {
+  Address,
+  beginCell,
+  internal,
+  storeMessageRelaxed,
+  toNano,
+} from "@ton/core";
 
 async function main() {
-    const single_nominator_address = Address.parse('single nominator address');
-    const WITHDRAW_OP = 0x1000;
-    const amount = 50000;
+  const single_nominator_address = Address.parse("single nominator address");
+  const WITHDRAW_OP = 0x1000;
+  const amount = 50000;
 
-    const messageBody = beginCell()
- .storeUint(WITHDRAW_OP, 32) // op code for withdrawal
- .storeUint(0, 64)            // query_id
- .storeCoins(amount)          // amount to withdraw
- .endCell();
+  const messageBody = beginCell()
+    .storeUint(WITHDRAW_OP, 32) // op code for withdrawal
+    .storeUint(0, 64) // query_id
+    .storeCoins(amount) // amount to withdraw
+    .endCell();
 
-    const internalMessage = internal({
-        to: single_nominator_address,
-        value: toNano('1'),
-        bounce: true,
-        body: messageBody
- });
+  const internalMessage = internal({
+    to: single_nominator_address,
+    value: toNano("1"),
+    bounce: true,
+    body: messageBody,
+  });
 }
 ```
 
@@ -405,12 +411,12 @@ MyTonCtrl> disable_mode validator
 
 Initially, the owner of the vesting contract manages it with their wallet contract. This scheme involves managing interactions between multiple contracts.
 
-| Contracts               | Interface for managing       |
-|-------------------------|------------------------------|
-| `validator_wallet` | MyTonCtrl                    |
-| `vesting` | [vesting.ton.org](https://vesting.ton.org/) |
-| `owner_wallet` | Apps like Tonkeeper or MyTonWallet |
-| `single_nominator_pool` | MyTonCtrl                    |
+| Contracts               | Interface for managing                      |
+| ----------------------- | ------------------------------------------- |
+| `validator_wallet`      | MyTonCtrl                                   |
+| `vesting`               | [vesting.ton.org](https://vesting.ton.org/) |
+| `owner_wallet`          | Apps like Tonkeeper or MyTonWallet          |
+| `single_nominator_pool` | MyTonCtrl                                   |
 
 - `owner_wallet` – The TON wallet that owns the `vesting`.
 
@@ -447,11 +453,10 @@ MyTonCtrl> activate_single_pool my_s_pool
 
 6. After the `single_nominator_pool` address appears on-chain, request whitelisting from the person who provided the vesting contract.
 7. Once whitelisted, you can send locked tokens from the `vesting` contract to the `single_nominator_pool` using [vesting.ton.org](https://vesting.ton.org/):
-    - a. Connect the `owner_wallet` on [vesting.ton.org](https://vesting.ton.org/).
-    - b. Test by sending 10 TON from `vesting` to the `single_nominator_pool`.
-    - c. Return the remaining funds (~8 TON) to `vesting` with a message [amount 0, comment `w`] via the [vesting.ton.org](https://vesting.ton.org/) interface.
-    - d. Confirm the remaining funds are received in `vesting`.
+   - a. Connect the `owner_wallet` on [vesting.ton.org](https://vesting.ton.org/).
+   - b. Test by sending 10 TON from `vesting` to the `single_nominator_pool`.
+   - c. Return the remaining funds (~8 TON) to `vesting` with a message [amount 0, comment `w`] via the [vesting.ton.org](https://vesting.ton.org/) interface.
+   - d. Confirm the remaining funds are received in `vesting`.
 8. Transfer the required TON amount from `vesting` to `single_nominator_pool` for both cycles.
 9. Wait for the validators’ voting.
-<Feedback />
-
+   <Feedback />

--- a/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx
+++ b/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx
@@ -1,4 +1,4 @@
-import Feedback from "@site/src/components/Feedback";
+import Feedback from '@site/src/components/Feedback';
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";

--- a/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx
+++ b/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx
@@ -1,7 +1,7 @@
 import Feedback from '@site/src/components/Feedback';
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # How to use a single nominator pool
 


### PR DESCRIPTION
## Description

Fix : from Toncenter -> TON Center accross the whole documentation

Closes https://github.com/ton-community/ton-docs/issues/1137

## Checklist

- [X] I have created an issue.
- [X] I am working on content that aligns with the [Style guide](https://docs.ton.org/v3/contribute/style-guide/).
- [X] I have reviewed and formatted the content according to [Content standardization](https://docs.ton.org/v3/contribute/content-standardization/).
- [X] I have reviewed and formatted the text in the article according to [Typography](https://docs.ton.org/v3/contribute/typography/).
