### PR TITLE
Split: update docs/v3/concepts/dive-into-ton/ton-blockchain/ton-networking.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/concepts/dive-into-ton/ton-blockchain/ton-networking.mdx
+++ b/docs/v3/concepts/dive-into-ton/ton-blockchain/ton-networking.mdx
@@ -2,22 +2,18 @@ import Feedback from '@site/src/components/Feedback';
 
 # TON networking
 
-TON Ecosystem uses its peer-to-peer network protocols.
+The TON Ecosystem uses peer-to-peer network protocols.
 
-- **TON Blockchain** uses these protocols to propagate new blocks, send and collect transaction candidates, etc.
+- **TON Blockchain** uses these protocols to propagate new blocks, send and collect transactions.
 
-  While the networking demands of single-blockchain projects, such as Bitcoin or Ethereum, can be met quite easily: one essentially needs to construct a peer-to-peer overlay network and then propagate all new blocks and transaction candidates via a [gossip](https://en.wikipedia.org/wiki/Gossip_protocol) protocol.
+  While the networking demands of single-blockchain projects, such as Bitcoin or Ethereum, can be met quite easily, one essentially needs to construct a peer-to-peer overlay network and then propagate all new blocks and transactions via a [gossip](https://en.wikipedia.org/wiki/Gossip_protocol) protocol. Multi-blockchain projects, such as TON, are much more demanding. For example, one must be able to subscribe to updates for only some shardchains, not necessarily all of them.
 
-Multi-blockchain projects, such as TON, are much more demanding. For example, one must be able to subscribe to updates for only some shardchains, not necessarily all of them.
+- **TON Ecosystem services** such as TON Proxy, TON Sites, TON Storage, and DApps run on these protocols.
 
-- **TON Ecosystem services** like TON Proxy, TON Sites, TON Storage, and dApps run on these protocols.
-
-  Once the more sophisticated network protocols are in place to support the TON blockchain.
-  They can easily be used for purposes not necessarily related to the immediate demands of the blockchain itself, thus providing more possibilities and flexibility for creating new services in TON Ecosystem.
+  Once the more sophisticated network protocols are in place to support the TON Blockchain, they can be used for purposes not necessarily related to the immediate demands of the blockchain itself, thus providing more possibilities and flexibility for creating new services in the TON Ecosystem.
 
 ## TON network protocols
 
-- [TON Connect](/v3/guidelines/ton-connect/overview/)
 - [ADNL protocol](/v3/documentation/network/protocols/adnl/overview/)
 - [Overlay subnetworks](/v3/documentation/network/protocols/overlay/)
 - [RLDP protocol](/v3/documentation/network/protocols/rldp/)
@@ -25,6 +21,7 @@ Multi-blockchain projects, such as TON, are much more demanding. For example, on
 
 ## See also
 
+- [TON Connect](/v3/guidelines/ton-connect/overview/)
 - [TON security audits](/v3/concepts/dive-into-ton/ton-blockchain/security-measures/)
 
 <Feedback />

--- a/docs/v3/concepts/dive-into-ton/ton-blockchain/ton-networking.mdx
+++ b/docs/v3/concepts/dive-into-ton/ton-blockchain/ton-networking.mdx
@@ -6,7 +6,7 @@ The TON Ecosystem uses peer-to-peer network protocols.
 
 - **TON Blockchain** uses these protocols to propagate new blocks, send and collect transactions.
 
-  While the networking demands of single-blockchain projects, such as Bitcoin or Ethereum, can be met quite easily, one essentially needs to construct a peer-to-peer overlay network and then propagate all new blocks and transactions via a [gossip](https://en.wikipedia.org/wiki/Gossip_protocol) protocol. Multi-blockchain projects, such as TON, are much more demanding. For example, one must be able to subscribe to updates for only some shardchains, not necessarily all of them.
+  While the networking demands of single-blockchain projects, such as Bitcoin or Ethereum, can be met quite easily, one essentially needs to construct a peer-to-peer overlay network and then propagate all new blocks and transactions via a [gossip](https://en.wikipedia.org/wiki/Gossip_protocol) protocol. Multi-blockchain projects, such as TON, are much more demanding. For example, one must be able to subscribe to updates for only some ShardChains, not necessarily all of them.
 
 - **TON Ecosystem services** such as TON Proxy, TON Sites, TON Storage, and DApps run on these protocols.
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-concepts-dive-into-ton-ton-blockchain-ton-networking.mdx` into `main`.

Changed file(s):
- M: `docs/v3/concepts/dive-into-ton/ton-blockchain/ton-networking.mdx`

Related issues (from issues.normalized.md):
- [x] **188. Clarify opening sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/ton-networking.mdx?plain=1#L5

Change "TON Ecosystem uses its peer-to-peer network protocols." to "The TON Ecosystem uses peer-to-peer network protocols." for clarity.

---

- [x] **189. Fix colon, remove "etc.", and use "transactions"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/ton-networking.mdx?plain=1#L7-L11

Replace the colon after the "While" clause with a comma and combine the contrast into one sentence, remove "etc.", and change "transaction candidates" to "transactions".

---

- [x] **190. Use "such as" instead of "like"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/ton-networking.mdx?plain=1#L13

Replace "like TON Proxy, TON Sites, TON Storage, and dApps" with "such as TON Proxy, TON Sites, TON Storage, and dApps" for formal tone.

---

- [x] **191. Capitalize "DApps"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/ton-networking.mdx?plain=1#L13

Change "dApps" to "DApps" to match glossary capitalization.

---

- [x] **192. Merge fragment and capitalize "TON Blockchain"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/ton-networking.mdx?plain=1#L15-L16

Merge "Once the more sophisticated network protocols are in place to support the TON blockchain." with the following sentence, remove "easily", and capitalize "TON Blockchain".

---

- [x] **193. Capitalize "ShardChains"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/ton-networking.mdx?plain=1

Change "shardchains" to "ShardChains" for consistent capitalization.

---

- [x] **194. Reclassify TON Connect in protocol list**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-blockchain/ton-networking.mdx?plain=1

Move "TON Connect" out of the "TON network protocols" list into a "See also" section to avoid mixing application-level items with low-level network protocols.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.