### PR TITLE
Update docs for Tolk v1.0

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -373,7 +373,7 @@
     "deployment",
     "docs/learn/tvm-instructions/instructions.csv",
     "docs/learn/tvm-instructions/generate_md.py",
-    "docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.md",
+    "docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx",
     "sidebars.js",
     "sidebars",
     "i18n",

--- a/docs/v3/documentation/smart-contracts/tolk/changelog.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/changelog.mdx
@@ -2,7 +2,16 @@ import Feedback from '@site/src/components/Feedback';
 
 # History of Tolk
 
-Once new versions of Tolk are released, they are mentioned here.
+Once new versions are released, they are mentioned here.
+
+
+## v1.0
+
+1. The magic `lazy` keyword — lazy loading, partial loading, partial updating
+2. Auto-detect and inline functions at the compiler level
+3. Various peephole optimizations for gas efficiency
+4. `onInternalMessage` and `onBouncedMessage`, TVM 11 support
+5. Custom pack/unpack serializers for custom types
 
 
 ## v0.99
@@ -78,30 +87,48 @@ Once new versions of Tolk are released, they are mentioned here.
 The first public release. Here are some notes about its origin: 
 
 
+## A brief history of Tolk
+
+When Tolk was first conceived, the idea was simple:
+What if we had a language for TON that was **low-level and efficient**, but **felt more familiar** to developers coming from TypeScript, Rust, or Go?
+
+FunC gave complete control over the TVM — and if you mastered it, it gave you power.
+But its Lisp-like syntax and functional style made onboarding difficult for many.
+
+Tolk started as an experiment: keep the efficiency, but change the interface.
+No parentheses, no prefix notation. Just clean types, structs, pattern matching, and a modern toolchain.
+
+Since then, Tolk has grown far beyond just being "easier FunC." It now offers:
+- a powerful type system,
+- automatic serialization,
+- idiomatic message composition,
+- and better performance — not in spite of abstraction, but thanks to it.
+
+Today, Tolk is not an experiment — it's a production-ready replacement for FunC.
+
 ## How Tolk was born
 
