### PR TITLE
Split: update docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-comparison.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-comparison.mdx
+++ b/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-comparison.mdx
@@ -8,7 +8,6 @@ This document provides a comparative analysis of TON against Ethereum and Solana
 |----------------------------|------------------------|------------------|-------------|
 | **Consensus**              | Proof of Stake         | Proof of History | BFT PoS     |
 | **TPS**                    | 100,000 TPS            | 59,400 TPS       | 104,715 TPS |
-| **Block Time**             | 12 sec                 | < 1 sec          | < 1 sec     |
-| **Time to Finalize Block** | 10-15 min              | ~13 sec          | < 3 sec     |
+| **Block time**             | 12 seconds             | &lt; 1 second      | &lt; 1 second |
+| **Time-to-finality**       | 10-15 minutes          | ~13 seconds      | &lt; 3 seconds |
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-concepts-dive-into-ton-ton-blockchain-blockchain-comparison.mdx` into `main`.

Changed file(s):
- M: `docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-comparison.mdx`

Related issues (from issues.normalized.md):
- [ ] **117. Simplify opening sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-comparison.mdx?plain=1#L5

Replace the opening with: "This page provides a quick comparison of TON, Ethereum, and Solana."

---

- [ ] **118. Fix Ethereum header and ticker consistency**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-comparison.mdx?plain=1#L7

Replace "Ethereum 2.0 (ETH 2.0)" with "Ethereum" and standardize tickers across all headers—either remove them everywhere or use correct ones consistently (Ethereum (ETH), Solana (SOL), TON (TON)).

---

- [ ] **119. Correct Solana consensus to PoS + Tower BFT (PoH‑assisted)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-comparison.mdx?plain=1#L9

Change Solana’s consensus entry from "Proof of History" to "Proof of Stake + Tower BFT (PoH‑assisted)."

---

- [ ] **120. Clarify TON consensus as Proof‑of‑stake (Catchain)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-comparison.mdx?plain=1#L9

Replace "BFT PoS" with the corpus‑aligned label "Proof‑of‑stake (Catchain)."

---

- [ ] **121. Add context and sources for TPS figures**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-comparison.mdx?plain=1#L10

Label TPS values by context (e.g., L1 typical/theoretical/benchmark) and add citations, or include a source note linking to https://ton.org/comparison_of_blockchains.pdf.

---

- [ ] **122. Standardize time units to "seconds" and "minutes"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-comparison.mdx?plain=1#L11-L12

Replace "sec"/"min" with spelled‑out units ("seconds"/"minutes") consistently across the table.

---

- [ ] **123. Rename row to "Time‑to‑finality"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-comparison.mdx?plain=1#L12

Change the row label "Time to Finalize Block" to "Time‑to‑finality" to match common terminology and the FAQ.

---

- [ ] **124. Update Solana time‑to‑finality value**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-comparison.mdx?plain=1#L12

Replace "~13 sec" with a current Solana finality figure from official docs and add a citation.

---

- [ ] **125. Align TON time‑to‑finality with FAQ**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-comparison.mdx?plain=1#L12

Update the TON value from "< 3 sec" to "under 6 seconds" to match docs/v3/documentation/faq.mdx#time-to-finality.

---

- [ ] **126. Use "Block time" capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-comparison.mdx?plain=1

Change the row label "Block Time" to "Block time" (lowercase "time") for consistency with the FAQ.

---

- [ ] **127. Align TON block time with FAQ**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-comparison.mdx?plain=1

Change the TON "Block time" value from "< 1 sec" to "2–5 seconds" to match docs/v3/documentation/faq.mdx#block-time.

---

- [ ] **128. Escape "<" in table cells**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-comparison.mdx?plain=1

Replace literal "<" with "&lt;" in table cells to prevent MDX/HTML parsing issues.

---

- [ ] **3295. Align block time and finality with comparison table**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

FAQ lists “Block time: 2–5 seconds” and “Time-to-finality: under 6 seconds,” but the comparison table shows “Block Time: < 1 sec” and “Time to Finalize Block: < 3 sec”; align these values to the comparison or remove hard numbers and defer to docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-comparison.mdx as the source of truth.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.