### PR TITLE
Split: update docs/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton.mdx
+++ b/docs/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton.mdx
@@ -3,11 +3,11 @@ import Player from "@site/src/components/player";
 
 # Explorers in TON
 
-This article will consider TON explorers and their capabilities and features from the user's perspective.
+This article covers TON explorers—their capabilities and features—from a user’s perspective.
 
 ## What is an explorer?
 
-An explorer is a website that allows you to view information in a blockchain, such as the account balance, transaction history, and blocks.
+An explorer is a website that allows you to view information on a blockchain, such as account balances, transaction history, and blocks.
 
 <Player url="https://www.youtube.com/watch?v=i5en19kzX6M" />
 
@@ -19,7 +19,7 @@ Among TON explorers, you can distinguish several categories:
 - With extended information for developers
 - Specialized
 
-This division into categories is mainly conditional, and one explorer can belong to several categories simultaneously. So let's not pay too much attention to this.
+This categorization is approximate; many explorers fit multiple categories. Treat it as guidance rather than a strict classification.
 
 ## General functionality
 
@@ -27,11 +27,11 @@ Blockchain explorers allow you to view and search the blockchain, similarly to h
 
 Just as you use a banking app to track where your money goes, who sends you payments, and when transactions occur, blockchain explorers let you see this information for digital assets on the blockchain. They are essential for transparency, allowing anyone to verify transactions independently, see the flow of cryptocurrency, and analyze the activity on the blockchain.
 