-In June 2024, I created a pull request [FunC v0.5.0](https://github.com/ton-blockchain/ton/pull/1026).
-Besides this PR, I've written a roadmap for what can be enhanced in FunC, syntactically and semantically.
+In June 2024, I submitted a pull request: [FunC v0.5.0](https://github.com/ton-blockchain/ton/pull/1026) — along with a roadmap for how FunC could be improved, syntactically and semantically.
 
-Instead of merging v0.5.0 and continuing to develop FunC, we decided to **fork** it.
-To leave FunC untouched as it is. As it always was. And to develop a new language driven by a fresh and new name.
+But instead of merging it, we made a decision: **To fork**.
+To leave FunC untouched. As it is. As it always was. And to create a new language driven by a fresh and new name.
 
-For several months, I have worked on Tolk privately. I have implemented a giant list of changes.
-And it's not only about the syntax. For instance, Tolk has an internal AST representation that is completely missed in FunC.
+Over the next several months, I worked on Tolk privately, implementing not just syntax changes,
+but a fully redesigned architecture — including an internal AST representation that FunC never had.
 
-On TON Gateway, from 1 to 2 November in Dubai, I gave a speech presenting Tolk to the public, and we released it the same day.
+On TON Gateway, in November 2024 in Dubai, I gave a speech presenting Tolk to the public.
 The video is available [on YouTube](https://www.youtube.com/watch?v=Frq-HUYGdbI).
 
-Here is the very first pull request: ["Tolk Language: next-generation FunC"](https://github.com/ton-blockchain/ton/pull/1345).
+The very first pull request: ["Tolk Language: next-generation FunC"](https://github.com/ton-blockchain/ton/pull/1345).
 
-The first version of the Tolk Language is v0.6, a metaphor of FunC v0.5 that missed a chance to occur.
+The first released version of Tolk was **v0.6** — a metaphor for the **FunC v0.5** that could have been, but never was.
 
 
 ## Meaning of the name "Tolk"
 
 **Tolk** is a wonderful word. 
 
-In English, it's consonant with *talk*. Because, generally, what do we need a language for? We need it *to talk* to computers. 
+In English, it sounds like *talk*. And after all, what do we use a language for? To talk. To talk to computers. 
 
 In all Slavic languages, the root *tolk* and the phrase *"to have tolk"* means "to make sense"; "to have deep internals".
 
@@ -109,8 +136,8 @@ But actually, **TOLK** is an abbreviation.
 You know, that TON is **The Open Network**.  
 By analogy, TOLK is **The Open Language K**.   
 
-What is K, will you ask? Probably, "kot" — the nick of Nikolay Durov? Or Kolya? Kitten? Kernel? Kit? Knowledge?  
-The right answer — none of this. This letter does not mean anything. It's open.  
+What is K, you might ask? Maybe, it's *kot* — the nickname of Nikolay Durov? Or Kolya? Kitten? Kernel? Kit? Knowledge?  
+The correct answer: none of these. The K stands for nothing. It's open.  
 *The Open Letter K*
 
 <Feedback />

--- a/docs/v3/documentation/smart-contracts/tolk/overview.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/overview.mdx
@@ -7,33 +7,27 @@ import Button from "@site/src/components/button";
 
 # Tolk language: overview
 
-**Tolk** is a new language for writing smart contracts in TON.
-Tolk compiler is a fork of FunC compiler, introducing familiar syntax similar to TypeScript
-but leaving all low-level optimizations untouched. Think of Tolk as the next‑generation FunC.
+**Tolk** is a next-generation language for smart contracts in TON.
+It replaces FunC with modern syntax, strong types, and built-in serialization — while generating even more efficient assembler code.
 
 ```tolk
-import "utils.tolk"
+import "utils"
 
 struct Storage {
-    counter: int32;
+    counter: int32
 }
 
 fun Storage.load() {
     return Storage.fromCell(contract.getData());
 }
 
-fun onInternalMessage(msgValue: int, msgFull: cell, msgBody: slice) {
-    var cs = msgFull.beginParse();
-    var flags = cs.loadMessageFlags();
-    if (isMessageBounced(flags)) {
-        return;
-    }
+fun onInternalMessage(in: InMessage) {
     ...
 }
 
-get currentCounter(): int32 {
-    val st = Storage.load();
-    return st.counter;
+get fun currentCounter(): int {
+    val storage = lazy Storage.load();
+    return storage.counter;
 }
 ```
 
@@ -83,81 +77,48 @@ int currentCounter() method_id {
 </Button>
 <div style={{ height: "2em" }}></div>
 
-## Motivation behind Tolk
-
-FunC is awesome.
-It is low-level and encourages a programmer to think about compiler internals.
-It gives complete control over TVM assembler, allowing a programmer to make his contract as effective as possible.
-If you get used to it, you love it.
-
-But there is a problem.
-FunC is **functional C**, and it's for ninja.
-If you are keen on Lisp and Haskell, you'll be happy.
-But if you are a JavaScript / Go / Kotlin developer, its syntax is peculiar for you, leading to occasional mistakes.
-A struggle with syntax may decrease your motivation for digging into TON.
-
-Imagine what if there was a language that was smart and low-level but not functional and not like C?
-Leaving all beauty and complexity inside, what if it would be more similar to popular languages at first glance?
-
-That's what Tolk is about.
-
 ## Migrating from FunC to Tolk
 
-If you know FunC and want to try a new syntax, your way is:
+If you are familiar with FunC and want to explore Tolk, here's your path:
 
-1. Read [Tolk vs FunC: in short](/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short).
-2. With a blueprint, create a new Tolk contract (for example, a counter) and experiment around it. Remember that almost all stdlib functions are renamed to ~~verbose~~ clear names. Here is [a mapping](/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib).
-3. Try a [converter](https://github.com/ton-blockchain/convert-func-to-tolk) for your existing contracts or one from [FunC contracts](/v3/documentation/smart-contracts/contracts-specs/examples). Remember that contracts written in Tolk from scratch look nicer than auto-converted ones. For instance, using logical operators instead of bitwise tremendously increases code readability.
+1. Create a fresh "Tolk counter" project: `npm create ton@latest`. You'll notice how different the code feels: structures, unions, matching, toCell(), etc.
+2. Explore the [Tolk vs FunC benchmarks](https://github.com/ton-blockchain/tolk-bench). These are real-world contracts (Jetton, NFT, Wallet, etc.) migrated from FunC — same logic, but written in a cleaner, more expressive style.
+3. Read the guide [Tolk vs FunC: in short](/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short). It highlights syntax differences — but remember, Tolk is more than just syntax. It encourages a shift in mindset toward data-driven, declarative logic.
+4. Try a [FunC-to-Tolk converter](https://github.com/ton-blockchain/convert-func-to-tolk). It's a great starting point for incremental migration.
 
 ## How to try Tolk if you don't know FunC
 
-:::tip Currently, this documentation assumes that you know FunC
-This section describes the **Tolk vs FunC** differences.
-Later, it will be adapted to land newcomers. Moreover, FunC will eventually become deprecated for onboarding,
-and all code snippets throughout the documentation will be rewritten for Tolk.
-:::
+Since Tolk has just been released, it lacks full-fledged documentation.
 
 If you are new to TON, your way is:
 
-1. Dig into [this documentation](/v3/documentation/smart-contracts/overview) to acquire basic on development in TON. No matter your language, you must be aware of cells, slices, and TON asynchronous nature.
-2. Facing FunC snippets, you can still use FunC or try to express the same in Tolk. If FunC syntax is peculiar to you, don't worry: the goal of Tolk is to fix this issue precisely.
-3. Once you understand what's happening, try using Tolk with [blueprint](https://github.com/ton-org/blueprint).
+1. Dig into [this documentation](/v3/documentation/smart-contracts/overview) to acquire basic development in TON. Get familiar with cells and TON asynchronous nature.
+2. Create a "Tolk counter" with blueprint: `npm create ton@latest`. Ensure it works.
+3. Continue reading documentation and doing some experience. Facing FunC/Tact snippets, keep in mind that being expressed with Tolk, they would look nicer.
 
-## Tooling around Tolk language
+In the upcoming months, the whole TON documentation will be adapted to onboard newcomers onto Tolk instead of FunC.
 
-Sources of the Tolk compiler are a part of the `ton-blockchain` [repo](https://github.com/ton-blockchain/ton).
-Besides the compiler, we have:
+## Tooling around Tolk
 
-1. [tolk-js](https://github.com/ton-blockchain/tolk-js) — a WASM wrapper for Tolk compiler.
-2. [JetBrains IDE plugin](https://github.com/ton-blockchain/intellij-ton) supports Tolk besides FunC, Fift, TL/B, and Tact.
-3. [VS Code Extension](https://github.com/ton-blockchain/tolk-vscode) enabling Tolk Language support.
-4. [Converter from FunC to Tolk](https://github.com/ton-blockchain/convert-func-to-tolk) — convert a `.fc` file to a `.tolk` file with a single `npx` command.
-5. Tolk Language is available in [blueprint](https://github.com/ton-org/blueprint).
+Tolk is supported across the ecosystem:
+
+1. [JetBrains IDE plugin](https://github.com/ton-blockchain/intellij-ton) supports Tolk, FunC, Fift, and TL/B
+2. [VS Code Extension](https://github.com/ton-blockchain/ton-language-server) with Tolk support
+3. [Language server](https://github.com/ton-blockchain/ton-language-server) for any LSP-compatible editor
+4. [FunC-to-Tolk converter](https://github.com/ton-blockchain/convert-func-to-tolk) — migrate a whole project with a single `npx` command
+5. [tolk-js](https://github.com/ton-blockchain/tolk-js) — WASM wrapper for Tolk compiler, integrated into blueprint
+
+The Tolk compiler itself is part of the `ton-blockchain` [repository](https://github.com/ton-blockchain/ton).
 
 ## Is Tolk production-ready?
 
-The Tolk compiler, a fork of the FunC compiler, is deemed production-ready, albeit somewhat experimental at the moment.
+All contracts in the [Tolk vs FunC benchmarks](https://github.com/ton-blockchain/tolk-bench)
+pass the same test suites as their FunC counterparts — with identical logic and behavior.
 
-Undiscovered bugs may exist, potentially inherited from FunC or attributable to TVM characteristics.
-Anyway, no matter your language, you should cover your contracts with tests to reach high reliability.
+Yes, the compiler is new, and some edge cases might still appear.
+But Tolk is already a **production-ready replacement for FunC** — and ready for real-world usage.
 
-## Roadmap
-
-The first released version of Tolk is v0.6, emphasizing [missing](/v3/documentation/smart-contracts/tolk/changelog#how-tolk-was-born) FunC v0.5.
-
-Here are some points to investigate:
-
-- type system improvements
-- gas and stack optimizations, AST inlining
-- extending and maintaining stdlib
-- some ABI (how explorers "see" bytecode)
-- gas and fee management in general
-
-The following strategic milestone for **Tolk v1.0** is structures with auto-serialization into cells (almost done).
-
-This milestone eliminates manual manipulations with builders and slices, allowing data and messages to be described declaratively.
-Closely related to this is the **ABI (interface) of contracts**.
-Well-designed structures make up the majority of an ABI.
+(And regardless of the language, well-tested code is the key to reliable smart contracts.)
 
 ## Issues and contacts
 

--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx
@@ -243,7 +243,7 @@ struct ProbablyLarge {
 val contents: ProbablyLarge = { ... };  // but you are sure: coins are small
 createMessage({                         // so, you take the risks
     body: UnsafeBodyNoRef {             // and force "no ref"
-        bodyForceNoRef: contents,
+        forceInline: contents,
     }
 
 // here TBody = UnsafeBodyNoRef<ProbablyLarge>

--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx
@@ -74,7 +74,7 @@ You can use backticks to surround an identifier, and then it can contain any sym
   <tbody>
   <tr>
     <td><code>{'const op::increase = 0x1234;'}</code></td>
-    <td><code>{'const OP_INCREASE = 0x1234;'}</code></td>
+    <td><code>{'const OP_INCREASE = 0x1234'}</code></td>
   </tr>
   <tr>
     <td><code dangerouslySetInnerHTML={{__html: ';; even 2%&!2 is valid<br>int 2+2 = 5;'}}></code></td>
@@ -145,7 +145,7 @@ Types of variables — also to the right:
   </tr>
   <tr>
     <td><code>{'global int stake_at;'}</code></td>
-    <td><code>{'global stake_at: int;'}</code></td>
+    <td><code>{'global stake_at: int'}</code></td>
   </tr>
   </tbody>
 </table>
@@ -170,7 +170,7 @@ Modifiers `inline` and others — with annotations:
   </tr>
   <tr>
     <td><code>{'global int stake_at;'}</code></td>
-    <td><code>{'global stake_at: int;'}</code></td>
+    <td><code>{'global stake_at: int'}</code></td>
   </tr>
   </tbody>
 </table>
@@ -196,15 +196,15 @@ Modifiers `inline` and others — with annotations:
 ```tolk
 @pure
 fun third<X>(t: tuple): X
-    asm "THIRD";
+    asm "THIRD"
 
 @pure
 fun iDictDeleteGet(dict: cell, keyLen: int, index: int): (cell, slice, int)
-    asm(index dict keyLen) "DICTIDELGET NULLSWAPIFNOT";
+    asm(index dict keyLen) "DICTIDELGET NULLSWAPIFNOT"
 
 @pure
 fun mulDivFloor(x: int, y: int, z: int): int
-    builtin;
+    builtin
 ```
 
 There is also a `@deprecated` attribute, not affecting compilation, but for a human and IDE.
@@ -225,12 +225,10 @@ In FunC, `method_id` (without arguments) declared a get method. In Tolk, you use
   <tbody>
   <tr>
     <td><code>{'int seqno() method_id { ... }'}</code></td>
-    <td><code>{'get seqno(): int { ... }'}</code></td>
+    <td><code>{'get fun seqno(): int { ... }'}</code></td>
   </tr>
   </tbody>
 </table>
-
-Both `get methodName()` and `get fun methodName()` are acceptable.
 
 For `method_id(xxx)` (uncommon in practice, but valid), there is an attribute:
 
@@ -367,7 +365,7 @@ These functions:
 
 ```tolk
 // type will be `address`
-const BASIC_ADDR = address("EQDKbjIcfM6ezt8KjKJJLshZJJSqX7XOA4ff-W72r5gqPrHF");
+const BASIC_ADDR = address("EQDKbjIcfM6ezt8KjKJJLshZJJSqX7XOA4ff-W72r5gqPrHF")
 
 // return type will be `int`
 fun minihashDemo() {
@@ -438,7 +436,7 @@ if (smth) {
     </tr>
     <tr>
         <td><code>{'const ONE_TON = 1000000000;'}</code></td>
-        <td><code>{'const ONE_TON = ton("1");'}</code></td>
+        <td><code>{'const ONE_TON = ton("1")'}</code></td>
     </tr>
     </tbody>
 </table>
@@ -576,7 +574,7 @@ fun callAnyFn2<TObj, TCallback>(f: TCallback, arg: TObj) {
 Note that while generic `T` is mostly detected from arguments, there are no such obvious corner cases when `T` does not depend on arguments:
 ```tolk
 fun tupleLast<T>(t: tuple): T
-    asm "LAST";
+    asm "LAST"
 
 var last = tupleLast(t);    // error, can not deduce T
 ```
@@ -594,18 +592,6 @@ return tupleLast(t);       // ok if function specifies return type
 Also note that `T` for asm functions must occupy one stack slot, whereas for a user-defined function, `T` could be of any shape. Otherwise, asm body is unable to handle it properly.
 
 
-### Another naming for recv_internal / recv_external
-
-```tolk
-fun onInternalMessage
-fun onExternalMessage
-fun onTickTock
-fun onSplitPrepare
-fun onSplitInstall
-```
-
-All parameter types and their order rename the same, only naming is changed. `fun main` is also available.
-
 
 ### #include → import. Strict imports
 
@@ -620,7 +606,7 @@ All parameter types and their order rename the same, only naming is changed. `fu
   <tbody>
   <tr>
     <td><code>{'#include "another.fc";'}</code></td>
-    <td><code>{'import "another.tolk"'}</code></td>
+    <td><code>{'import "another"'}</code></td>
   </tr>
   </tbody>
 </table>
@@ -1185,8 +1171,8 @@ Tolk supports type aliases, similar to TypeScript and Rust.
 An alias creates a new name for an existing type but **remains interchangeable with it**.
 
 ```tolk
-type UserId = int32;
-type MaybeOwnerHash = bytes32?;
+type UserId = int32
+type MaybeOwnerHash = bytes32?
 
 fun calcHash(id: UserId): MaybeOwnerHash { ... }
 
@@ -1298,7 +1284,7 @@ For now, working with dicts will require the `!` operator.
 // it returns either (slice, true) or (null, false)
 @pure
 fun dict.iDictGet(self, keyLen: int, key: int): (slice?, bool)
-    asm(key self keyLen) "DICTIGET" "NULLSWAPIFNOT";
+    asm(key self keyLen) "DICTIGET" "NULLSWAPIFNOT"
 
 var (cs, exists) = myDict.iDictGet(...);
 // if exists is true, cs is not null
@@ -1391,8 +1377,8 @@ match (result) {
 
 `match` must cover all union cases (should be *exhaustive*). It can also be **used as an expression**:
 ```tolk
-type Pair2 = (int, int);
-type Pair3 = (int, int, int);
+type Pair2 = (int, int)
+type Pair3 = (int, int, int)
 
 fun getLast(tensor: Pair2 | Pair3) {
     return match (tensor) {
@@ -1464,7 +1450,7 @@ fun f(v: cell | slice | builder) {
         v.cellHash();
     } else {
         // v is `slice | builder`
-        if (v !is builder) { return; }
+        if (v !is builder) { return }
         // v is `slice`
         v.sliceHash();
     }
@@ -1515,8 +1501,8 @@ val nextValue = match (curValue) {
 Looks like TypeScript — but works in TVM!
 ```tolk
 struct Point {
-    x: int;
-    y: int;
+    x: int
+    y: int
 }
 
 fun calcMaxCoord(p: Point) {
@@ -1532,7 +1518,7 @@ calcMaxCoord({ x: 10, y: 20 });
 
 // works with shorthand syntax
 fun createPoint(x: int, y: int): Point {
-    return { x, y };
+    return { x, y }
 }
 ```
 
@@ -1542,23 +1528,23 @@ fun createPoint(x: int, y: int): Point {
 
 This means **no bytecode overhead** — you can replace unreadable tensors with clean, structured types.
 
-Fields can be separated by `;` or `,` (both are valid, like in TypeScript). Trailing commas are allowed.
+Fields can be separated by newlines (recommended) or by `;` / `,` (both are valid, like in TypeScript).
 
-When creating a structure, you can specify `StructName { ... }` or simply `{ ... }` if the type is clear from the context (e.g., return type or assignment):
+When creating an object, you can specify `StructName { ... }` or simply `{ ... }` if the type is clear from the context (e.g., return type or assignment):
 ```tolk
 var s: StoredInfo = { counterValue, ... };
 var s: (int, StoredInfo) = (0, { counterValue, ... });
 
-// also valid, but not preferred
+// also valid
 var s = StoredInfo { counterValue, ... };
 ```
 
 Default values for fields are supported:
 ```tolk
 struct DefDemo {
-    f1: int = 0;
-    f2: int? = null;
-    f3: (int, coins) = (0, ton("0.05"));
+    f1: int = 0
+    f2: int? = null
+    f3: (int, coins) = (0, ton("0.05"))
 }
 
 var d: DefDemo = {};         // ok
@@ -1574,13 +1560,13 @@ Structs can have methods as extension functions, read below.
 They exist only at the type level (no runtime cost).
 ```tolk
 struct Container<T> {
-    isAllowed: bool;
-    element: T?;
+    isAllowed: bool
+    element: T?
 }
 
-struct Nothing {}
+struct Nothing
 
-type Wrapper<T> = Nothing | Container<T>;
+type Wrapper<T> = Nothing | Container<T>
 ```
 
 Example usage:
@@ -1615,15 +1601,15 @@ doSmth({ item: cellOrNull });  // T = cell?
 
 Demo: `Response<TResult, TError>`:
 ```tolk
-struct Ok<TResult> { result: TResult; }
-struct Err<TError> { err: TError; }
+struct Ok<TResult> { result: TResult }
+struct Err<TError> { err: TError }
 
-type Response<R, E> = Ok<R> | Err<E>;
+type Response<R, E> = Ok<R> | Err<E>
 
 fun tryLoadMore(slice: slice): Response<cell, int32> {
     return ...
         ? Ok { result: ... }
-        : Err { err: ErrorCodes.NO_MORE_REFS };
+        : Err { err: ErrorCodes.NO_MORE_REFS }
 }
 
 match (val r = tryLoadMore(inMsg)) {
@@ -1651,10 +1637,10 @@ fun Point.create(x: int, y: int): Point {
 Methods can be created **for any type**, including aliases, unions, and built-in types:
 ```tolk
 fun int.isZero(self) {
-    return self == 0;
+    return self == 0
 }
 
-type MyMessage = CounterIncrement | ...;
+type MyMessage = CounterIncrement | ...
 
 fun MyMessage.parse(self) { ... }
 // this is identical to
@@ -1665,7 +1651,7 @@ Methods perfectly work with `asm`, since `self` is just a regular variable:
 ```tolk
 @pure
 fun tuple.size(self): int
-    asm "TLEN";
+    asm "TLEN"
 ```
 
 By default, **`self` is immutable**. It means that you can't modify it or call mutating methods.
@@ -1684,7 +1670,7 @@ Methods for generic structs created seamlessly.
 Note, that no extra `<T>` is required: while parsing the receiver type, compiler treats unknown symbols as generic arguments.
 ```tolk
 struct Container<T> {
-    item: T;
+    item: T
 }
 
 // compiler treats T (unknown symbol) as a generic parameter
@@ -1701,8 +1687,8 @@ fun Container<int>.getItem(self) {
 Another example:
 ```tolk
 struct Pair<T1, T2> {
-    first: T1;
-    second: T2;
+    first: T1
+    second: T2
 }
 
 // both <T1,T2>, <A,B>, etc. work: any unknown symbols
@@ -1751,7 +1737,7 @@ fun T.copy(self) { ... }
 ```
 
 ```tolk
-type MyMessage = CounterIncrement | CounterReset;
+type MyMessage = CounterIncrement | CounterReset
 fun MyMessage.check() { ... }
 fun CounterIncrement.check() { ... }
 
@@ -1780,10 +1766,75 @@ callable2(someContainer32);   // pass it as self
 ```
 
 
+### Auto-detect and inline functions
+
+
+
+Tolk can inline functions at the compiler level, NOT via `PROCINLINE` by Fift.
+
+```tolk
+fun Point.create(x: int, y: int): Point {
+    return {x, y}
+}
+
+fun Point.getX(self) {
+    return self.x
+}
+
+fun sum(a: int, b: int) {
+    return a + b;
+}
+
+fun main() {
+    var p = Point.create(10, 20);
+    return sum(p.getX(), p.y);
+}
+```
+
+is compiled just to
+```fift
+main PROC:<{
+  30 PUSHINT
+}>
+```
+
+The compiler automatically detects what functions to inline. The attribute `@inline` also forces compiler inlining. The attribute `@noinline` forces a function to stay in a dict, `@inline_ref` remains "inline ref" (perfect for "unlikely" execution paths).
+
+Compiler inlining is efficient in terms of stack manipulations. It works with arguments of any stack width. It works with any functions and methods, except recursive or having `return` in the middle. It works with `mutate` and `self`.
+
+You should not worry that "simple getters" like `fun Point.getX(self) { return self.x }` will require stack reordering. You can extract small functions, they are absolutely zero-cost. You don't think about `@inline` and Fift, because no inlining is deferred to Fift: the compiler will handle everything in advance.
+
+**How does "auto-inline" work?**
+
+In two words,
+- "simple small functions" are inlined always
+- if a function is called only once, it's inlined
+
+Some details. For every function, the compiler calculates "weight" (a heuristic AST-based metric) and usages count. If "weight < THRESHOLD," it's inlined always. If "usages == 1," it's inlined always. Otherwise, there is some empiric formula.
+
+No one prevents you to force `@inline` annotation for "big functions" also. For example, if you know that all usages correspond to hot paths. Sometimes, on the contrary, you'd want to "prevent inlining" with `@inline_ref` for example, even if a function is called once — if it's an unlikely path. Anyway, if you are keen on optimization, cover your contract with gas benchmarks and experiment with inlining, branch reordering, etc.
+
+**What can NOT be auto-inlined?**
+
+A function will NOT be inlined (even marked as `@inline`) if:
+
+1) It has `return` in the middle. If a function has multiple return points, the compiler can't do anything with it, currently. In Tolk v1.x it will be partially resolved for some use cases.
+
+2) A function that appears in a recursive call chain (`f -> g -> f`). Very unlikely in practice.
+
+3) It's used as non-call. For example, you take a reference to it like `val callback = f`
+
+
 ### No tilda ~ methods, mutate keyword instead
 
 
-This change is so huge that it's described on a separate page: [Tolk mutability](/v3/documentation/smart-contracts/tolk/tolk-vs-func/mutability).
+If FunC has `.methods()` and `~methods()`, Tolk has only a dot, and the only way to call a method is `.method()`. Basically, Tolk just works as expected:
+```tolk
+b.storeUint(x, 32);   // modifies a builder, can be chainable
+s.loadUint(32);       // modifies a slice, returns integer
+```
+
+Continue reading on a separate page: [Mutability in Tolk](/v3/documentation/smart-contracts/tolk/tolk-vs-func/mutability).
 
 
 ### Auto-packing to/from cells/builders/slices
@@ -1792,11 +1843,11 @@ This change is so huge that it's described on a separate page: [Tolk mutability]
 Having any struct, you can unpack in from a cell or pack and object to a cell:
 ```tolk
 struct Point {
-    x: int8;
-    y: int8;
+    x: int8
+    y: int8
 }
 
-var value: Point = { x: 10, y: 20 };
+var value: Point = { x: 10, y: 20 }
 
 // makes a cell containing "0A14"
 var c = value.toCell();
@@ -1824,25 +1875,115 @@ reply.send(SEND_MODE_REGULAR);
 Continue reading on a separate page: [Universal createMessage](/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message).
 
 
+
+### Modern onInternalMessage
+
+
+In Tolk, you don't need to manually parse `msg_cell` to retrieve `sender_address` or `fwd_fee`. Everything is pretty straightforward:
+```tolk
+fun onInternalMessage(in: InMessage) {
+    in.senderAddress
+    in.originalForwardFee
+    in.valueCoins   // typically called "msg value"
+
+    in.|   // IDE suggests you
+}
+```
+
+While an "old-fashioned way" with accepting 4 parameters like `recv_internal` still works, the above is preferred. Moreover, it's much more efficient: fields of `InMessage` are mapped onto new TVM-11 instructions.
+
+**The pattern**:
+
+1) describe every message in a struct (most likely, with 32-bit opcode)
+2) describe a union "allowed messages"
+3) `val msg = lazy MyUnion.fromSlice(in.body)`
+4) `match (msg)` for every branch, and probably `else`
+
+Do not follow an "old-fashioned way" to extract fwd_fee etc. at the beginning of the function, there is no need of it. Just use `in.smth` on demand.
+
+```tolk
+type AllowedMessageToMinter =
+    | MintNewJettons
+    | BurnNotificationForMinter
+    | RequestWalletAddress
+
+fun onInternalMessage(in: InMessage) {
+    val msg = lazy AllowedMessageToMinter.fromSlice(in.body);
+
+    match (msg) {
+        BurnNotificationForMinter => {
+            var storage = lazy MinterStorage.load();
+            ...
+            storage.save();    
+            ...
+        }
+        RequestWalletAddress => ...
+        MintNewJettons => ...
+        else => {
+            // for example:
+            // ignore empty messages, "wrong opcode" for others
+            assert (in.body.isEmpty()) throw 0xFFFF
+        }
+    }
+}
+```
+
+**A separate `onBouncedMessage`**
+
+In FunC, you parsed `msg_cell`, read 4-bit flags, and tested for `flags & 1` to check whether a message is bounced.
+
+In Tolk, if you want to handle bounces, you create a separate entrypoint:
+```tolk
+fun onBouncedMessage(in: InMessageBounced) {
+}
+```
+It's automatically called by the compiler, similarly to this:
+```tolk
+fun onInternalMessage(in: InMessage) {
+    // the compiler inserts this automatically:
+    if (MSG_IS_BOUNCED) { onBouncedMessage(...); return; }
+
+    ... // your code
+}
+```
+
+If you don't declare `onBouncedMessage`, all bounces will be just filtered out:
+```tolk
+fun onInternalMessage(in: InMessage) {
+    // the compiler inserts this automatically:
+    if (MSG_IS_BOUNCED) { return; }
+
+    ... // your code
+}
+```
+
+**Remember about 256 bits on bounces**
+
+Currently, TON Blockchain works in such a way that when a message is bounced, only the first 256 bits are present, starting with 0xFFFFFFFF ("bounced prefix"). That's why you manually control which fields you can read (they fit rest 224 bits), which not.
+
+```tolk
+fun onBouncedMessage(in: InMessageBounced) {
+    in.bouncedBody    // 256 bits
+
+    // typically, you'll do
+    in.bouncedBody.skipBouncedPrefix();   // skips 0xFFFFFFFF
+    // handle rest of body, probably with lazy match
+}
+```
+
+
+
 <hr />
 
-<h3>Tolk vs FunC gas consumption</h3>
+<h3>Where to go next?</h3>
 
-:::tip The same or slightly less
-If you transform FunC code line-by-line (for example, using a [converter](https://github.com/ton-blockchain/convert-func-to-tolk)),
-you'll have the same results or even a bit better.
-:::
+Explore the [Tolk vs FunC benchmarks](https://github.com/ton-blockchain/tolk-bench). 
+These are real-world contracts (Jetton, NFT, Wallet, etc.) migrated from FunC — same logic, but written in a cleaner, more expressive style.
 
-Since Tolk is a fork of FunC, part of its core remains unchanged — particularly the stack manipulation logic.
-Yes, Tolk is a completely different language, with its own syntax and semantics,
-but its low-level internal representation is exactly the same as FunC's.
-As a result, the syntax has no impact on gas consumption.
-In fact, it's even slightly lower, since the strict type system
-gives the compiler more room for optimizations.
+Try a [FunC-to-Tolk converter](https://github.com/ton-blockchain/convert-func-to-tolk). It's a great starting point for incremental migration.
 
-However, once Tolk v1.0 is released, it will be significantly more efficient.
-Auto-serialized structures, automatic message construction, and other features will be
-noticeably cheaper than manual work with builders and slices — almost always.
+Run `npm create ton@latest` and just start experimenting.
+
 
 <Feedback />
 

--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx
@@ -5,7 +5,7 @@ import Feedback from '@site/src/components/Feedback';
 Tolk is much more similar to TypeScript and Kotlin than C and Lisp. 
 But it still gives you complete control over the TVM assembler since it has a FunC kernel inside.
 
-1. Functions are declared via `fun`, get methods via `get`, variables via `var`, immutable variables via `val`, putting types on the right; parameter types are mandatory; return type can be omitted (auto inferred), as well as for locals; specifiers `inline` and others are `@` attributes
+1. Functions are declared via `fun`, get methods via `get fun`, variables via `var`, immutable variables via `val`, putting types on the right; parameter types are mandatory; return type can be omitted (auto inferred), as well as for locals; specifiers `inline_ref` and others are `@` attributes
 ```tolk
 global storedV: int;
 
@@ -20,10 +20,10 @@ fun sum(a: int, b: int) {   // auto inferred int
     return both;
 }
 
-get currentCounter(): int { ... }
+get fun currentCounter(): int { ... }
 ```
 2. No `impure`, it's by default, the Tolk compiler won't drop user function calls
-3. Not `recv_internal` and `recv_external`, but `onInternalMessage` and `onExternalMessage`
+3. Not `recv_internal` and `recv_external`, but `onInternalMessage` / `onExternalMessage` / `onBouncedMessage`
 4. `2+2` is 4, not an identifier; identifiers are alpha-numeric; use naming `const OP_INCREASE` instead of `const op::increase`; `cell` and `slice` are valid identifiers (not keywords)
 5. Logical operators AND `&&`, OR `||`, NOT `!` are supported
 6. Syntax improvements:
@@ -61,12 +61,24 @@ get currentCounter(): int { ... }
 21. Fift output contains original .tolk lines as comments
 22. [Auto-packing](/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells) to/from cells — for any types
 23. [Universal createMessage](/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message) to avoid manual cells composition
+24. Auto-detect and inline functions at the compiler level
+25. Various optimizations for gas efficiency
 
-#### Tooling around
-- JetBrains plugin exists
-- VS Code extension [exists](https://github.com/ton-blockchain/tolk-vscode)
+### Tooling around
+
+- JetBrains IDE plugin [exists](https://github.com/ton-blockchain/intellij-ton)
+- VS Code extension [exists](https://github.com/ton-blockchain/ton-language-server)
 - WASM wrapper for blueprint [exists](https://github.com/ton-blockchain/tolk-js)
-- And even a converter from FunC to Tolk [exists](https://github.com/ton-blockchain/convert-func-to-tolk)
+- And even a "FunC-to-Tolk converter" [exists](https://github.com/ton-blockchain/convert-func-to-tolk)
+
+### Tolk vs FunC gas benchmarks
+
+The [tolk-bench repository](https://github.com/ton-blockchain/tolk-bench) contains several contracts migrated from FunC to Tolk — preserving all logic and passing the same tests.
+
+As you see, not only the code becomes readable, but gas usage is noticeably reduced. And there are no tricks here. Just clean, consistent logic — whether it's a Jetton or a Wallet.
+
+The rule is simple: **if you write code the way the language encourages — gas will take care of itself**.
+
 
 ## See also
 

--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/lazy-loading.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/lazy-loading.mdx
@@ -1,0 +1,214 @@
+---
+title: "The magic `lazy`"
+---
+
+import Feedback from '@site/src/components/Feedback';
+
+# Lazy loading, partial loading, partial updating
+
+One magic `lazy` keyword to rule them all.
+
+
+## Lazy loading, partial loading
+
+Say, you have a `Storage` in a wallet:
+```tolk
+struct Storage {
+    isSignatureAllowed: bool
+    seqno: uint32
+    subwalletId: uint32
+    publicKey: uint256
+    extensions: dict
+}
+
+fun Storage.load() {
+    return Storage.fromCell(contract.getData())
+}
+```
+
+What does `Storage.load()` do? It unpacks a cell and populates all fields of a struct, checks consistency, etc.
+
+**The magic `lazy Storage.load()` does NOT load a full cell**. Instead, the compiler tracks — what fields you are using, and automatically "picks" requested fields, skipping others.
+
+```tolk
+get fun getPublicKey() {
+    val st = lazy Storage.load();
+    // <-- here "skip 65 bits, preload uint256" is inserted
+    return st.publicKey
+}
+```
+
+That's it! With a single `lazy` keyword you defer loading until being accessed. 
+The compiler tracks all control flow paths and automatically inserts loading points, groups unused fields for skipping, etc. 
+Of course, it works with any types, any combination of fields used in any places within your code — the compiler tracks everything.
+
+
+## Even deeper than you might think
+
+Say, you have an NFT collection:
+```tolk
+struct NftCollectionStorage {
+    adminAddress: address
+    nextItemIndex: uint64
+    content: Cell<CollectionContent>
+    ...
+}
+
+struct CollectionContent {
+    metadata: cell
+    minIndex: int32
+    commonKey: uint256
+}
+```
+
+And somewhere, you need just to get `content` from a storage (and to get `commonKey` from there).
+```tolk
+val storage = lazy NftCollectionStorage.load();
+// <-- here just "preload ref" is inserted
+val contentCell = storage.content;
+```
+
+The first trick: no "skip address, skip uint64" is needed. To get a ref, no need to skip preceding data fields — the compiler knows about this.
+
+Second: okay, we have `contentCell`. How to get `commonKey` from there? The answer: it's a cell => you need to load it... lazily!
+```tolk
+val storage = lazy NftCollectionStorage.load();
+
+// <-- "preload ref" inserted — to get `content`
+// Cell<T>.load() unpacks a cell and gives you T
+val content = lazy storage.content.load();
+
+// <-- "skip 32 bits, preload uint256" - to get commonKey
+return content.commonKey;
+```
+
+A small reminder about `Cell<T>`. These are typed cells, widely used to describe nested references. 
+When you have `p: Cell<Point>`, you can't access `p.x` — you need to load that cell, either with `Point.fromCell(p)` — or (better) with `p.load()`. 
+Both variants can be called with `lazy`.
+
+
+## Lazy matching
+
+Similarly, when reading a union (an incoming message, for example), you do it with `lazy`:
+```tolk
+struct (0x12345678) CounterReset { ... }
+...
+type MyMessage = CounterReset | CounterIncrement | ...
+
+val msg = lazy MyMessage.fromSlice(msgBody);    
+match (msg) {
+    CounterReset => {
+        assert(senderAddress == storage.owner) throw 403;
+        // <-- here "load msg.initial" is inserted
+        storage.counter = msg.initial;
+```
+
+With `lazy` for a union,
+1) no union is allocated on a stack, actually: matching and loading is deferred
+2) `match` naturally works by a slice prefix (opcode)
+3) inside every branch, the compiler inserts loading points, skips unused fields, etc. — all that it does for a struct
+
+That's why **lazy matching is very efficient**. More efficient than `if (op == OP_RESET)` FunC pattern. 
+Described in terms of the type system, it perfectly fits TVM nature without extra stack manipulations.
+
+
+## Lazy matching and ELSE
+
+Since lazy `match` for a union is done by a prefix (opcode), when none of prefixes match, you can handle it with `else` branch.
+
+In FunC contracts, there was a common pattern to "ignore empty messages":
+```tolk
+// FunC-style
+if (msgBody.isEmpty()) {
+    return;    // ignore empty messages
+}
+val op = msgBody.loadUint(32);  // because this would throw excno 9
+
+if (op == OP_RESET) { 
+    ...
+    return; 
+}
+
+throw 0xFFFF;  // "invalid opcode"
+```
+
+The only reason for handling empty in advance was not to throw "cell underflow" in "loadUint".
+
+With lazy `match`, no need to waste gas in advance. Do all checks in `else`:
+```tolk
+val msg = lazy MyMessage.fromSlice(msgBody);    
+match (msg) {
+    CounterReset => { ... }
+    ...  // handle all types of a union
+
+    // else - when nothing matched;
+    // even corrupted input (less than 32 bits), no "underflow" fired
+    else => {
+        // ignore empty messages, "wrong opcode" for others
+        assert (msgBody.isEmpty()) throw 0xFFFF
+    }
+}
+```
+
+Without manual `else`, unpacking will throw 63 by default (controlled by an extra option `throwIfOpcodeDoesNotMatch` for fromCell/fromSlice). 
+With `else`, you can override any behavior.
+
+Note that `else` in `match` by type is allowed only with `lazy`, because it works on prefixes. 
+Without lazy, it's just a regular union, matched by a union tag (typeid) on a stack.
+
+
+## Partial updating
+
+It's not the end of magic. `lazy` not only works on reading, but perfectly **works on writing back**.
+
+Say, we load storage, use its fields for assertions, modify one field, and save it back:
+```tolk
+val storage = lazy Storage.load();
+
+assert (storage.validUntil > blockchain.now()) throw 123;
+assert (storage.seqno == msg.seqno) throw 456;
+...
+
+storage.seqno += 1;
+contract.setData(storage.toCell());   // <-- magic
+```
+
+The compiler is smart, and for toCell() it **does not save all fields of a storage**, because we modified only `seqno`. 
+Instead, on loading, after loading `seqno`, it saved "immutable tail," and reused it writing back:
+```tolk
+val storage = lazy Storage.load();
+// actually, what was done:
+// - load isSignatureAllowed, seqno
+// - save immutable tail
+// - load validUntil, etc.
+
+storage.seqno += 1;
+storage.toCell();
+// actually, what was done:
+// - store isSignatureAllowed, seqno
+// - store immutable tail
+```
+
+No more manual optimizations with intermediate slices — the compiler does all the stuff for you. 
+It can even group unmodified fields in the middle, load them as a slice, and preserve this slice when writing back.
+
+Of course, it works only when a compiler statically resolves control flow within a local scope of a function. 
+If you use globals, split logic into non-inlined functions, this optimization will obviously break, and `lazy` will fall back to regular loading.
+
+
+## Q: What are disadvantages of lazy?
+
+In terms of gas usage, lazy fromSlice is always less or equal than regular fromSlice, because in the worst case, when you access all fields, they are obviously all loaded one by one.
+
+But there is another difference, not related to gas usage.
+* When you do `T.fromSlice(s)`, it unpacks all fields of T and then inserts `s.assertEnd()` (it can be disabled by an option). So, if a slice is corrupted or has extra data, fromSlice will throw.
+* `lazy`, of course, "picks" only requested fields and easily works with partially invalid input. For example, `struct Point { x: int8, y: int8 }`, and you use `lazy Point` and `p.x` only. Then an input "FF" (8 bits) is okay, even though `y` is not presented at all. Similarly, "FFFF0000" (16 bits of extra data) is also okay, `lazy` just ignores everything not requested.
+
+Typically, it's not a problem. For storage, you have a guarantee that it's shaped correctly — since your contract manages it. For incoming messages, you typically use all fields (otherwise, why do you need them in structs?). If there is some extra data in input — who cares? The message can be deserialized well, I don't find any error here.
+
+Probably, some day `lazy` will become a default. For now, it's a separate keyword emphasizing "lazy loading" and a killer feature of Tolk.
+
+
+
+<Feedback />
+

--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/mutability.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/mutability.mdx
@@ -198,7 +198,7 @@ If you look into stdlib, you'll notice that many functions actually **mutate sel
 ```tolk
 @pure
 fun tuple.push<X>(mutate self, value: X): void
-    asm "TPUSH";
+    asm "TPUSH"
 
 t.push(1);
 ```
@@ -253,13 +253,13 @@ So, an `asm` function should place `self'` onto a stack before its return value:
 // so, self' = tuple', and return an empty tensor
 // `void` is a synonym for an empty tensor
 fun tuple.push<X>(mutate self, value: X): void
-    asm "TPUSH";
+    asm "TPUSH"
 
 // "LDU" pops (slice) and pushes (int, slice')
 // with asm(-> 1 0), we make it (slice', int)
 // so, self' = slice', and return int
 fun slice.loadMessageFlags(mutate self): int
-    asm(-> 1 0) "4 LDU";
+    asm(-> 1 0) "4 LDU"
 ```
 
 Note, that to return self, you don't have to do anything special, just specify a return type. The compiler will do the rest.
@@ -269,31 +269,20 @@ Note, that to return self, you don't have to do anything special, just specify a
 // so, self' = builder', and return an empty tensor
 // but to make it chainable, `self` instead of `void`
 fun builder.storeMessageOp(mutate self, op: int): self
-    asm(op self) "32 STU";
+    asm(op self) "32 STU"
 ```
 
 It's doubtful you'll have to do such tricks. Most likely, you'll write wrappers around existing functions:
 ```tolk
 // just do it like this, without asm; it's the same effective
 
-@inline
 fun slice.myLoadMessageFlags(mutate self): int {
     return self.loadUint(4);
 }
 
-@inline
 fun builder.myStoreMessageOp(mutate self, flags: int): self {
     return self.storeUint(32, flags);
 }
 ```
-
-### Do I need @inline for simple functions/methods?
-
-
-For now, better do it, yes. In most examples above, `@inline` was omitted for clarity. Without `@inline`, it will be a separate TVM continuation with jumps in/out. With `@inline`, a function will be generated, but inlined by Fift, like the `inline` specifier in FunC.
-
-In the future, Tolk will automatically detect simple functions and perform true inlining on the AST level. Such functions won't be even generated to Fift. The compiler would decide, better than a human, whether to inline, to make a ref, etc. But it will take some time for Tolk to become so smart :)
-
-For now, please specify the `@inline` attribute.
 
 <Feedback />

--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx
@@ -9,8 +9,8 @@ import Feedback from '@site/src/components/Feedback';
 A short demo of how it looks:
 ```tolk
 struct Point {
-    x: int8;
-    y: int8;
+    x: int8
+    y: int8
 }
 
 var value: Point = { x: 10, y: 20 };
@@ -46,8 +46,9 @@ For example, if you assign 256 to uint8, asm command "8 STU" will fail with code
 | Type                      | TL-B equivalent                          | Serialization notes                 |
 |---------------------------|------------------------------------------|-------------------------------------|
 | `int8`, `uint55`, etc.    | same as TL-B                             | `N STI` / `N STU`                   |
-| `coins`                   | TL-B varint16                            | `STGRAMS`                           |
-| `bytes8`, `bits123`, etc. | just N bits                              | runtime check + `STSLICE` (1)       |
+| `coins`                   | VarUInteger 16                           | `STGRAMS`                           |
+| `varint16`, 32, etc.      | Var(U)Integer 16/32                      | `STVARINT16` / `STVARUINT32` / etc. |
+| `bits8`, `bits123`, etc.  | just N bits                              | runtime check + `STSLICE` (1)       |
 | `address`                 | MsgAddress (internal/external/none)      | `STSLICE` (2)                       |
 | `bool`                    | one bit                                  | `1 STI`                             |
 | `cell`                    | untyped reference, TL-B `^Cell`          | `STREF`                             |
@@ -55,8 +56,8 @@ For example, if you assign 256 to uint8, asm command "8 STU" will fail with code
 | `Cell<T>`                 | typed reference, TL-B `^T`               | `STREF`                             |
 | `Cell<T>?`                | maybe typed reference, TL-B `(Maybe ^T)` | `STOPTREF`                          |
 | `RemainingBitsAndRefs`    | rest of slice                            | `STSLICE`                           |
-| `builder`                 | only for writing, not for reading        | `STBR`                              |
-| `slice`                   | only for writing, not for reading        | `STSLICE`                           |
+| `builder`                 | only for writing, not for reading (5)    | `STB`                               |
+| `slice`                   | only for writing, not for reading (5)    | `STSLICE`                           |
 | `T?`                      | TL-B `(Maybe T)`                         | `1 STI` + IF ...                    |
 | `T1 \| T2`                | TL-B `(Either T1 T2)`                    | `1 STI` + IF ... + ELSE ... (3)     |
 | `T1 \| T2 \| ...`         | TL-B multiple constructors               | IF ... + ELSE IF ... + ELSE ... (4) |
@@ -68,7 +69,7 @@ For example, if you assign 256 to uint8, asm command "8 STU" will fail with code
 * (1) By analogy with `intN`, there is are `bytesN` types. It's just a `slice` under the hood: the type shows how to serialize this slice. 
 By default, before `STSLICE`, the compiler inserts runtime checks (get bits/refs count + compare with N + compare with 0). 
 These checks ensure that serialized binary data will be correct, but they cost gas. 
-However, if you guarantee that a slice is valid (for example, it comes from trusted sources), pass an option `skipBitsNFieldsValidation` to disable runtime checks.
+However, if you guarantee that a slice is valid (for example, it comes from trusted sources), pass an option `skipBitsNValidation` to disable runtime checks.
 
 * (2) In TVM, all addresses are also plain slices. Type `address` indicates that it's a slice containing *some* valid address (internal/external/none). 
 It's packed with `STSLICE` (no runtime checks) and loaded with `LDMSGADDR`. 
@@ -83,34 +84,37 @@ However, if T1 and T2 are both structures with manual serialization prefixes, th
 (or the compiler will generate them right here). For primitives, like `int32 | int64 | int128 | int256`, the compiler generates a prefix tree 
 (00/01/10/11 in this case). Read **auto-generating serialization prefixes** below.
 
+* (5) Using raw `builder` and `slice` for writing is supported, but not recommended, since they do not tell anything about their internal structure.
+There will be auto-generated TypeScript wrappers in the future, but for a raw `slice`, a wrapper just cannot be generated, no way to predict how to read such a field back.
+Probably, this feature will be removed in the future.
 
 
 ## Some examples of valid types
 
 ```tolk
 struct A {
-    f1: int8;      // just int8
-    f2: int8?;     // maybe int8
-    f3: address;   // internal/external/none
-    f4: bool;      // TRUE (-1) serialized as bit '1'
-    f5: B;         // embed fields of struct B
-    f6: B?;        // maybe B
-    f7: coins;     // used for money amounts
+    f1: int8       // just int8
+    f2: int8?      // maybe int8
+    f3: address    // internal/external/none
+    f4: bool       // TRUE (-1) serialized as bit '1'
+    f5: B          // embed fields of struct B
+    f6: B?         // maybe B
+    f7: coins      // used for money amounts
 
-    r1: cell;         // always-existing untyped ref
-    r2: Cell<B>;      // typed ref
-    r3: Cell<int32>?; // optional ref that stores int32
+    r1: cell          // always-existing untyped ref
+    r2: Cell<B>       // typed ref
+    r3: Cell<int32>?  // optional ref that stores int32
 
-    u1: int32 | int64;  // Either
-    u2: B | C;          // also Either
-    u3: B | C | D;      // manual or autogenerated prefixes
-    u4: bits4 | bits8?; // autogenerated prefix tree
+    u1: int32 | int64   // Either
+    u2: B | C           // also Either
+    u3: B | C | D       // manual or autogenerated prefixes
+    u4: bits4 | bits8?  // Maybe<bits4 | bits8>
 
     // even this works
-    e: Point | Cell<Point>;
+    e: Point | Cell<Point>
 
     // rest of slice
-    rest: RemainingBitsAndRefs;  
+    rest: RemainingBitsAndRefs
 }
 ```
 
@@ -124,7 +128,7 @@ Typically, you'll use 32-bit prefixes for messages opcodes, or arbitrary prefixe
 
 ```tolk
 struct (0x7362d09c) TransferNotification {
-    queryId: uint64;
+    queryId: uint64
     ...
 }
 ```
@@ -148,19 +152,19 @@ asset_booking$1000 order_id:uint64 = Asset;
 You can express the same with structures and union types:
 ```tolk
 struct (0b001) AssetSimple {
-    workchain: int8;
-    ptr: bits32;
+    workchain: int8
+    ptr: bits32
 }
 
 struct (0b1000) AssetBooking {
-    orderId: uint64;
+    orderId: uint64
 }
 
-type Asset = AssetSimple | AssetBooking | ...;
+type Asset = AssetSimple | AssetBooking | ...
 
 struct ProvideAssetMessage {
     ...
-    asset: Asset;
+    asset: Asset
 }
 ```
 
@@ -235,13 +239,13 @@ fun invalidDemo(obj: A | B) {
 If you, by mistake, use unsupported types, Tolk compiler will fire a meaningful error. Example:
 ```tolk
 struct ExtraData {
-    owner: address;
-    lastTime: int;
+    owner: address
+    lastTime: int
 }
 
 struct Storage {
     ...
-    more: Cell<ExtraData>;
+    more: Cell<ExtraData>
 }
 
 Storage.fromSlice("");
@@ -268,17 +272,17 @@ There are two types of references: typed and untyped.
 
 ```tolk
 struct NftCollectionStorage {
-    ownerAddress: address;
-    nextItemIndex: uint64;
-    content: cell;                       // untyped
-    nftItemCode: cell;                   // untyped
-    royaltyParams: Cell<RoyaltyParams>;  // typed
+    ownerAddress: address
+    nextItemIndex: uint64
+    content: cell                        // untyped
+    nftItemCode: cell                    // untyped
+    royaltyParams: Cell<RoyaltyParams>   // typed
 }
 
 struct RoyaltyParams {
-    numerator: uint16;
-    denominator: uint16;
-    royaltyAddress: address;
+    numerator: uint16
+    denominator: uint16
+    royaltyAddress: address
 }
 ```
 
@@ -320,8 +324,8 @@ val p2 = c.load();   // Cell<Point> to Point
 With types cells, you can express snake data:
 ```tolk
 struct Snake {
-    data: bits1023;
-    next: Cell<Snake>?;
+    data: bits1023
+    next: Cell<Snake>?
 }
 ```
 
@@ -350,6 +354,41 @@ Point.fromSlice(s, {
 ```
 
 
+## Custom serializers for custom types
+
+Imagine that you have your own "variable-length string": you encode its len, and then data, like
+```
+len: (## 8)        // 8 bits of len
+data: (bits len)   // 0..255 bits of data
+```
+
+To express this, you can create your own type and **define a custom serializer**:
+```tolk
+type VariadicString = slice
+
+fun VariadicString.packToBuilder(self, mutate b: builder) {
+    val nBits = self.remainingBitsCount();
+    b.storeUint(nBits, 8);
+    b.storeSlice(self);
+}
+
+fun VariadicString.unpackFromSlice(mutate s: slice) {
+    val nBits = s.loadUint(8);
+    return s.loadBits(nBits);
+}
+```
+
+And just use `VariadicString` as a regular type — everywhere:
+```tolk
+tokenName: VariadicString
+fullDomain: Cell<VariadicString>
+```
+
+The compiler inlines your functions every time packing/unpacking takes place.
+
+Method names `packToBuilder` and `unpackFromSlice` are reserved for this purpose, their prototype must be exactly as showed.
+
+
 ## UnpackOptions and PackOptions
 
 They allow you to control behavior of `fromCell`, `toCell`, and similar functions:
@@ -375,9 +414,9 @@ For deserialization (`fromCell` and similar), there are now two available option
 
 For serialization (`toCell` and similar), there is now one option:
 
-| Field of PackOptions        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-|-----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `skipBitsNFieldsValidation` | when a struct has a field of type `bits128` and similar (it's a slice under the hood), by default, compiler inserts runtime checks (get bits/refs count + compare with 128 + compare with 0); these checks ensure that serialized binary data will be correct, but they cost gas; however, if you guarantee that a slice is valid (for example, it comes from trusted sources), set this option to true to disable runtime checks; *note: `int32` and other are always validated for overflow without any extra gas, so this flag controls only rarely used `bytesN` / `bitsN` types;* **default: false**  |
+| Field of PackOptions        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+|-----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `skipBitsNValidation`       | when a struct has a field of type `bits128` and similar (it's a slice under the hood), by default, compiler inserts runtime checks (get bits/refs count + compare with 128 + compare with 0); these checks ensure that serialized binary data will be correct, but they cost gas; however, if you guarantee that a slice is valid (for example, it comes from trusted sources), set this option to true to disable runtime checks; *note: `int32` and other are always validated for overflow without any extra gas, so this flag controls only rarely used `bitsN` types;* **default: false**  |
 
 
 ## Full list of serialization functions
@@ -436,15 +475,13 @@ It's a built-in type to get "all the rest" slice tail on reading. Example:
 ```tolk
 struct JettonMessage {
      // ... some fields
-     forwardPayload: RemainingBitsAndRefs;
+     forwardPayload: RemainingBitsAndRefs
 }
 ```
 
 When you deserialize JettonMessage, forwardPayload contains _everything left after reading fields above_. Essentially, it's an alias to a slice which is handled specially while unpacking:
-
-
-```
-type RemainingBitsAndRefs = slice;
+```tolk
+type RemainingBitsAndRefs = slice
 ```
 
 
@@ -455,12 +492,16 @@ We've mentioned multiple times, that `T1 | T2` is encoded as TL-B Either: bit '0
 
 ```tolk
 struct WithUnion {
-    f: int8 | int16 | int32;
+    f: int8 | int16 | int32
 }
 ```
 
 In this case, **the compiler auto-generates a prefix tree**. This field will be packed as: '00' + int8 OR '01' + int16 OR '10' + int32. 
 On deserialization, the same format is expected (prefix '11' will throw an exception).
+
+The rules:
+* if `null` exists, it's 0, all others are 1+tree: A|B|C|D|null => 0 | 100+A | 101+B | 110+C | 111+D
+* if no `null`, just distributed sequentially: A|B|C => 00+A | 01+B | 10+C
 
 Same for structs without a manually specified prefix:
 ```tolk
@@ -470,11 +511,13 @@ struct C { ... }
 
 struct WithUnion {
     // simple either ('0' + A OR '1' + B)
-    e: A | B;
-    // auto-generated prefix tree
-    f: A | B | C;
+    e: A | B
+    // auto-generated prefix tree: 00/01/10
+    f: A | B | C
+    // with null, like Maybe<A|B>: 0/10/11
+    g: A | B | null
     // even this works, why not
-    g: A | int32 | C | bits128;
+    h: A | int32 | C | bits128
 }
 ```
 
@@ -486,9 +529,9 @@ struct (0b1100) WithPrefixLen4 { ... }
 
 struct WithUnion {
     // manual prefixes will be used, not 0/1
-    e: WithPrefixLen8 | WithPrefixLen16;
+    e: WithPrefixLen8 | WithPrefixLen16
     // also, no auto-generation
-    f: WithPrefixLen8 | WithPrefixLen16 | WithPrefixLen4;
+    f: WithPrefixLen8 | WithPrefixLen16 | WithPrefixLen4
 }
 ```
 
@@ -505,13 +548,13 @@ So, the rules are quite simple:
 * if you specify prefixes manually, they will be used (no matter within a union or not)
 * if you don't specify any prefixes, the compiler auto-generates a prefix tree
 * if you specify prefix for A, but forgot prefix for B, `A | B` can't be serialized
-* either (0/1) is just a prefix tree for two cases
+* either bit (0/1) is just a prefix tree for two cases
 
 **How can I specify a serialization prefix for non-struct?** Currently, there is no way to write something like `Prefixed<int32, 0b0011>`. 
 But you can just create a struct with a single field:
 ```tolk
 struct (0b0011) MyPrefixedInt {
-    value: int32;
+    value: int32
 }
 ```
 It will have no overhead against just `int32`, the same slot on a stack, just adding a prefix for (de)serialization.
@@ -532,9 +575,9 @@ Why do we say "potentially"? Because for many types, their size can vary:
 So, suppose you have:
 ```tolk
 struct MoneyInfo {
-    fixed: bits800;
-    wallet1: coins;
-    wallet2: coins;
+    fixed: bits800
+    wallet1: coins
+    wallet2: coins
 }
 ```
 
@@ -558,19 +601,19 @@ struct MoneyInfo {
 ```tolk
 // you can extract the first field
 struct MoneyInfo {
-    fixed: Cell<bits800>;
-    wallet1: coins;
-    wallet2: coins;
+    fixed: Cell<bits800>
+    wallet1: coins
+    wallet2: coins
 }
 
 // or extract other 2 fields
 struct WalletsBalances {
-    wallet1: coins;
-    wallet2: coins;
+    wallet1: coins
+    wallet2: coins
 }
 struct MoneyInfo {
-    fixed: bits800;
-    balances: Cell<WalletsBalances>;
+    fixed: bits800
+    balances: Cell<WalletsBalances>
 }
 ```
 
@@ -592,7 +635,7 @@ And you want to use this `addrB` (it's `builder`! not `address`) to write into a
 ```tolk
 struct MyStorage {
     ...
-    addr: address;
+    addr: address
 }
 
 var st: MyStorage;
@@ -604,44 +647,58 @@ The solution is: if you want `builder` for writing, and `address` for reading...
 ```tolk
 struct MyStorageData<T> {
     ...
-    addr: T;
+    addr: T
 }
 
-type MyStorage = MyStorageData<address>;
-type MyStorageForWrite = MyStorageData<builder>;
+type MyStorage = MyStorageData<address>
+type MyStorageForWrite = MyStorageData<builder>
 ```
 
 The same technique can be combined with `RemainingBitsAndRefs` and some more cases. 
 Moreover, for performance optimizations, you can create different "views" over the same data. Don't underestimate generics and the type system in general.
 
 
-### Integration with message sending and receiving
+## Integration with message sending
 
-Tolk v0.13 doesn't provide any helpers for composing and sending messages. It's the task for future releases.
+Auto-serialization is natively integrated with sending messages to other contracts.
+You just "send some object," and the compiler automatically serializes it, detects whether it fits into a message cell, etc.
 
-So, for now, you can declare outgoing messages with structures, but you still manually create a message cell. 
-Thanks to `builder.storeAny`, you can prepare message body and write it automatically:
 ```tolk
-struct (0x...) SomeOutgoingMessage {
-    ...
+val reply = createMessage({
+    bounce: true,
+    value: ton("0.05"),
+    dest: senderAddress,
+    body: RequestedInfo {     // auto-serialized
+        ...
+    }
+});
+reply.send(SEND_MODE_REGULAR);
+```
+
+Continue reading here: [Universal createMessage](/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message).
+
+
+## Not "fromCell" but "lazy fromCell"
+
+Tolk has a special keyword `lazy` that is combined with auto-deserialization. The compiler will load not a whole struct, but only fields requested.
+```tolk
+struct Storage {
+    isSignatureAllowed: bool
+    seqno: uint32
+    subwalletId: uint32
+    publicKey: uint256
+    extensions: dict
 }
 
-val outBody: SomeOutgoingMessage = { 
-    ... 
-};
-
-// the same as you do now
-val out = beginCell()
-         .storeUint(0x18, 6)    // bounceable
-         ...                    // all the header
-         // but auto-serialize body (inline)
-         .storeAny(outBody)
-         // or — embed body as a ref
-         .storeRef(outBody.toCell());
-
-// same as before, but with auto-serialized body
-sendRawMessage(out.endCell(), mode);
+get fun getPublicKey() {
+    val st = lazy Storage.fromCell(contract.getData());
+    // <-- here "skip 65 bits, preload uint256" is inserted
+    return st.publicKey
+}
 ```
+
+Continue reading here: [lazy loading, partial loading](/v3/documentation/smart-contracts/tolk/tolk-vs-func/lazy-loading).
+
 
 
 <Feedback />

--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx
@@ -144,7 +144,7 @@ The table is "sorted" in a way how functions are declared in stdlib.fc:
 | slice_refs(s) or dot              | s.remainingRefsCount()             |                 |
 | slice_bits(s) or dot              | s.remainingBitsCount()             |                 |
 | slice_bits_refs(s) or dot         | s.remainingBitsAndRefsCount()      |                 |
-| slice_empty?(s) or dot            | s.isEnd()                          |                 |
+| slice_empty?(s) or dot            | s.isEmpty()                        |                 |
 | slice_data_empty?(s) or dot       | s.isEndOfBits()                    |                 |
 | slice_refs_empty?(s) or dot       | s.isEndOfRefs()                    |                 |
 | slice_depth(s) or dot             | s.depth()                          |                 |

--- a/sidebars/documentation.js
+++ b/sidebars/documentation.js
@@ -84,6 +84,7 @@ module.exports = [
           'v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib',
           'v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells',
           'v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message',
+          'v3/documentation/smart-contracts/tolk/tolk-vs-func/lazy-loading',
           'v3/documentation/smart-contracts/tolk/changelog',
         ],
       },

--- a/src/theme/prism/prism-tolk.js
+++ b/src/theme/prism/prism-tolk.js
@@ -22,7 +22,7 @@
 
     'boolean': /\b(false|true|null)\b/,
 
-    'keyword': /\b(do|if|as|is|try|else|while|break|throw|catch|return|assert|repeat|continue|asm|builtin|import|export|true|false|null|redef|mutate|tolk|global|const|var|val|fun|get|struct|match|type)\b/,
+    'keyword': /\b(do|if|as|is|try|else|while|break|throw|catch|return|assert|repeat|continue|asm|builtin|import|export|true|false|null|redef|mutate|tolk|global|const|var|val|fun|get|struct|match|type|lazy)\b/,
 
     'self': /\b(self)\b/,
 


### PR DESCRIPTION
## Description

Tolk v1.0 is finally releasing!

* https://github.com/ton-blockchain/ton/pull/1741

Closes #1312.

#### Notable changes in Tolk v1.0

1. The magic `lazy` keyword — lazy loading, partial loading, partial updating
2. Auto-detect and inline functions at the compiler level
3. Various optimizations for gas efficiency
4. `onInternalMessage` and `onBouncedMessage`, TVM 11 support
5. Custom pack/unpack serializers for custom types

## Checklist

- [x] I have created an issue.
- [x] I am working on content that aligns with the [Style guide](https://docs.ton.org/v3/contribute/style-guide/).
- [x] I have reviewed and formatted the content according to [Content standardization](https://docs.ton.org/v3/contribute/content-standardization/).
- [x] I have reviewed and formatted the text in the article according to [Typography](https://docs.ton.org/v3/contribute/typography/).
