### PR TITLE
Update docs for Tolk v0.12

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -364,6 +364,7 @@
     "deployment",
     "docs/learn/tvm-instructions/instructions.csv",
     "docs/learn/tvm-instructions/generate_md.py",
+    "docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.md",
     "sidebars.js",
     "sidebars",
     "i18n",

--- a/docs/v3/documentation/smart-contracts/tolk/changelog.md
+++ b/docs/v3/documentation/smart-contracts/tolk/changelog.md
@@ -5,6 +5,14 @@ import Feedback from '@site/src/components/Feedback';
 When new versions of Tolk are released, they will be mentioned here.
 
 
+## v0.12
+
+1. Structures `struct A { ... }`
+2. Generics `struct<T>` and `type<T>`
+3. Methods `fun Point.getX(self)`
+4. Rename stdlib functions to short methods
+
+
 ## v0.11
 
 1. Type aliases `type NewName = <existing type>`

--- a/docs/v3/documentation/smart-contracts/tolk/overview.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/overview.mdx
@@ -101,7 +101,7 @@ If you know FunC and want to try a new syntax, your way is:
 
 1. Read [Tolk vs FunC: in short](/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short).
 2. With a blueprint, create a new Tolk contract (for example, a counter) and experiment around it. Remember that almost all stdlib functions are renamed to ~~verbose~~ clear names. Here is [a mapping](/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib).
