### PR TITLE
fix(instructions): auto-switch to Aliases tab on alias-only searches

### DIFF
--- a/src/components/Instructions/InstructionGroups.tsx
+++ b/src/components/Instructions/InstructionGroups.tsx
@@ -67,34 +67,53 @@ export const InstructionGroups = React.memo(({ instructions, aliases, search }: 
       item.doc_fift?.toLowerCase()?.includes(searchValue),
   ), [searchValue]);
 
-  return <Tabs>
-    {
-      sections.map(({ label, types, value }) => {
-        if (value === 'alias') {
-          return filteredAliases?.length ? <TabItem label={label} value={value} key={value}>
-            <InstructionTable instructions={filteredAliases.map((alias) => ({
-              opcode: alias.instruction?.doc?.opcode,
-              fift: alias.doc_fift,
-              gas: alias.instruction?.doc?.gas,
-              description: alias.description,
-              stack: alias.doc_stack,
-            }))}/>
-          </TabItem> : null;
-        }
+    const activeTab = useMemo(() => {
+      if (filteredAliases.length > 0 && filteredInstructions.length === 0) {
+        return 'alias';
+      }
+      return 'all';
+    }, [filteredAliases, filteredInstructions]);
 
-        const tabInstructions = types ? filteredInstructions.filter(instruction => types.includes(instruction.doc.category)) : filteredInstructions;
-        return (tabInstructions?.length ?
-          <TabItem label={label} value={value} key={value}>
-            <InstructionTable
-              instructions={tabInstructions.map(instruction => ({
-                opcode: instruction.doc?.opcode,
-                fift: instruction.doc?.fift,
-                gas: instruction.doc?.gas,
-                description: instruction?.doc.description,
-                stack: instruction.doc?.stack,
-              }))}/>
-          </TabItem> : null);
-      })
-    }
-  </Tabs>;
-});
+    return (
+      <Tabs key={activeTab} defaultValue={activeTab}>
+        {sections.map(({ label, types, value }) => {
+          if (value === 'alias') {
+            if (!filteredAliases.length) return null;
+            return (
+              <TabItem label={label} value={value} key={value}>
+                <InstructionTable
+                  instructions={filteredAliases.map((alias) => ({
+                    opcode: alias.instruction?.doc.opcode,
+                    fift: alias.doc_fift,
+                    gas: alias.instruction?.doc.gas,
+                    description: alias.description,
+                    stack: alias.doc_stack,
+                  }))}
+                />
+              </TabItem>
+            );
+          }
+
+          const tabInstructions = types
+            ? filteredInstructions.filter((inst) => types.includes(inst.doc.category))
+            : filteredInstructions;
+
+          if (!tabInstructions.length) return null;
+          return (
+            <TabItem label={label} value={value} key={value}>
+              <InstructionTable
+                instructions={tabInstructions.map((inst) => ({
+                  opcode: inst.doc.opcode,
+                  fift: inst.doc.fift,
+                  gas: inst.doc.gas,
+                  description: inst.doc.description,
+                  stack: inst.doc.stack,
+                }))}
+              />
+            </TabItem>
+          );
+        })}
+      </Tabs>
+    );
+  },
+);


### PR DESCRIPTION
**What’s changed**

If your search only matches aliases (e.g. TRIPLE), the “Aliases” tab now opens automatically and its table is shown immediately.

![Screenshot 2025-05-30 at 02 08 06](https://github.com/user-attachments/assets/f203ab50-baf2-4ac6-a48b-b0a7c0a3d4a0)


**Why**
Previously you had to type “triple” and then manually click the Aliases tab to see the result. 

![Screenshot 2025-05-30 at 00 09 06](https://github.com/user-attachments/assets/1b3e6690-c4cc-47ec-a635-5e2444c58263)



Closes https://github.com/ton-community/ton-docs/issues/865#event-17844493317
