### PR TITLE
Split: update docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains.mdx
+++ b/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains.mdx
@@ -1,6 +1,6 @@
 import Feedback from '@site/src/components/Feedback';
 
-# Blockchain
+# Blockchain of Blockchains
 
 A **blockchain** is a chain of blocks, each containing information that all participants in the network can access and trust. Every block is securely linked to the previous one, and the entire chain is continuously replicated and synchronized across the network.
 
@@ -22,10 +22,68 @@ Unlike traditional _single-chain systems_, TON uses a **multi-chain**, **sharded
 
 All these levels work together: activity starts in the buildings **(accounts)**, flows through the streets **(shards)**, gets organized within districts **(WorkChains)**, and stays coordinated by the city hall **(the MasterChain)**.
 
+This behavior follows the **actor model**, where each contract is an independent entity reacting to messages.
+
+### The Lowest Level: AccountChain
+
+A **chain** can be viewed as a sequence of transactions, such as `Tx1 → Tx2 → Tx3 → …`. When this transaction sequence pertains to a single account, it is specifically termed an **AccountChain**.
+
+Since nodes processing these transactions periodically need to synchronize the smart contract state to achieve consensus, transactions are grouped into batches called **blocks**. For instance:
+
+```text
+[Tx1 → Tx2] → [Tx3 → Tx4 → Tx5] → [] → [Tx6]
+```
+
+Batching does not alter the underlying sequence. Each transaction has exactly one predecessor in the per-account chain; the next transaction, if any, follows in sequence. Batching simply organizes this sequence into manageable blocks for consensus purposes.
+
+Additionally, each block can contain queues of incoming and outgoing messages. Incorporating these queues ensures that a block fully encapsulates all events and state changes relevant to the smart contract within the block period.
+
+## Many AccountChains: Shards
+
+Now let us consider many accounts. We can group multiple AccountChains together; such a group of AccountChains is called a **ShardChain**. In the same way, we can cut a ShardChain into **ShardChain blocks**, which aggregate blocks for individual AccountChains.
+
+### Dynamic Splitting and Merging of ShardChains
+
+Note that since a ShardChain consists of easily distinguished AccountChains, we can easily split it. That way, if we have one ShardChain that describes events that happen with one million accounts and there are too many transactions per second to be processed by a single node, we **split** that chain into two smaller ShardChains, with each chain accounting for half a million accounts and each processed on a separate subset of nodes.
+
+Analogously, if some shards become underutilized, they can be **merged** into one shard.
+
+There are two limiting cases: when the shard cannot be split further and when the shard contains all accounts.
+
+Accounts can interact with each other by sending messages. A unique routing mechanism moves messages from outgoing queues to corresponding incoming queues and ensures:
+
+1. All messages are delivered.
+2. Messages from a specific account A to a specific account B are delivered in the same order they were sent. However, if multiple accounts are involved, the order of message delivery is not guaranteed.
+
+:::info SIDE NOTE
+An aggregation of AccountChains into shards is based on the bitwise representation of account addresses to make splitting and merging deterministic. For example, an address looks like `(shard prefix, account_id)`. That way, all accounts in the ShardChain will have the same binary prefix (for instance, all addresses will start with `0b00101`).
+:::
+
+## WorkChain
+
+An aggregation of all shards, which contains all accounts that behave according to one set of rules, is called a WorkChain.
+
+In TON, there can be many sets of rules, and thus, many WorkChains operate simultaneously and can interact with each other by sending messages cross-chain in the same way that accounts of one chain can interact with each other.
+
+### WorkChain: A Blockchain With Your Own Rules
+
+If you want to customize the rules for its ShardChains, you could create a **WorkChain**. For example, Hypothetical example: it is theoretically possible to create a WorkChain that supports EVM to run Solidity smart contracts, but this would be a complex undertaking due to the differences between TVM and EVM.
+
+Theoretically, anyone in the community can propose their own WorkChain. However, building one is a complex task. Furthermore, it requires governance approval.
+
+TON allows up to `2^32` WorkChains, each subdivided into up to `2^60` shards.
+
+Currently, there are only two WorkChains in TON: MasterChain and BaseChain.
+
+BaseChain is used for everyday transactions between actors; the MasterChain coordinates the network.
+
+### MasterChain
+
+There is a necessity for the synchronization of message routing and transaction execution. In other words, nodes in the network need a way to fix some point in a multichain state and reach a consensus about that state. In TON, a special chain called the **MasterChain** is used for that purpose. Blocks of the MasterChain contain additional information—such as the latest block hashes—about all other chains in the system, so any observer can unambiguously determine the state of the multichain system at a single MasterChain block.
+
 ## See also
 - [Sharding in TON](/v3/concepts/dive-into-ton/ton-blockchain/sharding)
 - [Blockchain structure](/v3/guidelines/dapps/transactions/foundations-of-blockchain#blockchain-structure)
 - [Shards](/v3/documentation/smart-contracts/shards/shards-intro)
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-concepts-dive-into-ton-ton-blockchain-blockchain-of-blockchains.mdx` into `main`.

Changed file(s):
- M: `docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains.mdx`

Related issues (from issues.normalized.md):
- [ ] **129. Standardize heading capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains.mdx?plain=1

Headings mix sentence case and Title Case; adopt one style (Title Case) and apply consistently, e.g., “Blockchain of Blockchains”, “Single Actor”, “The Lowest Level: AccountChain”, “Dynamic Splitting and Merging of ShardChains”, “WorkChain: A Blockchain With Your Own Rules”, “MasterChain”.

---

- [ ] **130. Define or replace undefined ‘AccountBlock’**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains.mdx?plain=1

The term “AccountBlock” is undefined; either define it (a block for a single AccountChain) where blocks are first introduced or replace with “ShardChain blocks aggregate individual AccountChain blocks.”

---

- [ ] **131. Correct sharding limit explanation (max 60-bit depth)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains.mdx?plain=1

Replace the confusing “2^256/2^60 accounts” limit with an explanation based on shard prefix depth (max 60 bits), stating that at maximum depth shards cannot be split further and at the other extreme a single shard may contain all accounts.

---

- [ ] **132. Clarify shard cap applies per WorkChain**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains.mdx?plain=1

Clarify that the 2^60 shard bound applies per WorkChain by rewriting to “TON allows up to 2^32 WorkChains, each subdivided into up to 2^60 shards.”

---

- [ ] **133. Correct transaction linkage; remove ‘prev tx’/‘next tx’**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains.mdx?plain=1

Correct the transaction linkage to reflect only a previous link and remove colloquial abbreviations by rewriting to “Each transaction has exactly one predecessor in the per-account chain; the next transaction, if any, follows in sequence.”

---

- [ ] **134. Clarify grouping of AccountChains**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains.mdx?plain=1

Replace “We can get a few AccountChains and store them together” with “We can group multiple AccountChains together; such a group of AccountChains is called a ShardChain” for clarity.

---

- [ ] **135. Use ‘bitwise representation’ instead of ‘bit-representation’**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains.mdx?plain=1

Use “bitwise representation” (or “bit representation”) instead of “bit-representation” when describing account address bits.

---

- [ ] **136. Remove quotes around “point”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains.mdx?plain=1

Remove unnecessary quotation marks around the word “point” in “fix some point in a multichain state.”

---

- [ ] **137. Replace “Nowadays” with “Currently”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains.mdx?plain=1

Replace the colloquial “Nowadays” with “Currently” for neutral tone.

---

- [ ] **138. Clarify BaseChain usage vs MasterChain costs**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains.mdx?plain=1

Replace the vague “because it's cheap” with “BaseChain is used for everyday transactions; MasterChain coordinates the network and has higher gas costs.”

---

- [ ] **139. Standardize ‘ShardBlock’ terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains.mdx?plain=1

Standardize the term by either defining “ShardBlock” and using it consistently (singular/plural) or replacing with “ShardChain blocks” throughout.

---

- [ ] **140. Lowercase ‘blockchain’ after TON**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains.mdx?plain=1

Lowercase “blockchain” in mid‑sentence references like “TON blockchain” for capitalization consistency.

---

- [ ] **141. Normalize bullet capitalization and punctuation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains.mdx?plain=1

Start bullet items with uppercase and end with periods for consistency, e.g., “The contract receives a message.” and “It handles the event …”.

---

- [ ] **142. Fix grammar in “ShardChains group”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains.mdx?plain=1

Replace “the rules of the ShardChains group” with “the rules of a group of ShardChains” or “the rules for its ShardChains” to fix grammar.

---

- [ ] **143. Avoid contractions for formal tone**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains.mdx?plain=1

Avoid contractions (e.g., replace “let’s” with “let us” and “it’s” with “it is”) for formal tone.

---

- [ ] **144. Soften WorkChain approval claim; remove unsupported 2/3 vote**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains.mdx?plain=1

Remove the unsupported claim “approved by a 2/3 vote from the validators” and instead state that WorkChain creation “requires governance approval” (link to governance docs if available), omitting specific thresholds/fees unless documented.

---

- [ ] **145. Scope message delivery guarantee to internal messages**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains.mdx?plain=1

Limit the delivery guarantee to internal messages by stating “All internal messages are delivered; external messages receive the same guarantee once accepted into an incoming queue.”

---

- [ ] **146. Mark EVM WorkChain example as hypothetical**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains.mdx?plain=1

Mark the EVM WorkChain example as hypothetical by prepending “Hypothetical example:” and noting that no official process is defined in these docs.

---

- [ ] **147. Correct tuple to “(shard prefix, account_id)”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains.mdx?plain=1

Change the tuple wording from “(shard prefix, address)” to “(shard prefix, account_id)” to avoid ambiguity.

---

- [ ] **148. Resolve WorkChain count inconsistency across docs**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains.mdx?plain=1

Resolve the inconsistency about current WorkChains by aligning this page with the canonical definition across the docs (decide whether MasterChain counts as a WorkChain and update accordingly).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.