-3. Try a [converter](https://github.com/ton-blockchain/convert-func-to-tolk) for your existing contracts or one from [FunC Contracts](/v3/documentation/smart-contracts/contracts-specs/examples). Remember that contracts written in Tolk from scratch look nicer than auto-converted ones. For instance, using logical operators instead of bitwise tremendously increases code readability.
+3. Try a [converter](https://github.com/ton-blockchain/convert-func-to-tolk) for your existing contracts or one from [FunC contracts](/v3/documentation/smart-contracts/contracts-specs/examples). Remember that contracts written in Tolk from scratch look nicer than auto-converted ones. For instance, using logical operators instead of bitwise tremendously increases code readability.
 
 ## How to try Tolk if you don't know FunC
 

--- a/docs/v3/documentation/smart-contracts/tolk/overview.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/overview.mdx
@@ -15,7 +15,7 @@ but leaving all low-level optimizations untouched. Think of Tolk as the next‑g
 import "storage.tolk"
 
 fun loadData() {
-    ctxCounter = getContractData().beginParse().loadUint(32);
+    ctxCounter = contract.getData().beginParse().loadUint(32);
 }
 
 fun onInternalMessage(msgValue: int, msgFull: cell, msgBody: slice) {
@@ -142,7 +142,6 @@ The first released version of Tolk is v0.6, emphasizing [missing](/v3/documentat
 Here are some points to investigate:
 
 - type system improvements
-- structures and generics
 - auto-pack structures to/from cells, probably integrated with message handlers
 - methods for structures, generalized to cover built-in types
 - easier message sending

--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx
@@ -473,6 +473,7 @@ We have the following types:
 - `void` (more canonical to be named `unit`, but `void` is more reliable)
 - `self`, to make chainable methods, described below; actually it's not a type, it can only occur instead of return type of a function
 - `never` (an always-throwing function returns `never`, for example; an "impossible type" is also `never`)
+- structures and generics
 
 The type system obeys the following rules:
 - variable types can be specified manually or are inferred from declarations, and never change after being declared
@@ -512,7 +513,7 @@ Comparison operators `== / >= /...` return `bool`. Logical operators `&& ||` ret
 Lots of stdlib functions now return `bool`, not `int` (having -1 and 0 at runtime):
 ```tolk
 var valid = isSignatureValid(...);    // bool
-var end = cs.isEndOfSlice();          // bool
+var end = cs.isEnd();                 // bool
 ```
 
 Operator `!x` supports both `int` and `bool`. Condition of `if` and similar accepts both `int` (!= 0) and `bool`.
@@ -546,43 +547,7 @@ But generally, if you need such a cast, probably you're doing something wrong (u
   ✅ Generic functions and instantiations like <code>f&lt;int&gt;(...)</code>
 </h3>
 
-In FunC, there were "forall" functions:
-```func
-forall X -> tuple tpush(tuple t, X value) asm "TPUSH";
-```
-
 Tolk introduces properly made generic functions. Their syntax reminds mainstream languages:
-```tolk
-fun tuplePush<T>(mutate self: tuple, value: T): void
-    asm "TPUSH";
-```
-
-When `f<T>` is called, `T` is detected (in most cases) by provided arguments:
-```tolk
-t.tuplePush(1);     // detected T=int
-t.tuplePush(cs);    // detected T=slice
-t.tuplePush(null);  // error, need to specify "null of what type"
-```
-
-The syntax `f<int>(...)` is also supported:
-```tolk
-t.tuplePush<int>(1);     // ok
-t.tuplePush<int>(cs);    // error, can not pass slice to int
-t.tuplePush<int?>(null); // ok, null is "null of type int"
-```
-
-User-defined functions may also be generic:
-```tolk
-fun replaceLast<T>(mutate self: tuple, value: T) {
-    val size = self.tupleSize();
-    self.tupleSetAt(value, size - 1);
-}
-```
-
-Having called `replaceLast<int>` and `replaceList<slice>` will result in TWO generated asm (fift) functions.
-They mostly remind template functions. The function's body is fully cloned under a new name at each unique invocation.
-
-There may be multiple generic parameters:
 ```tolk
 fun replaceNulls<T1, T2>(tensor: (T1?, T2?), v1IfNull: T1, v2IfNull: T2): (T1, T2) {
     var (a, b) = tensor;
@@ -615,25 +580,23 @@ fun callAnyFn2<TObj, TCallback>(f: TCallback, arg: TObj) {
 
 Note that while generic `T` is mostly detected from arguments, there are no such obvious corner cases when `T` does not depend on arguments:
 ```tolk
-fun tupleLast<T>(self: tuple): T
+fun tupleLast<T>(t: tuple): T
     asm "LAST";
 
-var last = t.tupleLast();    // error, can not deduce T
+var last = tupleLast(t);    // error, can not deduce T
 ```
 
 To make this valid, `T` should be provided externally:
 ```tolk
-var last: int = t.tupleLast();       // ok, T=int
-var last = t.tupleLast<int>();       // ok, T=int
-var last = t.tupleLast() as int;     // ok, T=int
+var last: int = tupleLast(t);       // ok, T=int
+var last = tupleLast<int>(t);       // ok, T=int
+var last = tupleLast(t) as int;     // ok, T=int
 
-someF(t.tupleLast());       // ok, T=(paremeter's declared type)
-return t.tupleLast();       // ok if function specifies return type
+someF(tupleLast(t));       // ok, T=(paremeter's declared type)
+return tupleLast(t);       // ok if function specifies return type
 ```
 
 Also note that `T` for asm functions must occupy one stack slot, whereas for a user-defined function, `T` could be of any shape. Otherwise, asm body is unable to handle it properly.
-
-In the future, when structures and generic structures are implemented, all the power of generic functions will come into play.
 
 
 <h3 className="cmp-func-tolk-header">
@@ -689,7 +652,7 @@ As for now, there is one experimental option introduced — `remove-unused-funct
 
 `#pragma version xxx` was replaced by `tolk xxx` (no >=, just a strict version). It's good practice to annotate the compiler version you are using. If it doesn't match, Tolk will show a warning.
 ```tolk
-tolk 0.6
+tolk 0.12
 ```
 
 
@@ -939,7 +902,7 @@ All names in the standard library were reconsidered. Now, functions are called u
   <tbody>
   <tr>
     <td><code dangerouslySetInnerHTML={{__html: 'cur_lt()<br>car(l)<br>get_balance().pair_first()<br>raw_reserve(count)<br>dict~idict_add?(...)<br>dict~udict::delete_get_max()<br>t~tpush(triple(x, y, z))<br>s.slice_bits()<br>~dump(x)<br>...'}}></code></td>
-    <td><code dangerouslySetInnerHTML={{__html: 'getLogicalTime()<br>listGetHead(l)<br>getMyOriginalBalance()<br>reserveToncoinsOnBalance(count)<br>dict.iDictSetIfNotExists(...)<br>dict.uDictDeleteLastAndGet()<br>t.tuplePush([x, y, z])<br>s.getRemainingBitsCount()<br>debugPrint(x)<br>...'}}></code></td>
+    <td><code dangerouslySetInnerHTML={{__html: 'blockchain.logicalTime()<br>listGetHead(l)<br>contract.getOriginalBalance()<br>reserveToncoinsOnBalance(count)<br>dict.iDictSetIfNotExists(...)<br>dict.uDictDeleteLastAndGet()<br>t.push([x, y, z])<br>s.remainingBitsCount()<br>debug.print(x)<br>...'}}></code></td>
   </tr>
   </tbody>
 </table>
@@ -1287,10 +1250,10 @@ For now, working with dicts will require the `!` operator.
 ```tolk
 // it returns either (slice, true) or (null, false)
 @pure
-fun iDictGet(self: cell?, keyLen: int, key: int): (slice?, bool)
+fun dict.iDictGet(self, keyLen: int, key: int): (slice?, bool)
     asm(key self keyLen) "DICTIGET" "NULLSWAPIFNOT";
 
-var (cs, exists) = dict.iDictGet(...);
+var (cs, exists) = myDict.iDictGet(...);
 // if exists is true, cs is not null
 if (exists) {
     cs!.loadInt(32);
@@ -1346,7 +1309,6 @@ Nullable types eliminate runtime errors, enforcing correct handling of optional 
 <h3 className="cmp-func-tolk-header">
   ✅ Union types `T1 | T2 | ...`, operators `match`, `is`, `!is`
 </h3>
-
 
 Union types allow a variable to hold multiple possible types, similar to TypeScript.
 ```tolk
@@ -1502,6 +1464,279 @@ val nextValue = match (curValue) {
 ```
 
 
+<h3 className="cmp-func-tolk-header">
+  ✅ Structures <code>{'struct A { ... }'}</code>
+</h3>
+
+Looks like TypeScript — but works in TVM!
+```tolk
+struct Point {
+    x: int;
+    y: int;
+}
+
+fun calcMaxCoord(p: Point) {
+    return p.x > p.y ? p.x : p.y;
+}
+
+// declared like a JS object
+var p: Point = { x: 10, y: 20 };
+calcMaxCoord(p);
+
+// called like a JS object
+calcMaxCoord({ x: 10, y: 20 });
+
+// works with shorthand syntax
+fun createPoint(x: int, y: int): Point {
+    return { x, y };
+}
+```
+
+* a struct is just **a named tensor**
+* `Point` is identical to `(int, int)` at the TVM level
+* field access `p.x` works like accessing tensor elements `t.0`, for reading and writing
+
+This means **no bytecode overhead** — you can replace unreadable tensors with clean, structured types.
+
+Fields can be separated by `;` or `,` (both are valid, like in TypeScript). Trailing commas are allowed.
+
+When creating a structure, you can specify `StructName { ... }` or simply `{ ... }` if the type is clear from the context (e.g., return type or assignment):
+```tolk
+var s: StoredInfo = { counterValue, ... };
+var s: (int, StoredInfo) = (0, { counterValue, ... });
+
+// also valid, but not preferred
+var s = StoredInfo { counterValue, ... };
+```
+
+Default values for fields are supported:
+```tolk
+struct DefDemo {
+    f1: int = 0;
+    f2: int? = null;
+    f3: (int, coins) = (0, ton("0.05"));
+}
+
+var d: DefDemo = {};         // ok
+var d: DefDemo = { f2: 5 };  // ok
+```
+
+Structs can have methods as extension functions, read below.
+
+
+<h3 className="cmp-func-tolk-header">
+  ✅ Generic structs and aliases
+</h3>
+
+They exist only at the type level (no runtime cost).
+```tolk
+struct Container<T> {
+    isAllowed: bool;
+    element: T?;
+}
+
+struct Nothing {}
+
+type Wrapper<T> = Nothing | Container<T>;
+```
+
+Example usage:
+```tolk
+fun checkElement(c: Container<T>) {
+    return c.element != null;
+}
+
+var c: Container<int32> = { isAllowed: false, element: null };
+
+var v: Wrapper<int> = Nothing {};
+var v: Wrapper<int32> = Container { value: 0 };
+```
+
+Since it's a generic, you should specify type arguments when using it:
+```tolk
+fun getItem(c: Container)        // error, specify type arguments
+fun getItem(c: Container<int>)   // ok
+fun getItem<T>(c: Container<T>)  // ok
+
+var c: Container = { ... }       // error, specify type arguments
+var c: Container<int> = { ... }  // ok
+```
+
+When you declare a generic function, the compiler can automatically infer type arguments for a call:
+```tolk
+fun doSmth<T>(value: Container<T>) { ... }
+
+doSmth({ item: 123 });         // T = int
+doSmth({ item: cellOrNull });  // T = cell?
+```
+
+Demo: `Response<TResult, TError>`:
+```tolk
+struct Ok<TResult> { result: TResult; }
+struct Err<TError> { err: TError; }
+
+type Response<R, E> = Ok<R> | Err<E>;
+
+fun tryLoadMore(slice: slice): Response<cell, int32> {
+    return ...
+        ? Ok { result: ... }
+        : Err { err: ErrorCodes.NO_MORE_REFS };
+}
+
+match (val r = tryLoadMore(inMsg)) {
+    Ok => { r.result }
+    Err => { r.err }
+}
+```
+
+
+<h3 className="cmp-func-tolk-header">
+  ✅ Methods: for any types, including structures
+</h3>
+
+Methods are declared as extension functions, similar to Kotlin.
+A method can accept the first `self` parameter (then it's an instance method) or not accept it (then it's a static method).
+```tolk
+fun Point.getX(self) {
+    return self.x
+}
+
+fun Point.create(x: int, y: int): Point {
+    return { x, y }
+}
+```
+
+Methods can be created **for any type**, including aliases, unions, and built-in types:
+```tolk
+fun int.isZero(self) {
+    return self == 0;
+}
+
+type MyMessage = CounterIncrement | ...;
+
+fun MyMessage.parse(self) { ... }
+// this is identical to
+// fun (CounterIncrement | ...).parse(self)
+```
+
+Methods perfectly work with `asm`, since `self` is just a regular variable:
+```tolk
+@pure
+fun tuple.size(self): int
+    asm "TLEN";
+```
+
+By default, **`self` is immutable**. It means that you can't modify it or call mutating methods.
+To make `self` mutable, you should explicitly declare `mutate self`:
+```tolk
+fun Point.assignX(mutate self, x: int) {
+    self.x = x;   // without mutate, an error "modifying immutable object"
+}
+
+fun builder.storeInt32(mutate self, v: int32): self {
+    return self.storeInt(v, 32);
+}
+```
+
+Methods for generic structs created seamlessly.
+Note, that no extra `<T>` is required: while parsing the receiver type, compiler treats unknown symbols as generic arguments.
+```tolk
+struct Container<T> {
+    item: T;
+}
+
+// compiler treats T (unknown symbol) as a generic parameter
+fun Container<T>.getItem(self) {
+    return self.item;
+}
+
+// and this is a specialization for integer containers
+fun Container<int>.getItem(self) {
+    ...
+}
+```
+
+Another example:
+```tolk
+struct Pair<T1, T2> {
+    first: T1;
+    second: T2;
+}
+
+// both <T1,T2>, <A,B>, etc. work: any unknown symbols
+fun Pair<A, B>.create(f: A, s: B): Pair<A, B> {
+    return {
+        first: f,
+        second: s,
+    }
+}
+```
+
+Similarly, any unknown symbol (typically, `T`) can be used to make a method accepting anything:
+```tolk
+// any receiver
+fun T.copy(self): T {
+    return self;
+}
+
+// any nullable receiver
+fun T?.isNull(self): bool {
+    return self == null;
+}
+```
+
+When you call `someObj.method()`, multiple methods with the same name may exist and theoretically be acceptable:
+```tolk
+fun T.copy(self) { ... }
+fun int.copy(self) { ... }
+
+someVar.copy();   // ???
+```
+
+So, the compiler performs matching to find as precise method as follows:
+1) Search for exact type receiver like `int.copy` (most practical cases finish here)
+2) Search for non-generic receivers that are acceptable (like `int32.copy` / `int?.copy`)
+3) Search for generic receivers except `T` (like `Container<T>.copy`)
+4) Search for `T` receivers (`T.copy`)
+
+```tolk
+fun int.copy(self) { ... }
+fun T.copy(self) { ... }
+
+6.copy()              // int.copy (rule 1)
+(6 as int32).copy()   // int.copy (rule 2)
+(6 as int32?).copy()  // T.copy with T=int? (rule 4)
+```
+
+```tolk
+type MyMessage = CounterIncrement | CounterReset;
+fun MyMessage.check() { ... }
+fun CounterIncrement.check() { ... }
+
+MyMessage{...}.check()         // first (rule 1)
+CounterIncrement{...}.check()  // second (rule 1)
+CounterReset{...}.check()      // first (rule 2)
+```
+
+In case of ambiguity, an error is printed:
+```tolk
+fun int?.doSmth(self) { ... }
+fun int64.doSmth(self) { ... }
+
+var v: int32;
+v.doSmth();   // error: no exact match, but two possible acceptable receivers
+```
+
+You can assign a generic function to the variable, but you should explicitly specify types:
+```tolk
+fun genericFn<T>(v: T) { ... }
+fun Container<T>.getItem(self) { ... }
+
+var callable1 = genericFn<slice>;
+var callable2 = Container<int32>.getItem;
+callable2(someContainer32);   // pass it as self
+```
+
 
 <h3 className="cmp-func-tolk-header">
   ✅ No tilda `~` methods, `mutate` keyword instead
@@ -1514,30 +1749,21 @@ This change is so huge that it's described on a separate page: [Tolk mutability]
 
 <h3>Tolk vs FunC gas consumption</h3>
 
-:::caution TLDR
-Tolk gas consumption could be higher because it fixes unexpected argument shuffling in FunC, but it's negligible in practice.  
-In the future, the Tolk compiler will become smart enough to reorder arguments targeting fewer stack manipulations,
-but still avoiding a shuffling problem.
+:::tip The same or slightly less
+If you transform FunC code line-by-line (for example, using a [converter](https://github.com/ton-blockchain/convert-func-to-tolk)),
+you'll have the same results or even a bit better.
 :::
 
-FunC compiler could unexpectedly shuffle arguments when calling an assembly function:
-```
-some_asm_function(f1(), f2());
-```
+Since Tolk is a fork of FunC, part of its core remains unchanged — particularly the stack manipulation logic.
+Yes, Tolk is a completely different language, with its own syntax and semantics,
+but its low-level internal representation is exactly the same as FunC's.
+As a result, the syntax has no impact on gas consumption.
+In fact, it's even slightly lower, since the strict type system
+gives the compiler more room for optimizations.
 
-Sometimes, `f2()` could be called before `f1()`, and it's unexpected.
-One could specify `#pragma compute-asm-ltr` to fix this behavior, forcing arguments to be evaluated constantly in ltr-order.
-This specifier was experimental and, therefore, turned off by default.
-
-This pragma reorders arguments on a stack, often leading to more stack manipulations than without.
-In other words, it fixes unexpected behavior but increases gas consumption.
-
-Tolk puts arguments onto a stack exactly as if this pragma is turned on.
-So, its gas consumption is sometimes higher than FunC's if you don't use this pragma.
-Of course, there is no shuffling problem in Tolk.
-
-In the future, the Tolk compiler will become smart enough to reorder arguments targeting fewer stack manipulations,
-but still avoiding a shuffling problem.
+However, once Tolk v1.0 is released, it will be significantly more efficient.
+Auto-serialized structures, automatic message construction, and other features will be
+noticeably cheaper than manual work with builders and slices — almost always.
 
 <Feedback />
 

--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.md
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.md
@@ -53,8 +53,12 @@ get currentCounter(): int { ... }
 13. Nullable types `T?`, null safety, smart casts, operator `!`
 14. Union types and pattern matching (for types and for expressions, switch-like behavior)
 15. Type aliases are supported
-16. Trailing comma is supported
-17. Semicolon after the last statement in a block is optional
+16. Structures are supported
+17. Generics are supported
+18. Methods (as extension functions) are supported
+19. Trailing comma is supported
+20. Semicolon after the last statement in a block is optional
+21. Fift output contains original .tolk lines as comments
 
 #### Tooling around
 - JetBrains plugin exists

--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/mutability.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/mutability.mdx
@@ -44,7 +44,7 @@ The goal is to have calls identical to JS and other languages:
   </tr>
   <tr>
     <td><code dangerouslySetInnerHTML={{__html: 'slice data = get_data()<br>             .begin_parse();<br>int flag = data~load_uint(32);'}}></code></td>
-    <td><code dangerouslySetInnerHTML={{__html: 'val flag = getContractData()<br>           .beginParse()<br>           .loadUint(32);'}}></code></td>
+    <td><code dangerouslySetInnerHTML={{__html: 'val flag = contract.getData()<br>           .beginParse()<br>           .loadUint(32);'}}></code></td>
   </tr>
   <tr>
     <td><code>{'dict~udict_set(...);'}</code></td>
@@ -139,12 +139,13 @@ incrementXY(mutate origX, mutate origY, 10);   // both += 10
 *You may ask — is it just passing by reference? It effectively is, but since "ref" is an overloaded term in TON (cells and slices have refs), the keyword `mutate` was chosen.*
 
 <h3 className="cmp-func-tolk-header">
-  `self` parameter turning a function into a method
+  By default, `self` in methods is immutable
 </h3>
 
-When you name the first parameter `self`, it emphasizes that the function, though still global, is a method and should be called via a dot.
+Methods — unlike global functions `fun f()` — are declared as `fun receiver_type.f()`.
+If a method accepts `self`, it's an instance method (if not, it's a static one).
 ```tolk
-fun assertNotEq(self: int, throwIfEq: int) {
+fun int.assertNotEq(self, throwIfEq: int) {
     if (self == throwIfEq) {
         throw 100;
     }
@@ -152,16 +153,15 @@ fun assertNotEq(self: int, throwIfEq: int) {
 
 someN.assertNotEq(10);
 10.assertNotEq(10);      // also ok, since self is not mutating
-assertNotEq(someN, 10);  // still allowed (but not recommended)
 ```
 
-`self`, without `mutate`, is **immutable** (unlike all other parameters). Think of it like a **read-only method**.
+`self` by default is immutable. Think of it like a **read-only method**.
 ```tolk
-fun readFlags(self: slice) {
+fun slice.readFlags(self) {
     return self.loadInt(32);  // error, modifying immutable variable
 }
 
-fun preloadInt32(self: slice) {
+fun slice.preloadInt32(self) {
     return self.preloadInt(32);  // ok, it's a read-only method
 }
 ```
@@ -174,13 +174,13 @@ Combining `mutate` and `self`, we get mutating methods.
 
 As follows:
 ```tolk
-fun readFlags(mutate self: slice) {
+fun slice.readFlags(mutate self) {
     return self.loadInt(32);
 }
 
 val flags = msgBody.readFlags(); // pretty obvious
 
-fun increment(mutate self: int) {
+fun int.increment(mutate self) {
     self += 1;
 }
 
@@ -189,7 +189,7 @@ origX.increment();    // 11
 10.increment();       // error, not lvalue
 
 // even this is possible
-fun incrementWithY(mutate self: int, mutate y: int, byValue: int) {
+fun int.incrementWithY(mutate self, mutate y: int, byValue: int) {
     self += byValue;
     y += byValue;
 }
@@ -197,13 +197,13 @@ fun incrementWithY(mutate self: int, mutate y: int, byValue: int) {
 origX.incrementWithY(mutate origY, 10);   // both += 10
 ```
 
-If you look into stdlib, you'll notice that many functions are actually **mutate self**, meaning they are methods of modifying an object. Tuples, dictionaries, and so on. In FunC, they were usually called via tilda.
+If you look into stdlib, you'll notice that many functions actually **mutate self**, meaning they are methods of modifying an object. Tuples, dictionaries, and so on. In FunC, they were usually called via tilda.
 ```tolk
 @pure
-fun tuplePush<X>(mutate self: tuple, value: X): void
+fun tuple.push<X>(mutate self, value: X): void
     asm "TPUSH";
 
-t.tuplePush(1);
+t.push(1);
 ```
 
 <h3 className="cmp-func-tolk-header">
@@ -212,7 +212,7 @@ t.tuplePush(1);
 
 It is precisely like `return self` in Python or `return this` in JavaScript. That makes methods like `storeInt()` and others chainable.
 ```tolk
-fun storeInt32(mutate self: builder, x: int): self {
+fun builder.storeInt32(mutate self, x: int): self {
     self.storeInt(x, 32);
     return self;
 
@@ -257,13 +257,13 @@ So, an `asm` function should place `self'` onto a stack before its return value:
 // "TPUSH" pops (tuple) and pushes (tuple')
 // so, self' = tuple', and return an empty tensor
 // `void` is a synonym for an empty tensor
-fun tuplePush<X>(mutate self: tuple, value: X): void
+fun tuple.push<X>(mutate self, value: X): void
     asm "TPUSH";
 
 // "LDU" pops (slice) and pushes (int, slice')
 // with asm(-> 1 0), we make it (slice', int)
 // so, self' = slice', and return int
-fun loadMessageFlags(mutate self: slice): int
+fun slice.loadMessageFlags(mutate self): int
     asm(-> 1 0) "4 LDU";
 ```
 
@@ -273,7 +273,7 @@ Note, that to return self, you don't have to do anything special, just specify a
 // with asm(op self), we put arguments to correct order
 // so, self' = builder', and return an empty tensor
 // but to make it chainable, `self` instead of `void`
-fun storeMessageOp(mutate self: builder, op: int): self
+fun builder.storeMessageOp(mutate self, op: int): self
     asm(op self) "32 STU";
 ```
 
@@ -282,12 +282,12 @@ It's doubtful you'll have to do such tricks. Most likely, you'll write wrappers 
 // just do it like this, without asm; it's the same effective
 
 @inline
-fun myLoadMessageFlags(mutate self: slice): int {
+fun slice.myLoadMessageFlags(mutate self): int {
     return self.loadUint(4);
 }
 
 @inline
-fun myStoreMessageOp(mutate self: builder, flags: int): self {
+fun builder.myStoreMessageOp(mutate self, flags: int): self {
     return self.storeUint(32, flags);
 }
 ```
@@ -298,30 +298,8 @@ fun myStoreMessageOp(mutate self: builder, flags: int): self {
 
 For now, better do it, yes. In most examples above, `@inline` was omitted for clarity. Without `@inline`, it will be a separate TVM continuation with jumps in/out. With `@inline`, a function will be generated, but inlined by Fift, like the `inline` specifier in FunC.
 
-In the future, Tolk will automatically detect simple functions and perform true inlining on the AST level. Such functions won't be even codegenerated to Fift. The compiler would decide, better than a human, whether to inline, to make a ref, etc. But it will take some time for Tolk to become so smart :) 
+In the future, Tolk will automatically detect simple functions and perform true inlining on the AST level. Such functions won't be even generated to Fift. The compiler would decide, better than a human, whether to inline, to make a ref, etc. But it will take some time for Tolk to become so smart :)
 
 For now, please specify the `@inline` attribute.
-
-<h3 className="cmp-func-tolk-header">
-  But `self` is not a method. It's still a function! I feel like I've been cheated
-</h3>
-
-Absolutely. Like FunC, Tolk has only global functions (as of v0.6). There are no classes or structures with methods. There are no methods `hash()` for `slice` and `hash()` for `cell`. Instead, there are functions `sliceHash()` and `cellHash()`, which can be called either like functions or by dot (preferred):
-```tolk
-fun f(s: slice, c: cell) {
-    // not like this
-    s.hash();
-    c.hash();
-    // but like this
-    s.sliceHash();
-    c.cellHash();
-    // since it's the same as
-    sliceHash(s);
-    cellHash(s);
-}
-```
-
-In the future, Tolk might be able to declare structures with actual methods that are generalized enough to cover built-in types. But it will take a long journey to follow and will be delivered at least after a giant amount of work on the type system, having fully refactored the FunC kernel inside.
-
 
 <Feedback />

--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.md
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.md
@@ -15,199 +15,238 @@ beginCell()          // available always
 createEmptyDict()    // available due to import
 ```
 2. You don't need to download it from GitHub; it's a part of Tolk distribution. 
-3. Almost all FunC functions were renamed to ~~verbose~~ clear names. So that when you write contracts or read examples, you better understand what's going on.
+3. Tolk has functions and methods (called via dot), lots of global FunC functions became methods of builder/slice/etc. (and can't be called as functions)
+
+
+## Functions vs methods
+
+In FunC, there are no methods, actually. All functions are global-scoped.  
+You just call any function via dot:
+```func
+;; FunC
+cell config_param(int x) asm "CONFIGOPTPARAM";
+
+config_param(16);   ;; ok
+16.config_param();  ;; also ok...
+```
+
+So, when you call `b.end_cell()`, you actually call a global function `end_cell`. 
+Since all functions are global-scoped, there are no "short methods."
+```func
+someTuple.tuple_size();
+;; why not someTuple.size()? because it's a global function:
+;; int tuple_size(tuple t)
+```
+
+**Tolk separates functions and methods** like it's done in most languages:
+1) functions can NOT be called via dot, only methods can
+2) methods can have short names, they don't conflict
+
+```tolk
+// FunC
+someCell.cell_hash();     // or cell_hash(someCell)
+someSlice.slice_hash();
+
+// Tolk
+someCell.hash();          // the only possible
+someSlice.hash();
+```
 
 
 ## A list of renamed functions
 
 If the **Required import** column is empty, a function is available without imports.
 
-Note that some of the functions were deleted because they either can be expressed syntactically,
+Note that some functions were deleted because they either can be expressed syntactically,
 or they were very uncommon in practice.
 
-| FunC name                | Tolk name                               | Required import |
-|--------------------------|-----------------------------------------|-----------------|
-| empty_tuple              | createEmptyTuple                        |                 |
-| tpush                    | tuplePush                               |                 |
-| first                    | tupleFirst                              |                 |
-| at                       | tupleAt                                 |                 |
-| touch                    | stackMoveToTop                          | tvm-lowlevel    |
-| impure_touch             | *(deleted)*                             |                 |
-| single                   | *(deleted)*                             |                 | 
-| unsingle                 | *(deleted)*                             |                 | 
-| pair                     | *(deleted)*                             |                 | 
-| unpair                   | *(deleted)*                             |                 | 
-| triple                   | *(deleted)*                             |                 | 
-| untriple                 | *(deleted)*                             |                 | 
-| tuple4                   | *(deleted)*                             |                 | 
-| untuple4                 | *(deleted)*                             |                 | 
-| second                   | *(deleted)*                             |                 | 
-| third                    | *(deleted)*                             |                 | 
-| fourth                   | *(deleted)*                             |                 | 
-| pair_first               | *(deleted)*                             |                 | 
-| pair_second              | *(deleted)*                             |                 | 
-| triple_first             | *(deleted)*                             |                 | 
-| triple_second            | *(deleted)*                             |                 | 
-| triple_third             | *(deleted)*                             |                 | 
-| minmax                   | minMax                                  |                 |
-| my_address               | getMyAddress                            |                 |
-| get_balance              | getMyOriginalBalanceWithExtraCurrencies |                 |
-| cur_lt                   | getLogicalTime                          |                 |
-| block_lt                 | getCurrentBlockLogicalTime              |                 |
-| cell_hash                | cellHash                                |                 |
-| slice_hash               | sliceHash                               |                 |
-| string_hash              | sliceBitsHash                           |                 |
-| check_signature          | isSignatureValid                        |                 |
-| check_data_signature     | isSliceSignatureValid                   |                 |
-| compute_data_size        | calculateCellSizeStrict                 |                 |
-| slice_compute_data_size  | calculateSliceSizeStrict                |                 |
-| compute_data_size?       | calculateCellSize                       |                 |
-| slice_compute_data_size? | calculateSliceSize                      |                 |
-| ~dump                    | debugPrint                              |                 |
-| ~strdump                 | debugPrintString                        |                 |
-| dump_stack               | debugDumpStack                          |                 |
-| get_data                 | getContractData                         |                 |
-| set_data                 | setContractData                         |                 |
-| get_c3                   | getTvmRegisterC3                        | tvm-lowlevel    |
-| set_c3                   | setTvmRegisterC3                        | tvm-lowlevel    |
-| bless                    | transformSliceToContinuation            | tvm-lowlevel    |
-| accept_message           | acceptExternalMessage                   |                 |
-| set_gas_limit            | setGasLimit                             |                 |
-| buy_gas                  | *(deleted)*                             |                 |
-| commit                   | commitContractDataAndActions            |                 |
-| divmod                   | divMod                                  |                 |
-| moddiv                   | modDiv                                  |                 |
-| muldiv                   | mulDivFloor                             |                 |
-| muldivr                  | mulDivRound                             |                 |
-| muldivc                  | mulDivCeil                              |                 |
-| muldivmod                | mulDivMod                               |                 |
-| begin_parse              | beginParse                              |                 |
-| end_parse                | assertEndOfSlice                        |                 |
-| load_ref                 | loadRef                                 |                 |
-| preload_ref              | preloadRef                              |                 |
-| load_int                 | loadInt                                 |                 |
-| load_uint                | loadUint                                |                 |
-| preload_int              | preloadInt                              |                 |
-| preload_uint             | preloadUint                             |                 |
-| load_bits                | loadBits                                |                 |
-| preload_bits             | preloadBits                             |                 |
-| load_grams               | loadCoins                               |                 |
-| load_coins               | loadCoins                               |                 |
-| skip_bits                | skipBits                                |                 |
-| first_bits               | getFirstBits                            |                 |
-| skip_last_bits           | removeLastBits                          |                 |
-| slice_last               | getLastBits                             |                 |
-| load_dict                | loadDict                                |                 |
-| preload_dict             | preloadDict                             |                 |
-| skip_dict                | skipDict                                |                 |
-| load_maybe_ref           | loadMaybeRef                            |                 |
-| preload_maybe_ref        | preloadMaybeRef                         |                 |
-| cell_depth               | getCellDepth                            |                 |
-| slice_refs               | getRemainingRefsCount                   |                 |
-| slice_bits               | getRemainingBitsCount                   |                 |
-| slice_bits_refs          | getRemainingBitsAndRefsCount            |                 |
-| slice_empty?             | isEndOfSlice                            |                 |
-| slice_data_empty?        | isEndOfSliceBits                        |                 |
-| slice_refs_empty?        | isEndOfSliceRefs                        |                 |
-| slice_depth              | getSliceDepth                           |                 |
-| equal_slice_bits         | isSliceBitsEqual                        |                 |
-| builder_refs             | getBuilderRefsCount                     |                 |
-| builder_bits             | getBuilderBitsCount                     |                 |
-| builder_depth            | getBuilderDepth                         |                 |
-| begin_cell               | beginCell                               |                 |
-| end_cell                 | endCell                                 |                 |
-| store_ref                | storeRef                                |                 |
-| store_uint               | storeUint                               |                 |
-| store_int                | storeInt                                |                 |
-| store_slice              | storeSlice                              |                 |
-| store_grams              | storeCoins                              |                 |
-| store_coins              | storeCoins                              |                 |
-| store_dict               | storeDict                               |                 |
-| store_maybe_ref          | storeMaybeRef                           |                 |
-| store_builder            | storeBuilder                            |                 |
-| load_msg_addr            | loadAddress                             |                 |
-| parse_addr               | parseAddress                            |                 |
-| parse_std_addr           | parseStandardAddress                    |                 |
-| parse_var_addr           | *(deleted)*                             |                 |
-| config_param             | getBlockchainConfigParam                |                 |
-| raw_reserve              | reserveToncoinsOnBalance                |                 |
-| raw_reserve_extra        | reserveExtraCurrenciesOnBalance         |                 |
-| send_raw_message         | sendRawMessage                          |                 |
-| set_code                 | setContractCodePostponed                |                 |
-| rand                     | randomRange                             |                 |
-| get_seed                 | randomGetSeed                           |                 |
-| set_seed                 | randomSetSeed                           |                 |
-| randomize                | randomizeBy                             |                 |
-| randomize_lt             | randomizeByLogicalTime                  |                 |
-| dump                     | debugPrint                              |                 |
-| strdump                  | debugPrintString                        |                 |
-| dump_stk                 | debugDumpStack                          |                 |
-| empty_list               | createEmptyList                         | lisp-lists      |
-| cons                     | listPrepend                             | lisp-lists      |
-| uncons                   | listSplit                               | lisp-lists      |
-| list_next                | listNext                                | lisp-lists      |
-| car                      | listGetHead                             | lisp-lists      |
-| cdr                      | listGetTail                             | lisp-lists      |
-| new_dict                 | createEmptyDict                         | tvm-dicts       |
-| dict_empty?              | dictIsEmpty                             | tvm-dicts       |
-| idict_set_ref            | iDictSetRef                             | tvm-dicts       |
-| udict_set_ref            | uDictSetRef                             | tvm-dicts       |
-| idict_get_ref            | iDictGetRefOrNull                       | tvm-dicts       |
-| idict_get_ref?           | iDictGetRef                             | tvm-dicts       |
-| udict_get_ref?           | uDictGetRef                             | tvm-dicts       |
-| idict_set_get_ref        | iDictSetAndGetRefOrNull                 | tvm-dicts       |
-| udict_set_get_ref        | iDictSetAndGetRefOrNull                 | tvm-dicts       |
-| idict_delete?            | iDictDelete                             | tvm-dicts       |
-| udict_delete?            | uDictDelete                             | tvm-dicts       |
-| idict_get?               | iDictGet                                | tvm-dicts       |
-| udict_get?               | uDictGet                                | tvm-dicts       |
-| idict_delete_get?        | iDictDeleteAndGet                       | tvm-dicts       |
-| udict_delete_get?        | uDictDeleteAndGet                       | tvm-dicts       |
-| udict_set                | uDictSet                                | tvm-dicts       |
-| idict_set                | iDictSet                                | tvm-dicts       |
-| dict_set                 | sDictSet                                | tvm-dicts       |
-| udict_add?               | uDictSetIfNotExists                     | tvm-dicts       |
-| udict_replace?           | uDictSetIfExists                        | tvm-dicts       |
-| idict_add?               | iDictSetIfNotExists                     | tvm-dicts       |
-| idict_replace?           | iDictSetIfExists                        | tvm-dicts       |
-| udict_set_builder        | uDictSetBuilder                         | tvm-dicts       |
-| idict_set_builder        | iDictSetBuilder                         | tvm-dicts       |
-| dict_set_builder         | sDictSetBuilder                         | tvm-dicts       |
-| udict_add_builder?       | uDictSetBuilderIfNotExists              | tvm-dicts       |
-| udict_replace_builder?   | uDictSetBuilderIfExists                 | tvm-dicts       |
-| idict_add_builder?       | iDictSetBuilderIfNotExists              | tvm-dicts       |
-| idict_replace_builder?   | iDictSetBuilderIfExists                 | tvm-dicts       |
-| udict_delete_get_min     | uDictDeleteFirstAndGet                  | tvm-dicts       |
-| idict_delete_get_min     | iDictDeleteFirstAndGet                  | tvm-dicts       |
-| dict_delete_get_min      | sDictDeleteFirstAndGet                  | tvm-dicts       |
-| udict_delete_get_max     | uDictDeleteLastAndGet                   | tvm-dicts       |
-| idict_delete_get_max     | iDictDeleteLastAndGet                   | tvm-dicts       |
-| dict_delete_get_max      | sDictDeleteLastAndGet                   | tvm-dicts       |
-| udict_get_min?           | uDictGetFirst                           | tvm-dicts       |
-| udict_get_max?           | uDictGetLast                            | tvm-dicts       |
-| udict_get_min_ref?       | uDictGetFirstAsRef                      | tvm-dicts       |
-| udict_get_max_ref?       | uDictGetLastAsRef                       | tvm-dicts       |
-| idict_get_min?           | iDictGetFirst                           | tvm-dicts       |
-| idict_get_max?           | iDictGetLast                            | tvm-dicts       |
-| idict_get_min_ref?       | iDictGetFirstAsRef                      | tvm-dicts       |
-| idict_get_max_ref?       | iDictGetLastAsRef                       | tvm-dicts       |
-| udict_get_next?          | uDictGetNext                            | tvm-dicts       |
-| udict_get_nexteq?        | uDictGetNextOrEqual                     | tvm-dicts       |
-| udict_get_prev?          | uDictGetPrev                            | tvm-dicts       |
-| udict_get_preveq?        | uDictGetPrevOrEqual                     | tvm-dicts       |
-| idict_get_next?          | iDictGetNext                            | tvm-dicts       |
-| idict_get_nexteq?        | iDictGetNextOrEqual                     | tvm-dicts       |
-| idict_get_prev?          | iDictGetPrev                            | tvm-dicts       |
-| idict_get_preveq?        | iDictGetPrevOrEqual                     | tvm-dicts       |
-| udict::delete_get_min    | uDictDeleteFirstAndGet                  | tvm-dicts       |
-| idict::delete_get_min    | iDictDeleteFirstAndGet                  | tvm-dicts       |
-| dict::delete_get_min     | sDictDeleteFirstAndGet                  | tvm-dicts       |
-| udict::delete_get_max    | uDictDeleteLastAndGet                   | tvm-dicts       |
-| idict::delete_get_max    | iDictDeleteLastAndGet                   | tvm-dicts       |
-| dict::delete_get_max     | sDictDeleteLastAndGet                   | tvm-dicts       |
-| pfxdict_get?             | prefixDictGet                           | tvm-dicts       |
-| pfxdict_set?             | prefixDictSet                           | tvm-dicts       |
-| pfxdict_delete?          | prefixDictDelete                        | tvm-dicts       |
+The table is "sorted" in a way how functions are declared in stdlib.fc:
+
+| FunC name                         | Tolk name                          | Required import |
+|-----------------------------------|------------------------------------|-----------------|
+| empty_tuple                       | createEmptyTuple                   |                 |
+| t~tpush                           | t.push(v)                          |                 |
+| first(t) or dot t.first()         | t.first()                          |                 |
+| at(t,i) or dot t.at(i)            | t.get(i) or just t.0 etc.          |                 |
+| touch(v) or dot                   | v.stackMoveToTop()                 | tvm-lowlevel    |
+| impure_touch                      | *(deleted)*                        |                 |
+| single                            | *(deleted)*                        |                 | 
+| unsingle                          | *(deleted)*                        |                 | 
+| pair                              | *(deleted)*                        |                 | 
+| unpair                            | *(deleted)*                        |                 | 
+| triple                            | *(deleted)*                        |                 | 
+| untriple                          | *(deleted)*                        |                 | 
+| tuple4                            | *(deleted)*                        |                 | 
+| untuple4                          | *(deleted)*                        |                 | 
+| second                            | *(deleted)*                        |                 | 
+| third                             | *(deleted)*                        |                 | 
+| fourth                            | *(deleted)*                        |                 | 
+| pair_first                        | *(deleted)*                        |                 | 
+| pair_second                       | *(deleted)*                        |                 | 
+| triple_first                      | *(deleted)*                        |                 | 
+| triple_second                     | *(deleted)*                        |                 | 
+| triple_third                      | *(deleted)*                        |                 | 
+| minmax                            | minMax                             |                 |
+| now                               | blockchain.now                     |                 |
+| my_address                        | contract.getAddress                |                 |
+| get_balance + pair_first          | contract.getOriginalBalance        |                 |
+| cur_lt                            | blockchain.logicalTime             |                 |
+| block_lt                          | blockchain.currentBlockLogicalTime |                 |
+| cell_hash(c) or dot               | c.hash()                           |                 |
+| slice_hash(s) or dot              | s.hash()                           |                 |
+| string_hash(s) or dot             | s.bitsHash()                       |                 |
+| check_signature                   | isSignatureValid                   |                 |
+| check_data_signature              | isSliceSignatureValid              |                 |
+| compute_data_size(c) or dot       | c.calculateSizeStrict()            |                 |
+| slice_compute_data_size(s) or dot | s.calculateSizeStrict()            |                 |
+| c.compute_data_size?() or dot     | c.calculateSize()                  |                 |
+| slice_compute_data_size?() or dot | s.calculateSize()                  |                 |
+| ~dump                             | debug.print                        |                 |
+| ~strdump                          | debug.printString                  |                 |
+| dump_stack                        | debug.dumpStack                    |                 |
+| get_data                          | contract.getData                   |                 |
+| set_data                          | contract.setData                   |                 |
+| get_c3                            | getTvmRegisterC3                   | tvm-lowlevel    |
+| set_c3                            | setTvmRegisterC3                   | tvm-lowlevel    |
+| bless                             | transformSliceToContinuation       | tvm-lowlevel    |
+| accept_message                    | acceptExternalMessage              |                 |
+| set_gas_limit                     | setGasLimit                        |                 |
+| buy_gas                           | *(deleted)*                        |                 |
+| commit                            | commitContractDataAndActions       |                 |
+| divmod                            | divMod                             |                 |
+| moddiv                            | modDiv                             |                 |
+| muldiv                            | mulDivFloor                        |                 |
+| muldivr                           | mulDivRound                        |                 |
+| muldivc                           | mulDivCeil                         |                 |
+| muldivmod                         | mulDivMod                          |                 |
+| begin_parse                       | beginParse                         |                 |
+| end_parse(s) or dot               | s.assertEnd()                      |                 |
+| load_ref                          | loadRef                            |                 |
+| preload_ref                       | preloadRef                         |                 |
+| load_int                          | loadInt                            |                 |
+| load_uint                         | loadUint                           |                 |
+| preload_int                       | preloadInt                         |                 |
+| preload_uint                      | preloadUint                        |                 |
+| load_bits                         | loadBits                           |                 |
+| preload_bits                      | preloadBits                        |                 |
+| load_grams                        | loadCoins                          |                 |
+| load_coins                        | loadCoins                          |                 |
+| skip_bits                         | s.skipBits                         |                 |
+| first_bits                        | getFirstBits                       |                 |
+| skip_last_bits                    | removeLastBits                     |                 |
+| slice_last                        | getLastBits                        |                 |
+| load_dict                         | loadDict                           |                 |
+| preload_dict                      | preloadDict                        |                 |
+| skip_dict                         | skipDict                           |                 |
+| load_maybe_ref                    | loadMaybeRef                       |                 |
+| preload_maybe_ref                 | preloadMaybeRef                    |                 |
+| cell_depth(c) or dot              | c.depth()                          |                 |
+| slice_refs(s) or dot              | s.remainingRefsCount()             |                 |
+| slice_bits(s) or dot              | s.remainingBitsCount()             |                 |
+| slice_bits_refs(s) or dot         | s.remainingBitsAndRefsCount()      |                 |
+| slice_empty?(s) or dot            | s.isEnd()                          |                 |
+| slice_data_empty?(s) or dot       | s.isEndOfBits()                    |                 |
+| slice_refs_empty?(s) or dot       | s.isEndOfRefs()                    |                 |
+| slice_depth(s) or dot             | s.depth()                          |                 |
+| equal_slice_bits(a,b) or dot      | a.bitsEqual(b)                     |                 |
+| builder_refs(b) or dot            | b.refsCount()                      |                 |
+| builder_bits(b) or dot            | b.bitsCount()                      |                 |
+| builder_depth(b) or dot           | b.depth()                          |                 |
+| begin_cell                        | beginCell                          |                 |
+| end_cell                          | endCell                            |                 |
+| store_ref                         | storeRef                           |                 |
+| store_uint                        | storeUint                          |                 |
+| store_int                         | storeInt                           |                 |
+| store_slice                       | storeSlice                         |                 |
+| store_grams                       | storeCoins                         |                 |
+| store_coins                       | storeCoins                         |                 |
+| store_dict                        | storeDict                          |                 |
+| store_maybe_ref                   | storeMaybeRef                      |                 |
+| store_builder                     | storeBuilder                       |                 |
+| load_msg_addr                     | loadAddress                        |                 |
+| parse_addr                        | *(deleted)*                        |                 |
+| parse_std_addr                    | parseStandardAddress               |                 |
+| parse_var_addr                    | *(deleted)*                        |                 |
+| config_param                      | blockchain.configParam             |                 |
+| raw_reserve                       | reserveToncoinsOnBalance           |                 |
+| raw_reserve_extra                 | reserveExtraCurrenciesOnBalance    |                 |
+| send_raw_message                  | sendRawMessage                     |                 |
+| set_code                          | contract.setCodePostponed          |                 |
+| random                            | random.uint256                     |                 |
+| rand                              | random.range                       |                 |
+| get_seed                          | random.getSeed                     |                 |
+| set_seed                          | random.setSeed                     |                 |
+| randomize                         | random.initializeBy                |                 |
+| randomize_lt                      | random.initialize                  |                 |
+| dump                              | debug.print                        |                 |
+| strdump                           | debug.printString                  |                 |
+| dump_stk                          | debug.dumpStack                    |                 |
+| empty_list                        | createEmptyList                    | lisp-lists      |
+| cons                              | listPrepend                        | lisp-lists      |
+| uncons                            | listSplit                          | lisp-lists      |
+| list_next                         | listNext                           | lisp-lists      |
+| car                               | listGetHead                        | lisp-lists      |
+| cdr                               | listGetTail                        | lisp-lists      |
+| new_dict                          | createEmptyDict                    | tvm-dicts       |
+| dict_empty?(d) or dot             | d.dictIsEmpty                      | tvm-dicts       |
+| idict_set_ref                     | iDictSetRef                        | tvm-dicts       |
+| udict_set_ref                     | uDictSetRef                        | tvm-dicts       |
+| idict_get_ref                     | iDictGetRefOrNull                  | tvm-dicts       |
+| idict_get_ref?                    | iDictGetRef                        | tvm-dicts       |
+| udict_get_ref?                    | uDictGetRef                        | tvm-dicts       |
+| idict_set_get_ref                 | iDictSetAndGetRefOrNull            | tvm-dicts       |
+| udict_set_get_ref                 | iDictSetAndGetRefOrNull            | tvm-dicts       |
+| idict_delete?                     | iDictDelete                        | tvm-dicts       |
+| udict_delete?                     | uDictDelete                        | tvm-dicts       |
+| idict_get?                        | iDictGet                           | tvm-dicts       |
+| udict_get?                        | uDictGet                           | tvm-dicts       |
+| idict_delete_get?                 | iDictDeleteAndGet                  | tvm-dicts       |
+| udict_delete_get?                 | uDictDeleteAndGet                  | tvm-dicts       |
+| udict_set                         | uDictSet                           | tvm-dicts       |
+| idict_set                         | iDictSet                           | tvm-dicts       |
+| dict_set                          | sDictSet                           | tvm-dicts       |
+| udict_add?                        | uDictSetIfNotExists                | tvm-dicts       |
+| udict_replace?                    | uDictSetIfExists                   | tvm-dicts       |
+| idict_add?                        | iDictSetIfNotExists                | tvm-dicts       |
+| idict_replace?                    | iDictSetIfExists                   | tvm-dicts       |
+| udict_set_builder                 | uDictSetBuilder                    | tvm-dicts       |
+| idict_set_builder                 | iDictSetBuilder                    | tvm-dicts       |
+| dict_set_builder                  | sDictSetBuilder                    | tvm-dicts       |
+| udict_add_builder?                | uDictSetBuilderIfNotExists         | tvm-dicts       |
+| udict_replace_builder?            | uDictSetBuilderIfExists            | tvm-dicts       |
+| idict_add_builder?                | iDictSetBuilderIfNotExists         | tvm-dicts       |
+| idict_replace_builder?            | iDictSetBuilderIfExists            | tvm-dicts       |
+| udict_delete_get_min              | uDictDeleteFirstAndGet             | tvm-dicts       |
+| idict_delete_get_min              | iDictDeleteFirstAndGet             | tvm-dicts       |
+| dict_delete_get_min               | sDictDeleteFirstAndGet             | tvm-dicts       |
+| udict_delete_get_max              | uDictDeleteLastAndGet              | tvm-dicts       |
+| idict_delete_get_max              | iDictDeleteLastAndGet              | tvm-dicts       |
+| dict_delete_get_max               | sDictDeleteLastAndGet              | tvm-dicts       |
+| udict_get_min?                    | uDictGetFirst                      | tvm-dicts       |
+| udict_get_max?                    | uDictGetLast                       | tvm-dicts       |
+| udict_get_min_ref?                | uDictGetFirstAsRef                 | tvm-dicts       |
+| udict_get_max_ref?                | uDictGetLastAsRef                  | tvm-dicts       |
+| idict_get_min?                    | iDictGetFirst                      | tvm-dicts       |
+| idict_get_max?                    | iDictGetLast                       | tvm-dicts       |
+| idict_get_min_ref?                | iDictGetFirstAsRef                 | tvm-dicts       |
+| idict_get_max_ref?                | iDictGetLastAsRef                  | tvm-dicts       |
+| udict_get_next?                   | uDictGetNext                       | tvm-dicts       |
+| udict_get_nexteq?                 | uDictGetNextOrEqual                | tvm-dicts       |
+| udict_get_prev?                   | uDictGetPrev                       | tvm-dicts       |
+| udict_get_preveq?                 | uDictGetPrevOrEqual                | tvm-dicts       |
+| idict_get_next?                   | iDictGetNext                       | tvm-dicts       |
+| idict_get_nexteq?                 | iDictGetNextOrEqual                | tvm-dicts       |
+| idict_get_prev?                   | iDictGetPrev                       | tvm-dicts       |
+| idict_get_preveq?                 | iDictGetPrevOrEqual                | tvm-dicts       |
+| udict::delete_get_min             | uDictDeleteFirstAndGet             | tvm-dicts       |
+| idict::delete_get_min             | iDictDeleteFirstAndGet             | tvm-dicts       |
+| dict::delete_get_min              | sDictDeleteFirstAndGet             | tvm-dicts       |
+| udict::delete_get_max             | uDictDeleteLastAndGet              | tvm-dicts       |
+| idict::delete_get_max             | iDictDeleteLastAndGet              | tvm-dicts       |
+| dict::delete_get_max              | sDictDeleteLastAndGet              | tvm-dicts       |
+| pfxdict_get?                      | prefixDictGet                      | tvm-dicts       |
+| pfxdict_set?                      | prefixDictSet                      | tvm-dicts       |
+| pfxdict_delete?                   | prefixDictDelete                   | tvm-dicts       |
 
 
 ## A list of added functions
@@ -257,7 +296,7 @@ But if you used `dict.udict_set(…)` to obtain a copy, you'll need to express i
 [Read about mutability](/v3/documentation/smart-contracts/tolk/tolk-vs-func/mutability).
 
 
-## How does embedded stdlib work under the hood
+## How does embedded stdlib work under the hood?
 
 As told above, all standard functions are available out of the box. 
 You need `import` for non-common functions (it's intentional), but still, no external downloads.

--- a/src/theme/prism/prism-tolk.js
+++ b/src/theme/prism/prism-tolk.js
@@ -1,6 +1,6 @@
 /**
  * @file Prism.js definition for Tolk (next-generation FunC)
- * @version 0.6.0
+ * @version 0.12.0
  * @author Aleksandr Kirsanov (https://github.com/tolk-vm)
  * @license MIT
  */
@@ -18,17 +18,17 @@
       }
     ],
 
-    'type-hint': /\b(type|enum|int|cell|void|never|bool|slice|tuple|builder|continuation|coins|int8|int16|int32|int64|uint8|uint16|uint32|uint64|uint256|bytes16|bytes32|bytes64|bits8|bits16|bits32|bits64|bits128|bits256)\b/,
+    'type-hint': /\b(enum|int|cell|void|never|bool|slice|tuple|builder|continuation|coins|int8|int16|int32|int64|uint8|uint16|uint32|uint64|uint256|bytes16|bytes32|bytes64|bits8|bits16|bits32|bits64|bits128|bits256)\b/,
 
     'boolean': /\b(false|true|null)\b/,
 
-    'keyword': /\b(do|if|as|is|try|else|while|break|throw|catch|return|assert|repeat|continue|asm|builtin|import|export|true|false|null|redef|mutate|tolk|global|const|var|val|fun|get|struct|match)\b/,
+    'keyword': /\b(do|if|as|is|try|else|while|break|throw|catch|return|assert|repeat|continue|asm|builtin|import|export|true|false|null|redef|mutate|tolk|global|const|var|val|fun|get|struct|match|type)\b/,
 
     'self': /\b(self)\b/,
 
-    'function': /[a-zA-Z$_][a-zA-Z0-9$_]*(?=\s*[(<])/,
+    'function': /[a-zA-Z$_][a-zA-Z0-9$_]*(?=(<[^>]+>)*\()/,
 
-    'number': new RegExp("(-?([\\d]+|0x[\\da-fA-F]+|0b[01]+))\\b"),
+    'number': /\b(-?\d+|0x[\da-fA-F]+|0b[01]+)\b/,
 
     'string': [
       {


### PR DESCRIPTION
## Description

Update documentation for Tolk Language according to changes in Tolk v0.12.

* https://github.com/ton-blockchain/ton/pull/1645

### Notable changes in Tolk v0.12:

1. Structures – named data representations, replacing raw tensors
2. Generics – reusable, type-safe abstractions
3. Methods — extension functions for any custom or built-in type
4. Lots of long stdlib functions were renamed to short methods
5. Fift output now contains original .tolk lines as comments

Closes #1152

## Checklist

- [x] I have created an issue.
- [x] I am working on content that aligns with the [Style guide](https://docs.ton.org/v3/contribute/style-guide/).
- [x] I have reviewed and formatted the content according to [Content standardization](https://docs.ton.org/v3/contribute/content-standardization/).
- [x] I have reviewed and formatted the text in the article according to [Typography](https://docs.ton.org/v3/contribute/typography/).
