### PR TITLE
Split: update docs/v3/concepts/dive-into-ton/ton-blockchain/smart-contract-addresses.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/concepts/dive-into-ton/ton-blockchain/smart-contract-addresses.mdx
+++ b/docs/v3/concepts/dive-into-ton/ton-blockchain/smart-contract-addresses.mdx
@@ -8,10 +8,10 @@ This document provides a high-level overview of account addresses on TON Blockch
 
 A TON address is a composite identifier consisting of two main components:
 
-- **Workchain ID**: a signed 32-bit integer that identifies a specific Workchain.<br/>
-The Masterchain uses `-1`, and the Basechain uses `0`.
-- **Account ID**: a 256-bit unique identifier for a contract within its Workchain. <br/>
-It is derived from a hash of the contract's initial code and state.
+- **WorkChain ID**: a signed 32-bit integer that identifies a specific WorkChain.<br/>
+The MasterChain uses `-1`, and the BaseChain uses `0`.
+- **Account ID**: a 256-bit unique identifier for a contract within its WorkChain. <br/>
+It is derived from the hash of the contract’s initial state (`state_init`), which includes the code and data.
 
 For detailed technical specifications, see the [Addresses documentation](/v3/documentation/smart-contracts/addresses/address).
 
@@ -22,7 +22,7 @@ TON addresses are represented in two standard formats:
 -   **Raw format**: a direct representation of the `workchain_id` and `account_id` (e.g., `-1:fcb...260`). Intended for system-level use, it does not include user-facing safety features.
 -   **User-friendly format**: a base64-encoded version of the raw address that includes flags and a checksum. Designed for user interfaces, this format enhances security and prevents errors.
 
-These formats are not interchangeable. The user-friendly format includes critical metadata, such as _bounceable flags_ that determine message-handling behavior for uninitialized accounts. A *bounceable* message sent to an inactive address is returned to the sender. In contrast, a *non-bounceable* message will be credited to the account.
+These formats are not interchangeable. The user-friendly format includes critical metadata, such as the _bounceable flag_, which determines message-handling behavior for uninitialized accounts. A bounceable message sent to an address in `nonexist` or `uninit` state is returned to the sender. In contrast, a non-bounceable message will be credited to the account.
 
 For a detailed breakdown of address structures, encoding, and flags, refer to the [address formats documentation](/v3/documentation/smart-contracts/addresses/address-formats).
 
@@ -34,7 +34,7 @@ Every address on TON Blockchain exists in one of four states, reflecting its lif
 - `nonexist`: the initial state for all potential addresses. The address has no associated code, data, or balance.
 - `uninit`: the address has received funds and has a balance but contains no smart contract code or data. It cannot execute logic.
 - `active`: the address holds a balance, smart contract code, and data. It is fully operational and can process messages.
-- `frozen`: the contract's storage fees have exceeded its balance, freezing its state. The address cannot execute transactions until it is unfrozen by replenishing its balance and providing its state.
+- `frozen`: the contract's storage fees have exceeded its balance, freezing its state. The address cannot execute transactions until it is unfrozen by replenishing its balance and providing its exact `state_init` (with sufficient funds for storage fees).
 
 The address state dictates its capabilities and is fundamental to transaction processing. Further details are available in the [address states documentation](/v3/documentation/smart-contracts/addresses/address-states).
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-concepts-dive-into-ton-ton-blockchain-smart-contract-addresses.mdx` into `main`.

Changed file(s):
- M: `docs/v3/concepts/dive-into-ton/ton-blockchain/smart-contract-addresses.mdx`

Related issues (from issues.normalized.md):
- [ ] **182. Remove unnecessary comma in opening sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/smart-contract-addresses.mdx?plain=1

Change “Every actor … is represented by an address, used for all on-chain interactions.” to “Every actor … is represented by an address used for all on-chain interactions.”

---

- [ ] **183. Standardize capitalization of WorkChain/MasterChain/BaseChain**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/smart-contract-addresses.mdx?plain=1

Use “WorkChain”, “MasterChain”, and “BaseChain” consistently across the page. Examples: “Workchain ID” → “WorkChain ID”; “The Masterchain uses `-1`, and the Basechain uses `0`.” → “The MasterChain uses `-1`, and the BaseChain uses `0`.”; “…within its Workchain.” → “…within its WorkChain.”

---

- [ ] **184. Replace “inactive address” with precise TON states**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/smart-contract-addresses.mdx?plain=1

Use standard states (`nonexist`, `uninit`, `active`, `frozen`). Correct to: “A bounceable message sent to an address in `nonexist` or `uninit` state is returned to the sender. In contrast, a non-bounceable message will be credited to the account.”

---

- [ ] **185. Use singular “bounceable flag”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/smart-contract-addresses.mdx?plain=1

Change “such as bounceable flags” to “such as the bounceable flag,” optionally clarifying it determines message-handling behavior for uninitialized accounts.

---

- [ ] **186. Clarify Account ID derivation from state_init**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/smart-contract-addresses.mdx?plain=1

Replace “It is derived from a hash of the contract's initial code and state.” with “It is derived from the hash of the contract’s initial state (`state_init`), which includes the code and data.”

---

- [ ] **187. Specify unfreeze requirements for frozen state**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/smart-contract-addresses.mdx?plain=1

Replace “until it is unfrozen by replenishing its balance and providing its state.” with “until it is unfrozen by replenishing its balance and providing its exact `state_init` (with sufficient funds for storage fees).”

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.