### PR TITLE
Add Tact VS Code extension to the list of TL-B IDEs

### DIFF
--- a/docs/v3/documentation/data-formats/tlb/tlb-ide.md
+++ b/docs/v3/documentation/data-formats/tlb/tlb-ide.md
@@ -2,6 +2,18 @@ import Feedback from '@site/src/components/Feedback';
 
 # IDE support
 
+## VS Code
+
+The Tact VS Code extension supports the Tact language, as well as other languages including TL-B.
+
+- [Marketplace link](https://marketplace.visualstudio.com/items?itemName=tonstudio.vscode-tact)
+- [Open VSX registry link](https://open-vsx.org/extension/tonstudio/vscode-tact)
+- [GitHub repository](https://github.com/tact-lang/tact-language-server)
+
+Syntax specification is defined in the Tree-sitter [grammar.js](https://github.com/tact-lang/tact-language-server/blob/master/server/src/languages/tlb/tree-sitter-tlb/grammar.js) file.
+
+## JetBrains IDEs
+
 The [intellij-ton](https://github.com/andreypfau/intellij-ton) plugin supports the Fift and FunC programming languages and the Typed Language Binary (TL-B) format.
 
 The TL-B syntax specification is defined in the [TlbParser.bnf](https://github.com/ton-blockchain/intellij-ton/blob/main/src/main/grammar/TlbParser.bnf) file.


### PR DESCRIPTION
Fixes #1215


