### PR TITLE
Split: update docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx
+++ b/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx
@@ -1,6 +1,6 @@
 import Feedback from '@site/src/components/Feedback';
 
-# Differences between TON and Ethereum
+# Differences between TON and Ethereum blockchains
 
 ## Introduction
 
@@ -22,7 +22,7 @@ This section compares Ethereum and TON account models and interaction patterns.
 
 Ethereum uses an account-based model to track balances. An account stores its balance and state, like a regular bank account. There are two types of accounts:
 
-- **Externally-owned accounts (EOAs)** - externally managed accounts are controlled by the user using public and private key pairs. The address allows others to send funds to the account (the address is derived from the public key).
+- **Externally-owned accounts (EOAs)** - externally managed accounts are controlled by the user using public and private key pairs. The address allows others to send funds to the account, the address is derived from the public key.
 - **Contract accounts** - controlled by smart contract code rather than private keys. Contract accounts cannot initiate transactions independently because they do not have a private key.
 
 When an Ethereum user creates a wallet, an EOA is added to the global state on all nodes in the decentralized network. Deploying a smart contract creates a contract account capable of storing and distributing funds programmatically based on certain conditions. EOAs initiate transactions; contract accounts execute code and perform internal calls when invoked. This structure provides Ethereum's ability to serve as programmable money.
@@ -44,6 +44,14 @@ Processing a message produces a transaction; inter-contract communication is asy
 A developer coming from Ethereum needs to realize that smart contracts in the TON blockchain can only communicate with each other by sending asynchronous messages, which means that if there is a need to request data from another contract and an immediate response is required, this will not be possible. Instead, clients outside the network must call `get methods`, much like a wallet in Ethereum that uses RPC nodes to request smart contract states. This is an important limitation for several reasons. For example, flash loans are transactions executed within a single block, relying on the ability to borrow and repay in the same transaction.
 
 The synchronous nature of Ethereum's EVM facilitates such transactions, whereas the asynchronous nature of all transactions in TON makes executing a flash loan infeasible. Oracles, which provide smart contracts with external data, also involve a more intricate design process in TON. What oracles are and how to use them in TON can be found [here](/v3/documentation/dapps/oracles/about_blockchain_oracles/).
+
+
+:::info
+Read more in [Accounts](/v3/concepts/dive-into-ton/ton-blockchain/accounts).
+:::
+
+
+
 
 ### Wallets
 
@@ -72,24 +80,22 @@ Transaction flow
 1. A transaction hash is cryptographically generated: `0x97d99bc7729211111a21b12c933c949d4f31684f1d6954ff477d0477538ff017`
 2. The transaction is then broadcast to the network and added to a transaction pool consisting of all other pending network transactions.
 3. A validator must pick your transaction and include it in a block to verify and consider it successful.
-4. As time passes, the block containing your transaction will be confirmed and then finalized. These upgrades ensure that your transaction was successful and will never be altered. Once a block is finalized, it could only ever be changed by a network-level attack that would cost many billions of dollars.
+4. As time passes, the block containing your transaction will be upgraded to `justified` and then `finalized`. These upgrades ensure that your transaction was successful and will never be altered. Once a block is finalized, it could only ever be changed by a network-level attack that would cost many billions of dollars.
 
 #### TON
 
 In TON, the entity that transfers data between two contracts is called a message. For example, a message contains arbitrary data about a token transfer sent to a specified address. When the message arrives at the contract, the contract processes this according to the code. The contract updates its state and optionally sends a new message. [Transaction](/v3/documentation/smart-contracts/message-management/messages-and-transactions/) is an entire flow from receiving messages to executing actions on the account.
 
-For example, consider the interaction of accounts where we have messages from contract **A** to contract **B**. In this case, we have two messages (external to the wallet and internal to the destination) and two transactions.
-
 But initially, to change the state of the blockchain, you need an outside signal. To invoke a smart contract, you need to send an external message to the validators, and they will apply it to the smart contract.
+
+For example, consider the interaction of accounts where we have messages from contract **A** to contract **B**. In this case, we have two messages (external to the wallet and internal to the destination) and two transactions.
 
 As we already discussed, a wallet is a smart contract, so this external message usually first goes to the wallet's smart contract, which records it as the first transaction, and that first transaction usually contains an embedded message for the actual destination contract.
 
 When the wallet smart contract receives the message, it processes it and delivers it to the destination contract. In our example, contract **A** could be a wallet; when it receives the external message, it will have the first transaction.
 
-We can represent the sequence of transactions as a chain. In this representation, each smart contract has its transactions, which means that each contract has its [AccountChain](/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains), so the network can process the transactions independently.
-
 :::info
-Read more in [Blockchain of blockchains](/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains).
+Read more in [Messages and transactions](/v3/documentation/smart-contracts/message-management/messages-and-transactions).
 :::
 
 ### Gas
@@ -137,12 +143,12 @@ Ethereum inherits and extends the foundational principles of Bitcoin. This appro
 
 #### TON
 
