### PR TITLE
fix incorrect telegram bot username for receive testnet coins

### DIFF
--- a/docs/v3/documentation/smart-contracts/getting-started/testnet.mdx
+++ b/docs/v3/documentation/smart-contracts/getting-started/testnet.mdx
@@ -9,7 +9,7 @@ Coins in the test network have no value, and the network can be reset at any tim
 :::
 
 - Testnet global configuration: [https://ton.org/testnet-global.config.json](https://ton.org/testnet-global.config.json)
-- Get free test coins from the [@test_giver_ton_bot](https://t.me/testgiver_ton_bot)
+- Get free test coins from the [@testgiver_ton_bot](https://t.me/testgiver_ton_bot)
 - Check the testnet status in the Telegram channel: [@testnetstatus](https://t.me/testnetstatus)
 
 ### Core services

--- a/i18n/ru/docusaurus-plugin-content-docs/current/v3/documentation/smart-contracts/getting-started/testnet.mdx
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/v3/documentation/smart-contracts/getting-started/testnet.mdx
@@ -11,7 +11,7 @@
 :::
 
 - Глобальная конфигурация тестовой сети: https://ton.org/testnet-global.config.json
-- Получите бесплатные тестовые монеты от [@test_giver_ton_bot](https://t.me/testgiver_ton_bot)
+- Получите бесплатные тестовые монеты от [@testgiver_ton_bot](https://t.me/testgiver_ton_bot)
 - Проверьте статус тестовой сети в Telegram канале: [@testnetstatus](https://t.me/testnetstatus)
 
 ### Основные сервисы

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/v3/documentation/smart-contracts/getting-started/testnet.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/v3/documentation/smart-contracts/getting-started/testnet.mdx
@@ -7,7 +7,7 @@
 :::
 
 - 测试网络全局配置: https://ton.org/testnet-global.config.json
-- 您可以在 [@test_giver_ton_bot](https://t.me/testgiver_ton_bot) 获取免费的测试代币
+- 您可以在 [@testgiver_ton_bot](https://t.me/testgiver_ton_bot) 获取免费的测试代币
 - 在这个 Telegram 频道中查看测试网络的状态: [@testnetstatus](https://t.me/testnetstatus)
 
 ## 服务


### PR DESCRIPTION
## Description

Fix incorrect Telegram bot username for receiving testnet coins
`@test_giver_ton_bot` -> `@testgiver_ton_bot` 

Closes #1357

## Checklist

- [x] I have created an issue.
- [x] I am working on content that aligns with the [Style guide](https://docs.ton.org/v3/contribute/style-guide/).
- [x] I have reviewed and formatted the content according to [Content standardization](https://docs.ton.org/v3/contribute/content-standardization/).
- [x] I have reviewed and formatted the text in the article according to [Typography](https://docs.ton.org/v3/contribute/typography/).
