### PR TITLE
Split: update docs/v3/concepts/dive-into-ton/go-from-ethereum/tvm-vs-evm.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/concepts/dive-into-ton/go-from-ethereum/tvm-vs-evm.mdx
+++ b/docs/v3/concepts/dive-into-ton/go-from-ethereum/tvm-vs-evm.mdx
@@ -5,9 +5,9 @@ import Feedback from '@site/src/components/Feedback';
 ## Introduction
 **Ethereum Virtual Machine (EVM)** and **TON Virtual Machine (TVM)** are stack-based virtual machines developed for running smart contract code. Although they have standard features, there are notable distinctions between them.
 
-## Differences of TVM and EVM
+## Differences between TVM and EVM
 
-### Data presentation
+### Data representation
 
 #### EVM
 
@@ -108,7 +108,7 @@ It’s essential to note that the EVM supports complex data structures by levera
 
 #### TVM
 
-- TVM supports 256-bit Elliptic Curve Cryptography (ECC) for predefined curves, like Curve25519. It also supports Weil pairings on some elliptic curves, which are helpful for the fast implementation of zk-SNARKs (zero-knowledge proofs). Popular hash functions like sha256 are also supported, providing more cryptographic operation options. In addition, TVM can work with Merkle proofs, providing additional cryptographic features that can be beneficial for specific use cases, such as verifying the inclusion of a transaction in a block.
+- TVM supports 256-bit Elliptic Curve Cryptography (ECC) for predefined curves, like Curve25519. It also supports Weil pairings on some elliptic curves, which are helpful for the fast implementation of zk-SNARKs (zero-knowledge proofs). Popular hash functions like SHA-256 are also supported, providing more cryptographic operation options. In addition, TVM can work with Merkle proofs, providing additional cryptographic features that can be beneficial for specific use cases, such as verifying the inclusion of a transaction in a block.
 
 ### High-level languages
 
@@ -132,4 +132,3 @@ TVM’s support for sharding-aware smart contracts and its unique data represent
 - [TVM overview](/v3/documentation/tvm/tvm-overview/)
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-concepts-dive-into-ton-go-from-ethereum-tvm-vs-evm.mdx` into `main`.

Changed file(s):
- M: `docs/v3/concepts/dive-into-ton/go-from-ethereum/tvm-vs-evm.mdx`

Related issues (from issues.normalized.md):
- [ ] **90. Fix section heading phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/tvm-vs-evm.mdx?plain=1#L8

Change the heading text from “Differences of TVM and EVM” to “Differences between TVM and EVM” for idiomatic English.

---

- [ ] **91. Use “Data representation” in heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/tvm-vs-evm.mdx?plain=1#L10

Replace “Data presentation” with “Data representation” to correctly describe how data is modeled.

---

- [ ] **92. Correct Ethereum state and address/storage mapping**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/tvm-vs-evm.mdx?plain=1#L18-L19

Fix the description to: “Ethereum’s global state maps 160‑bit addresses to account objects; each account’s storage maps 256‑bit keys to 256‑bit values,” and avoid introducing “Merkle Patricia Trie (MPT)” terminology here.

---

- [ ] **93. Correct TVM cell capacity (bits vs bytes)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/tvm-vs-evm.mdx?plain=1#L27

Change “up to 128 data bytes” to “up to 1023 data bits (about 128 bytes) and up to 4 references to other cells.”

---

- [ ] **94. Fix hashmap example code blocks (language, syntax, identifiers)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/tvm-vs-evm.mdx?plain=1#L54-L59,L72-L78

Retag the illustrative blocks from “js” to “text” (or make them valid JS), add the missing comma after “1: 10”, remove parenthetical prose, and use a single consistent identifier form (e.g., “cell_a”) across both blocks.

---

- [ ] **95. Include dictionary operand in example steps**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/tvm-vs-evm.mdx?plain=1#L63-L66

Update the step sequence to push the dictionary onto the stack before lookups (e.g., “0. Push the hashmap; 1. Push key; 2. dictionary get …”).

---

- [ ] **96. Clarify TVM overflow behavior (quiet vs non‑quiet; exit code 4)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/tvm-vs-evm.mdx?plain=1#L99-L101

Replace the blanket claim with: “TVM offers quiet and non‑quiet arithmetic; non‑quiet variants perform overflow checks and throw on overflow (exit code 4), while quiet variants do not.”

---

- [ ] **97. Remove unsupported TVM cryptography claims**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/tvm-vs-evm.mdx?plain=1#L111

Delete references to Curve25519, pairings, and zk‑SNARK support; if needed, restrict to features documented in this corpus (e.g., hash functions and Merkle proof cells).

---

- [ ] **98. Use “SHA‑256” capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/tvm-vs-evm.mdx?plain=1#L111

Change “sha256” to “SHA‑256” to match standard naming and corpus usage.

---

- [ ] **99. Align Solidity description with corpus**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/tvm-vs-evm.mdx?plain=1#L117

Rephrase to: “Solidity is an object‑oriented, high‑level, strictly typed language influenced by C++, Python, and JavaScript.”

---

- [ ] **100. Correct TVM integer model (signed 257‑bit)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/tvm-vs-evm.mdx?plain=1

Replace the list of fixed widths (64/128/256) with a statement that TVM arithmetic operates on signed 257‑bit integers; mention narrower helpers only if cited.

---

- [ ] **101. Remove unsourced Solidity 0.8 overflow claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/tvm-vs-evm.mdx?plain=1

Delete or internally cite the statement about automatic overflow/underflow checks in Solidity 0.8; avoid unsourced cross‑chain assertions.

---

- [ ] **102. Include Tact and Tolk in language list**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/tvm-vs-evm.mdx?plain=1

Update wording to: “TON smart contracts are written in languages such as FunC, Tact, and Tolk; FunC compiles to Fift, which compiles to TVM bytecode.”

---

- [ ] **103. Replace undefined “sharding‑aware” phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/tvm-vs-evm.mdx?plain=1

Change “sharding‑aware smart contracts” to “asynchronous messaging model and sharding architecture,” linking to the shards overview if appropriate.

---

- [ ] **104. Use neutral dictionary get/set wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/tvm-vs-evm.mdx?plain=1

Replace raw opcode names like DICTGET/DICTSET with neutral terms (“dictionary get/set”) and reference the dictionary docs.

---

- [ ] **105. Remove unsupported EVM cryptography claims**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/go-from-ethereum/tvm-vs-evm.mdx?plain=1

Eliminate unsourced statements about secp256k1, keccak256, or Merkle proof support, or add internal citations; keep claims within documented scope.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.