### PR TITLE
Split: update docs/v3/concepts/dive-into-ton/ton-blockchain/sharding.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/concepts/dive-into-ton/ton-blockchain/sharding.mdx
+++ b/docs/v3/concepts/dive-into-ton/ton-blockchain/sharding.mdx
@@ -2,7 +2,7 @@ import Feedback from '@site/src/components/Feedback';
 
 # Sharding in TON
 
-Sharding in TON refers to dividing the blockchain into smaller, manageable pieces, or shards, for scalability. An independent set of validators operates and maintains a shard as a smaller piece of the blockchain.
+Sharding in TON refers to dividing the blockchain into smaller, manageable pieces, or shards, for scalability. Each shard is operated and maintained by an independent set of validators.
 
 Validators in separate shards can handle transactions in parallel, ensuring high throughput even as the network grows. This approach unlocks the execution of a massive number of transactions.
 
@@ -10,21 +10,21 @@ In TON, sharding is highly dynamic. Unlike other blockchains with a fixed number
 Shards split as the transaction load increases, and as the load decreases, they merge.
 This flexibility ensures the system can adapt to varying workloads while maintaining efficiency.
 
-![](/img/docs/blockchain-fundamentals/scheme.png)
+![Schematic of TON multichain: Masterchain, Workchains, ShardChains](/img/docs/blockchain-fundamentals/scheme.png)
 
-The **MasterChain** is crucial in maintaining the network configuration and the final state of all **WorkChains** and **ShardChains**.
-While the MasterChain is responsible for overall coordination, WorkChains operate under their specific rules, each of which can be split further into SharChains.
-Only one WorkChain - the **BaseChain**, currently operates on TON.
+The **Masterchain** is crucial in maintaining the network configuration and the final state of all **Workchains** and **ShardChains**.
+While the Masterchain is responsible for overall coordination, Workchains operate under their own specific rules, each of which can be split further into ShardChains.
+Currently, two Workchains are active: Masterchain and BaseChain.
 
-At the heart of TON's efficiency is the [Infinity sharding paradigm](/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm/), which treats each account as part of its own AccountChain.
+At the heart of TON's efficiency is the [Infinity Sharding Paradigm](/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm/), which treats each account as its own AccountChain.
 These AccountChains are then aggregated into ShardChain blocks, facilitating efficient transaction processing.
 
-In addition to dynamically creating shards, TON uses **split merge** functionality, which allows the network to efficiently respond to changing transaction loads. This system enhances scalability and interaction within the blockchain network, exemplifying TON's approach to resolving typical blockchain challenges with a focus on efficiency and global consistency.
+In addition to dynamically creating shards, TON uses **split-merge** functionality, which allows the network to efficiently respond to changing transaction loads. This system enhances scalability and interaction within the blockchain network, exemplifying TON's approach to resolving typical blockchain challenges with a focus on efficiency and global consistency.
 
 ## See also
 
 - [Blockchain of blockchains](/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains/)
-- [Shards dive in](/v3/documentation/smart-contracts/shards/shards-intro/)
-- [Infinity sharding paradigm](/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm/)
+- [Shards](/v3/documentation/smart-contracts/shards/shards-intro/)
+- [Infinity Sharding Paradigm](/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm/)
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-concepts-dive-into-ton-ton-blockchain-sharding.mdx` into `main`.

Changed file(s):
- M: `docs/v3/concepts/dive-into-ton/ton-blockchain/sharding.mdx`

Related issues (from issues.normalized.md):
- [ ] **174. Clarify validator responsibility per shard**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/sharding.mdx?plain=1#L5

Rephrase to "Each shard is operated and maintained by an independent set of validators." for clarity and subject agreement.

---

- [ ] **175. Add descriptive alt text to sharding diagram**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/sharding.mdx?plain=1#L13

Replace empty alt with a descriptive one, e.g., change ![](/img/docs/blockchain-fundamentals/scheme.png) to ![Schematic of TON multichain: MasterChain, WorkChains, ShardChains](/img/docs/blockchain-fundamentals/scheme.png).

---

- [ ] **176. Fix ShardChains typo and possessive phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/sharding.mdx?plain=1#L16

Replace “SharChains” with “ShardChains” and change “their specific rules” to “their own specific rules.”

---

- [ ] **177. Correct active WorkChains sentence and punctuation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/sharding.mdx?plain=1#L17

Update to: “Currently, two WorkChains are active: MasterChain and BaseChain.”

---

- [ ] **178. Capitalize ISP link and fix AccountChain phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/sharding.mdx?plain=1#L19

Capitalize the link text to “Infinity Sharding Paradigm” and change “as part of its own AccountChain” to “as its own AccountChain.”

---

- [ ] **179. Hyphenate split-merge consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/sharding.mdx?plain=1#L22

Change “split merge” to “split-merge.”

---

- [ ] **180. Standardize Masterchain/Workchains casing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/sharding.mdx?plain=1

Align with the Glossary by updating “MasterChain” to “Masterchain” and “WorkChains” to “Workchains” throughout the page.

---

- [ ] **181. Align “Shards” link text with target title**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/sharding.mdx?plain=1

Change the link text “Shards dive in” to “Shards” to match the target page’s title.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.