-TON offers an alternative approach to improve scalability and performance in response to these challenges. Designed to provide developers with maximum flexibility to create various applications, TON uses the concept of shards and the MasterChain to optimize the block creation process. TON features sub-second block times and ~3s finalization, ensuring fast transaction execution. Unlike Ethereum, where state updates are synchronous, TON implements asynchronous messaging between smart contracts, allowing each transaction to be processed independently and in parallel, significantly speeding up transaction processing on the network. Sections and articles to familiarize yourself with:
+TON offers an alternative approach to improve scalability and performance in response to these challenges. Designed to provide developers with maximum flexibility to create various applications, TON uses the concept of shards and the MasterChain to optimize the block creation process. TON each ShardChain and MasterChain generate a new block on average every 3 seconds, ensuring fast transaction execution. Unlike Ethereum, where state updates are synchronous, TON implements asynchronous messaging between smart contracts, allowing each transaction to be processed independently and in parallel, significantly speeding up transaction processing on the network. Sections and articles to familiarize yourself with:
 
-- [Shards](/v3/concepts/dive-into-ton/ton-blockchain/sharding)
+- [Sharding in TON](/v3/concepts/dive-into-ton/ton-blockchain/sharding)
 - [Comparison of blockchains](/v3/concepts/dive-into-ton/ton-blockchain/blockchain-comparison)
 
-In conclusion, by comparing TON and Ethereum's architecture and technological underpinnings, it's clear that TON offers significant advantages. With its innovative approach to asynchronous transaction processing and unique shard and MasterChain architecture, TON demonstrates the potential to support high throughput without compromising security or centralization. High scalability provides the platform with outstanding flexibility and efficiency, making it ideal for various applications.
+In conclusion, by comparing TON and Ethereum's architecture and technological underpinnings, it's clear that TON offers significant advantages. With its innovative approach to asynchronous transaction processing and unique shard and MasterChain architecture, TON demonstrates the potential to support millions of transactions per second without compromising security or centralization. High scalability provides the platform with outstanding flexibility and efficiency, making it ideal for various applications.
 
 ## See also
 

--- a/docs/v3/concepts/dive-into-ton/ton-blockchain/accounts.mdx
+++ b/docs/v3/concepts/dive-into-ton/ton-blockchain/accounts.mdx
@@ -12,7 +12,7 @@ In TON, an **account** is an **actor** - an isolated computational entity that c
 ## Components
 Each account consists of:
 - **Account properties** — basic information such as the account’s ID, balance, status, and its last transaction. These properties let users track their funds and activity.
-- **Data** — user-defined storage, holding variables or contract-specific information. This is where an account keeps its custom data.
+- **Data** — storage, holding contract-specific information. This is where an account keeps its custom data.
 - **Code** — the logic that determines how the account reacts to incoming messages and generates outgoing ones. This defines the account’s behavior on the blockchain.
 
 :::note


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-concepts-dive-into-ton-go-from-ethereum-difference-of-blockchains.mdx` into `main`.

Changed file(s):
- M: `docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx`

Related issues (from issues.normalized.md):
- [33] Fix H1 title grammar and scope
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L3
- [34] Improve introduction parallelism and clarity
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L7
- [35] Pluralize “Account” heading
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L17
- [36] Remove self-referential lead-in in Accounts
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L19-L20
- [37] Correct Ethereum account model wording
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L23-L24
- [38] Use address (not public key) for receiving funds
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L25
- [39] Make account type bullets consistent
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L25-L26
- [40] Clarify who initiates transactions in Ethereum
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L28
- [41] Clarify synchronicity drawbacks wording
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L30
- [42] Use “microservice architectures” and drop “reentrant”
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L34-L35
- [43] Replace “scripts” and refine async phrasing
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L36-L43
- [44] Fix transaction vs multiple calls contradiction
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L42-L43
- [45] Remove brand reference to Infura
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L44
- [46] Lowercase “oracles”
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L46
- [47] Clean up Ethereum wallets section content and naming
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L52-L56
- [48] Remove redundancy “DApp application”
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L62
- [49] Pluralize “Transaction” heading
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L64
- [50] Add comma after introductory clause
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L68
- [51] Generalize Ethereum confirmation wording
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L70-L76
- [52] Move period outside inline code
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L75
- [53] Clarify message and transaction counts in TON example
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L78-L88
- [54] Fix pronoun agreement for external message
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L85
- [55] Use “AccountChain” terminology
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L86-L90
- [56] Fix link text to match target page
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L92-L95
- [57] Improve fee formula lead-in and code fence
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L105-L109
- [58] Clarify Ethereum storage cost statement
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L110-L112
- [59] Refine TON gas wording, currency, and refunds
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L114-L125
- [60] Align block time claim with comparison page
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L140
- [61] Fix broken sharding link path
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L142
- [62] Soften or cite throughput claim
  - https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/difference-of-blockchains.mdx?plain=1#L145

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.