### PR TITLE
1182-fix-blueprint-sdk

### DIFF
--- a/docs/v3/documentation/smart-contracts/getting-started/javascript.mdx
+++ b/docs/v3/documentation/smart-contracts/getting-started/javascript.mdx
@@ -3,7 +3,7 @@ import Feedback from '@site/src/components/Feedback';
 import Button from '@site/src/components/button'
 
 
-# Blueprint SDK
+# Blueprint
 
 ![Blueprint](/img/blueprint/logo.svg)
 

--- a/docs/v3/guidelines/dapps/overview.mdx
+++ b/docs/v3/guidelines/dapps/overview.mdx
@@ -67,7 +67,7 @@ Here are key resources for your dApp development journey:
 1. [Developer wallets](/v3/concepts/dive-into-ton/ton-ecosystem/wallet-apps)
 2. [Blockchain explorers](/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton)
 3. [API documentation](/v3/guidelines/dapps/apis-sdks/api-types)
-4. [SDKs for various Languages](/v3/guidelines/dapps/apis-sdks/sdk)
+4. [SDKs for various languages](/v3/guidelines/dapps/apis-sdks/sdk)
 5. [Using the testnet](/v3/documentation/smart-contracts/getting-started/testnet)
 6. [TON unfreezer](https://unfreezer.ton.org/)
 

--- a/docs/v3/guidelines/quick-start/developing-smart-contracts/func-tolk-folder/blueprint-sdk-overview.mdx
+++ b/docs/v3/guidelines/quick-start/developing-smart-contracts/func-tolk-folder/blueprint-sdk-overview.mdx
@@ -3,11 +3,11 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import Button from '@site/src/components/button'
 
-# Blueprint SDK overview
+# Blueprint overview
 
 > **Summary:** In the previous steps, we installed and configured all the tools required for TON smart contract development and created our first project template.
 
-Before we proceed to actual smart contract development, let's briefly describe the project structure and explain how to use the **`Blueprint SDK`**.
+Before we proceed to actual smart contract development, let's briefly describe the project structure and explain how to use the **`Blueprint`**.
 
 ## Project structure
 

--- a/docs/v3/guidelines/quick-start/developing-smart-contracts/func-tolk-folder/deploying-to-network.mdx
+++ b/docs/v3/guidelines/quick-start/developing-smart-contracts/func-tolk-folder/deploying-to-network.mdx
@@ -50,7 +50,7 @@ This mechanism plays a crucial role in [Jetton Processing](/v3/guidelines/dapps/
 */}
 ## Implementation
 
-Now that our smart contracts are fully tested, we are ready to deploy them to TON. In `Blueprint SDK`, this process is the same for both `Mainnet` and `Testnet` and for any of the presented languages in the guide: `FunC` or `Tolk`.
+Now that our smart contracts are fully tested, we are ready to deploy them to TON. In `Blueprint`, this process is the same for both `Mainnet` and `Testnet` and for any of the presented languages in the guide: `FunC` or `Tolk`.
 
 ### Step 1: update the deployment script
 
@@ -137,7 +137,7 @@ You can view it at https://testnet.tonscan.org/address/EQBrFHgzSwxVYBXjIYAM6g2RH
 **Congratulations!** Your custom `smart contract` is ready to execute `get methods` the same way as your wallet in the [Getting started](/v3/guidelines/quick-start/getting-started#navigation-tabs/) section and execute `transactions` the same as in the [Blockchain Interaction](/v3/guidelines/quick-start/blockchain-interaction/reading-from-network) section — consider reading it to understand how to interact with `smart contracts` off-chain if you haven't already.
 
 :::tip
-Using `Blueprint SDK` and wallet apps is not the only option. You can create a message with [state_init](/v3/documentation/smart-contracts/message-management/sending-messages#message-layout/) by yourself. Moreover, you can do it even through a smart contract's [internal message](/v3/documentation/smart-contracts/message-management/sending-messages#message-layout/).
+Using `Blueprint` and wallet apps is not the only option. You can create a message with [state_init](/v3/documentation/smart-contracts/message-management/sending-messages#message-layout/) by yourself. Moreover, you can do it even through a smart contract's [internal message](/v3/documentation/smart-contracts/message-management/sending-messages#message-layout/).
 :::
 
 <Feedback />

--- a/docs/v3/guidelines/quick-start/developing-smart-contracts/func-tolk-folder/processing-messages.mdx
+++ b/docs/v3/guidelines/quick-start/developing-smart-contracts/func-tolk-folder/processing-messages.mdx
@@ -191,7 +191,7 @@ This implementation is **unsafe** and may lead to losing your contract funds. Do
 
 ## Implementation
 
-Let's modify our smart contract to receive external messages following the standard steps described in the previous [Blueprint SDK overview](/v3/guidelines/quick-start/developing-smart-contracts/blueprint-sdk-overview/) section.
+Let's modify our smart contract to receive external messages following the standard steps described in the previous [Blueprint overview](/v3/guidelines/quick-start/developing-smart-contracts/blueprint-sdk-overview/) section.
 
 ### Step 1: edit smart contract code
 

--- a/docs/v3/guidelines/quick-start/developing-smart-contracts/func-tolk-folder/processing-messages.mdx
+++ b/docs/v3/guidelines/quick-start/developing-smart-contracts/func-tolk-folder/processing-messages.mdx
@@ -191,7 +191,7 @@ This implementation is **unsafe** and may lead to losing your contract funds. Do
 
 ## Implementation
 
-Let's modify our smart contract to receive external messages following the standard steps described in the previous [Blueprint overview](/v3/guidelines/quick-start/developing-smart-contracts/blueprint-sdk-overview/) section.
+Let's modify our smart contract to receive external messages following the standard steps described in the previous [Blueprint overview](/v3/guidelines/quick-start/developing-smart-contracts/func-tolk-folder/blueprint-sdk-overview/) section.
 
 ### Step 1: edit smart contract code
 

--- a/docs/v3/guidelines/quick-start/developing-smart-contracts/func-tolk-folder/storage-and-get-methods.mdx
+++ b/docs/v3/guidelines/quick-start/developing-smart-contracts/func-tolk-folder/storage-and-get-methods.mdx
@@ -54,7 +54,7 @@ interface Cell {
 
 ## Implementation
 
-Let's modify our smart contract by following the standard steps described in the previous [Blueprint overview](/v3/guidelines/quick-start/developing-smart-contracts/blueprint-overview/) section.
+Let's modify our smart contract by following the standard steps described in the previous [Blueprint overview](/v3/guidelines/quick-start/developing-smart-contracts/func-tolk-folder/blueprint-sdk-overview/) section.
 
 ### Step 1: edit smart contract code
 

--- a/docs/v3/guidelines/quick-start/developing-smart-contracts/func-tolk-folder/storage-and-get-methods.mdx
+++ b/docs/v3/guidelines/quick-start/developing-smart-contracts/func-tolk-folder/storage-and-get-methods.mdx
@@ -5,7 +5,7 @@ import Button from '@site/src/components/button'
 
 # Storage and get methods
 
-> **Summary:** In the previous steps, we learned how to use the `Blueprint SDK` and its project structure.
+> **Summary:** In the previous steps, we learned how to use the `Blueprint` and its project structure.
 
 :::tip
 If you're stuck on any of the examples, you can find the original template project with all modifications made during this guide [here](https://github.com/ton-community/onboarding-sandbox/tree/main/quick-start/smart-contracts/Example/contracts).
@@ -54,7 +54,7 @@ interface Cell {
 
 ## Implementation
 
-Let's modify our smart contract by following the standard steps described in the previous [Blueprint SDK overview](/v3/guidelines/quick-start/developing-smart-contracts/blueprint-sdk-overview/) section.
+Let's modify our smart contract by following the standard steps described in the previous [Blueprint overview](/v3/guidelines/quick-start/developing-smart-contracts/blueprint-overview/) section.
 
 ### Step 1: edit smart contract code
 

--- a/docs/v3/guidelines/quick-start/developing-smart-contracts/setup-environment.mdx
+++ b/docs/v3/guidelines/quick-start/developing-smart-contracts/setup-environment.mdx
@@ -5,7 +5,7 @@ import Button from '@site/src/components/button'
 
 > **Summary:** In the previous steps, we learned the concept of a smart contract and basic ways of interacting with TON Blockchain through **wallet apps** and **explorers**.
 
-This guide covers the basic steps of setting up your smart contract development environment using **`Blueprint SDK`** and creating a basic project template.
+This guide covers the basic steps of setting up your smart contract development environment using **`Blueprint`** and creating a basic project template.
 
 ## Prerequisites
 
@@ -14,7 +14,7 @@ This guide covers the basic steps of setting up your smart contract development 
 
 ## Setup development environment
 
-For this guide, we will rely on the [Blueprint SDK](https://github.com/ton-org/blueprint/) and [Node.js](https://nodejs.org/en)/TypeScript stack for writing wrappers, tests, and deployment scripts for your smart contract, as it provides the easiest, ready-to-use environment for smart contract development.
+For this guide, we will rely on the [Blueprint](https://github.com/ton-org/blueprint/) and [Node.js](https://nodejs.org/en)/TypeScript stack for writing wrappers, tests, and deployment scripts for your smart contract, as it provides the easiest, ready-to-use environment for smart contract development.
 
 :::info
 Using native tools and language-dependent SDKs for smart contract development is covered in more advanced sections here:
@@ -41,7 +41,7 @@ During the guide, we provide examples in `FunC`, `Tolk`, and `Tact`. You can cho
 You can find a brief overview of the languages here: [Programming languages](/v3/documentation/smart-contracts/overview#programming-languages/)
 :::
 
-### Step 3: set up Blueprint SDK
+### Step 3: set up Blueprint
 
 Change the directory to the parent folder of your future project and run the following command:
 
@@ -89,7 +89,6 @@ Now that your environment is set up choose a programming language to get started
   Start with Tact
 
 </Button>
-
 
 
 

--- a/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-blueprint-sdk-overview.mdx
+++ b/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-blueprint-sdk-overview.mdx
@@ -82,7 +82,7 @@ npx blueprint run
 ```
 
 :::tip
-All examples in this guide follow the sequence of these **1-3 steps** with corresponding code samples. **Step 5**, the deployment process, is covered in the last section of the guide: [Deploying to network](/v3/guidelines/quick-start/developing-smart-contracts/deploying-to-network/).
+All examples in this guide follow the sequence of these **1-3 steps** with corresponding code samples. **Step 5**, the deployment process, is covered in the last section of the guide: [Deploying to network](/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network/).
 :::
 
 Also, you can always generate the same structure for another smart contract if, for example, you want to create multiple contracts interacting with each other by using the following command:

--- a/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-blueprint-sdk-overview.mdx
+++ b/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-blueprint-sdk-overview.mdx
@@ -3,7 +3,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import Button from '@site/src/components/button'
 
-# Blueprint SDK overview
+# Blueprint overview
 
 > **Summary:** In the previous steps, we installed and configured all the tools required for TON smart contract development and created our first project template.
 
@@ -11,7 +11,7 @@ import Button from '@site/src/components/button'
 We recommend installing the [Tact extension for VS Code](https://marketplace.visualstudio.com/items?itemName=tonstudio.vscode-tact). It offers syntax highlighting, error hints, and a smoother development experience.
 :::
 
-Before we proceed to actual smart contract development, let's briefly describe the project structure and explain how to use the **`Blueprint SDK`**.
+Before we proceed to actual smart contract development, let's briefly describe the project structure and explain how to use the **`Blueprint`**.
 
 ## Project structure
 

--- a/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx
+++ b/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx
@@ -50,7 +50,7 @@ This mechanism plays a crucial role in [Jetton Processing](/v3/guidelines/dapps/
 
 ## Implementation
 
-Now that our smart contracts are fully tested, we are ready to deploy them to TON. In `Blueprint SDK`, this process is the same for both `Mainnet` and `Testnet` and for any of the presented languages in the guide: `FunC`, `Tact`, or `Tolk`.
+Now that our smart contracts are fully tested, we are ready to deploy them to TON. In `Blueprint`, this process is the same for both `Mainnet` and `Testnet` and for any of the presented languages in the guide: `FunC`, `Tact`, or `Tolk`.
 
 ### Step 1: update the deployment script
 
@@ -139,7 +139,7 @@ You can view it at https://testnet.tonscan.org/address/EQBrFHgzSwxVYBXjIYAM6g2RH
 **Congratulations!** Your custom `smart contract` is ready to execute `get methods` the same way as your wallet in the [Getting started](/v3/guidelines/quick-start/getting-started#navigation-tabs/) section and execute `transactions` the same as in the [Blockchain Interaction](/v3/guidelines/quick-start/blockchain-interaction/reading-from-network) section — consider reading it to understand how to interact with `smart contracts` off-chain if you haven't already.
 
 :::tip
-Using `Blueprint SDK` and wallet apps is not the only option. You can create a message with [state_init](/v3/documentation/smart-contracts/message-management/sending-messages#message-layout/) by yourself. Moreover, you can do it even through a smart contract's [internal message](/v3/documentation/smart-contracts/message-management/sending-messages#message-layout/).
+Using `Blueprint` and wallet apps is not the only option. You can create a message with [state_init](/v3/documentation/smart-contracts/message-management/sending-messages#message-layout/) by yourself. Moreover, you can do it even through a smart contract's [internal message](/v3/documentation/smart-contracts/message-management/sending-messages#message-layout/).
 :::
 
 <Feedback />

--- a/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx
+++ b/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx
@@ -5,7 +5,7 @@ import Button from '@site/src/components/button'
 
 # Storage and get methods
 
-> **Summary:** In the previous steps, we learned how to use the `Blueprint SDK` and its project structure.
+> **Summary:** In the previous steps, we learned how to use the `Blueprint` and its project structure.
 
 Tact is a high-level programming language for the TON Blockchain, focused on efficiency and simplicity. It is designed to be easy to learn and use while being well-suited for smart contract development. Tact is a statically typed language with a simple syntax and a powerful type system.
 
@@ -13,7 +13,7 @@ Tact is a high-level programming language for the TON Blockchain, focused on eff
 For more details, refer to the [Tact documentation](https://docs.tact-lang.org/#start/) and [Tact By Example](https://tact-by-example.org/00-hello-world/).
 :::
 
-Let's create and modify our smart contract following standard steps described in the previous [Blueprint SDK overview](/v3/guidelines/quick-start/developing-smart-contracts/blueprint-sdk-overview/) section.
+Let's create and modify our smart contract following standard steps described in the previous [Blueprint overview](/v3/guidelines/quick-start/developing-smart-contracts/blueprint-sdk-overview/) section.
 
 ## Step 1: edit smart contract code
 

--- a/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx
+++ b/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx
@@ -13,7 +13,7 @@ Tact is a high-level programming language for the TON Blockchain, focused on eff
 For more details, refer to the [Tact documentation](https://docs.tact-lang.org/#start/) and [Tact By Example](https://tact-by-example.org/00-hello-world/).
 :::
 
-Let's create and modify our smart contract following standard steps described in the previous [Blueprint overview](/v3/guidelines/quick-start/developing-smart-contracts/blueprint-sdk-overview/) section.
+Let's create and modify our smart contract following standard steps described in the previous [Blueprint overview](/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-blueprint-sdk-overview/) section.
 
 ## Step 1: edit smart contract code
 

--- a/docs/v3/guidelines/quick-start/getting-started.mdx
+++ b/docs/v3/guidelines/quick-start/getting-started.mdx
@@ -19,7 +19,7 @@ Welcome to the TON Quick start guide! This guide will give you a starting point 
 - Understand the key principles of TON Blockchain, including `messages`, `smart contracts`, and `addresses`.
 - Interact with TON Ecosystem, including wallets and blockchain explorers.
 - Interact with TON Blockchain, such as reading from and writing data.
-- Set up a development environment using the `SDK` for `smart contract` development.
+- Set up a development environment using the `Blueprint` for `smart contract` development.
 - Start writing smart contracts using the `FunC`, `Tolk`, and `Tact` programming languages in TON.
 
 ## Concept of smart contract

--- a/docs/v3/guidelines/smart-contracts/get-methods.md
+++ b/docs/v3/guidelines/smart-contracts/get-methods.md
@@ -222,7 +222,7 @@ You can call get methods on the "Get methods" tab.
 We will use Javascript libraries and tools for the examples below:
 
 - [ton](https://github.com/ton-org/ton/) library
-- [Blueprint](/v3/documentation/smart-contracts/getting-started/javascript/) SDK
+- [Blueprint](/v3/documentation/smart-contracts/getting-started/javascript/) 
 
 Let's say there is some contract with the following get method:
 

--- a/docs/v3/guidelines/smart-contracts/testing/writing-test-examples.mdx
+++ b/docs/v3/guidelines/smart-contracts/testing/writing-test-examples.mdx
@@ -5,7 +5,7 @@ import ThemedImage from "@theme/ThemedImage";
 
 # Writing test examples
 
-This page demonstrates how to write tests for FunC contracts using the [Blueprint SDK](https://github.com/ton-org/blueprint) ([Sandbox](https://github.com/ton-org/sandbox)).  
+This page demonstrates how to write tests for FunC contracts using the [Blueprint](https://github.com/ton-org/blueprint) ([Sandbox](https://github.com/ton-org/sandbox)).
 The test suites focus on the demo contract [Fireworks](https://github.com/ton-community/fireworks-func), a smart contract that starts running with the `set_first` message.
 
 When you create a new FunC project using `npm create ton@latest`, the SDK automatically generates a test file `tests/contract.spec.ts` in the project directory for testing the contract:


### PR DESCRIPTION
## Description

removing SDK from "Blueprint SDK"

Closes https://github.com/ton-community/ton-docs/issues/1182.

## Checklist

- [x] I have created an issue.
- [x] I am working on content that aligns with the [Style guide](https://docs.ton.org/v3/contribute/style-guide/).
- [x] I have reviewed and formatted the content according to [Content standardization](https://docs.ton.org/v3/contribute/content-standardization/).
- [x] I have reviewed and formatted the text in the article according to [Typography](https://docs.ton.org/v3/contribute/typography/).