-Typically, an explorer allows you to find a transaction or an account by its identifier. Some explorers also support DNS extensions or their own [address book](/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton#address-alias-in-explorers), which adds a human-readable label to a specific account. Example: [TON Foundation](https://tonviewer.com/UQAFmjUoZUqKFEBGYFEMbv-m61sFStgAfUR8J6hJDwUU04VW).
+Typically, an explorer allows you to find a transaction or an account by its identifier. Some explorers also support TON DNS extensions or their own [address book](/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton#address-alias-in-explorers), which adds a human-readable label to a specific account. Example: [TON Foundation](https://tonviewer.com/UQAFmjUoZUqKFEBGYFEMbv-m61sFStgAfUR8J6hJDwUU04VW).
 
 ## Native explorers
 
-### Tonscan
+### Tonscan (tonscan.org)
 
 It is a good explorer for everyday use. It provides a comprehensive view of the TON Blockchain, allowing users to search for transactions, addresses, blocks, and more.
 
@@ -41,9 +41,9 @@ It is a good explorer for everyday use. It provides a comprehensive view of the 
 #### Features
 
 - Convenient for everyday use and developers
-- Advanced jetton and nominator pools pages for users
+- Advanced Jetton and nominator pool pages for users
 - Contract types and disassembler
-- User-friendly search uses DNS and [address book](https://github.com/catchain/address-book) labels.
+- User-friendly search uses TON DNS and [address book](https://github.com/catchain/address-book) labels
 
 ### Tonviewer
 
@@ -57,9 +57,9 @@ It is a good explorer for everyday use with a balanced UI for users and develope
 - Convenient for everyday use and developers
 - Advanced information for developers with traces
 - Contract types and disassembler
-- User-friendly search uses DNS and [tonkeeper/ton-assets](https://github.com/tonkeeper/ton-assets) labels.
+- User-friendly search uses TON DNS and [tonkeeper/ton-assets](https://github.com/tonkeeper/ton-assets) labels
 
-### Tonscan by Bastion
+### Tonscan by Bastion (tonscan.com)
 
 - Mainnet: [tonscan.com](https://tonscan.com/)
 
@@ -82,9 +82,9 @@ It also has a feature that allows you to see the computation phase of the transa
 - Extended information about the computation phase
 - Contract types and disassembler
 
-### Ton Whales explorer
+### TON Whales
 
-Explorer for developers.
+An explorer geared toward developers.
 
 - Mainnet: [tonwhales.com/explorer](https://tonwhales.com/explorer)
 
@@ -94,26 +94,26 @@ Explorer for developers.
 - Contract types and disassembler
 - Simple and convenient validator details
 
-### TON NFT EXPLORER
+### TON NFT Explorer
 
 This explorer specializes in NFTs but is also suitable as a regular explorer.
 
 - Mainnet: [explorer.tonnft.tools](https://explorer.tonnft.tools/)
 - Testnet: [testnet.explorer.tonnft.tools](https://testnet.explorer.tonnft.tools/)
 
-When viewing the wallet address, you can find out which NFT it stores, and when viewing the NFT, you can find the metadata, collection address, owner, and transaction history.
+When viewing the account address, you can find out which NFT it stores, and when viewing the NFT, you can find the metadata, collection address, owner, and transaction history.
 
 #### Features
 
 - Convenient for developers
-- Specialized in NFT
+- Specialized in NFTs
 - Contract types
 
-## Crosschain explorers
+## Cross-chain explorers
 
-### OKX TON explorer
+### OKX TON
 
-This explorer is designed to provide comprehensive and detailed data insights into TON. Whether you're tracking wallet addresses, exploring Jetton tokens, or delving into NFT collections, it offers a user-friendly experience tailored for both beginners and developers.
+This explorer is designed to provide comprehensive and detailed data insights into TON. Whether you're tracking account addresses, exploring Jettons, or delving into NFT collections, it offers a user-friendly experience tailored for both beginners and developers.
 
 - Mainnet: [web3.okx.com/explorer/ton](https://web3.okx.com/explorer/ton)
 
@@ -155,6 +155,8 @@ It displays various statistics, such as the number of registered network address
 
 Arkham is a crypto analytics platform that identifies individuals and organizations behind blockchain activity, providing users with detailed data and behavioral insights on on-chain transactions.
 
+#### Features
+
 - Integrated exchange with analytics tools
 - AI-based address matching
 - Behavioral analytics on wallets and organizations
@@ -165,7 +167,7 @@ Arkham is a crypto analytics platform that identifies individuals and organizati
 Make your service address more user-friendly by using an address alias. Create Pull Requests (PRs) according to the provided guidelines:
 
 - [tonkeeper/ton-assets](https://github.com/tonkeeper/ton-assets) - Tonviewer.com alias
-- [catchain/address-book](https://github.com/catchain/address-book)- Tonscan.org alias
+- [catchain/address-book](https://github.com/catchain/address-book) - Tonscan.org alias
 - [ton-labels](https://github.com/ton-studio/ton-labels) - Public dataset of labeled TON blockchain addresses
 
 ## Want to be on this list?


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-concepts-dive-into-ton-ton-ecosystem-explorers-in-ton.mdx` into `main`.

Changed file(s):
- M: `docs/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton.mdx`

Related issues (from issues.normalized.md):
- [ ] **195. Rewrite intro sentence for clarity**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton.mdx?plain=1#L6

Replace the awkward future-tense sentence with: "This article covers TON explorers—their capabilities and features—from a user’s perspective."

---

- [ ] **196. Use "on a blockchain" and pluralize balances**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton.mdx?plain=1#L10

Change "view information in a blockchain, such as the account balance" to "view information on a blockchain, such as account balances, transaction history, and blocks."

---

- [ ] **197. Refine categorization wording and tone**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton.mdx?plain=1#L22

Replace the colloquial phrasing with: "This categorization is approximate; many explorers fit multiple categories. Treat it as guidance rather than a strict classification."

---

- [ ] **198. Use "TON DNS" terminology consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton.mdx?plain=1#L30

Use "TON DNS" instead of generic "DNS" terms throughout (e.g., replace "DNS extensions" at L30 and "DNS" in features at L46, L60, and L123 with "TON DNS").

---

- [ ] **199. Capitalize Jetton and remove "Jetton tokens" redundancy**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton.mdx?plain=1#L44

Capitalize the term Jetton and avoid redundant "Jetton tokens" (e.g., change "Advanced jetton and nominator pools pages for users" to "Advanced Jetton and nominator pool pages for users").

---

- [ ] **200. Fix heading casing: TON Whales**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton.mdx?plain=1#L85

Change the heading to "### TON Whales" for brand capitalization and consistency with other product headings.

---

- [ ] **201. Fix heading casing: TON NFT Explorer**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton.mdx?plain=1#L97

Change "### TON NFT EXPLORER" to "### TON NFT Explorer" to avoid ALL CAPS.

---

- [ ] **202. Use "account address" consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton.mdx?plain=1#L104

Replace "wallet address" with "account address" for consistency with the rest of the page.

---

- [ ] **203. Pluralize NFTs in feature bullet**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton.mdx?plain=1#L109

Change "Specialized in NFT" to "Specialized in NFTs."

---

- [ ] **204. Hyphenate "Cross-chain" in heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton.mdx?plain=1#L112

Change "## Crosschain explorers" to "## Cross-chain explorers."

---

- [ ] **205. Fix heading style: OKX TON**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton.mdx?plain=1#L114

Change "### OKX TON explorer" to "### OKX TON" for consistency with other product headings.

---

- [ ] **206. Add "Features" subheading for Arkham**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton.mdx?plain=1#L156-L160

Insert a "#### Features" subheading above the Arkham feature bullet list to match other sections.

---

- [ ] **207. Add space before dash in link bullet**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton.mdx?plain=1#L168

Add a space before the dash so it reads "...address-book) - Tonscan.org alias".

---

- [ ] **208. Disambiguate Tonscan names with domains**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton.mdx?plain=1

Include the domain in each heading to avoid confusion, e.g., "Tonscan (tonscan.org)" and "Tonscan by Bastion (tonscan.com)".

---

- [ ] **209. Make feature list punctuation consistent**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton.mdx?plain=1

Standardize feature bullets to a single style (e.g., remove trailing periods from short phrase bullets) for consistency across sections.

---

- [ ] **210. Fix fragment: "Explorer for developers."**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton.mdx?plain=1

Rewrite the fragment as a complete phrase, e.g., "An explorer geared toward developers."

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.