### PR TITLE
Split: update docs/v3/concepts/dive-into-ton/ton-ecosystem/wallet-apps.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/concepts/dive-into-ton/ton-ecosystem/wallet-apps.mdx
+++ b/docs/v3/concepts/dive-into-ton/ton-ecosystem/wallet-apps.mdx
@@ -18,7 +18,7 @@ Explore the full [ton.org/wallets](https://ton.org/wallets) catalog for more wal
 
 ## Non-custodial wallets
 
-**Non-custodial wallets** empower users with full ownership and control over their private keys and funds. Unlike custodial wallets, which a third party manages, non-custodial wallets store private keys exclusively with the user, secured using a seed phrase (also called recovery phrase)—a unique sequence of 12 or 24 words.
+**Non-custodial wallets** empower users with full ownership and control over their private keys and funds. Unlike custodial wallets, which a third party manages, non-custodial wallets store private keys exclusively with the user, secured using a seed phrase (also called recovery phrase) — a unique sequence of 24 words.
 
 ### Software (hot) wallets
 
@@ -28,17 +28,14 @@ Below is a selection of prominent non-custodial software wallets.
 
 #### Wallets for everyday users
 
-<a id="tonkeeper-test-environment" />
-### Tonkeeper test environment
-
 <table style={{ width: '100%', tableLayout: 'fixed' }}>
   <thead>
   <tr>
     <th style={{ width: '5%' }}>Wallet</th>
-    <th style={{ width: '25%' }}>Description</th>
-    <th style={{ width: '10%' }}>Platforms</th>
+    <th style={{ width: '40%' }}>Description</th>
+    <th style={{ width: '1%' }}>Platforms</th>
     <th style={{ width: '50%' }}>Testnet Access</th>
-    <th style={{ width: '10%' }}>Links</th>
+    <th style={{ width: '4%' }}>Links</th>
   </tr>
   </thead>
   <tbody>
@@ -47,23 +44,21 @@ Below is a selection of prominent non-custodial software wallets.
     <td>Open-source wallet commonly used in the TON ecosystem. Supports tokens and NFTs.</td>
     <td>iOS, Android</td>
     <td>
-      1. Create wallet and save seed phrase.<br />
+      1. Create wallet and save recovery phrase.<br />
       2. From main screen, tap wallet name → **Add Wallet** → **Testnet Account**.<br />
-      3. Enter saved seed phrase.
+      3. Enter saved recovery phrase.
     </td>
-
     <td>
-      <a href="https://github.com/tonkeeper/wallet">GitHub</a><br />
+      <a href="https://github.com/tonkeeper/">GitHub</a><br />
       <a href="https://github.com/tonkeeper/wallet-api">Wallet API</a>
     </td>
   </tr>
 
   <tr>
     <td><a href="https://mytonwallet.io"><strong>MyTonWallet</strong></a></td>
-    <td>Open-source browser wallet supporting tokens, NFTs, TON DNS, TON Sites, and TON Proxy.</td>
-    <td>Chrome, Firefox</td>
+    <td>Open-source web wallet supporting tokens, NFTs, TON DNS, TON Sites and TON Proxy — also compatible with TRON.</td>
+    <td>iOS, Android, Chrome, Firefox</td>
     <td>
-    <br />
       1. Open **Settings**.
       2. Scroll down and tap **MyTonWallet app version**.
       3. Select the environment in the popup.
@@ -79,9 +74,11 @@ Below is a selection of prominent non-custodial software wallets.
     <td>Open-source, mobile-first wallet with <a href="https://github.com/tonwhales/ton-nominators">Ton Nominator</a> integration.</td>
     <td>iOS, Android</td>
     <td>
-      Requires <strong>Sandbox app</strong>:<br />
-      <a href="https://apps.apple.com/app/ton-development-wallet/id1607857373">iOS</a> /
+      - Requires different app for 
+      <a href="https://apps.apple.com/app/ton-development-wallet/id1607857373">iOS</a>
+      - Same app for 
       <a href="https://play.google.com/store/apps/details?id=com.tonhub.wallet">Android</a>
+      - Tap 6+ times on the app version to change the environment
     </td>
     <td>
       <a href="https://github.com/tonwhales/wallet">GitHub</a><br />
@@ -113,7 +110,7 @@ Below is a selection of prominent non-custodial software wallets.
     <td>
       <ul style={{ paddingLeft: '16px', margin: 0 }}>
         <li>Seamless integration with TON Connect</li>
-        <li>Local transaction emulation before submitting on-chain</li>
+        <li>Local transaction emulation before on-chain submission.</li>
         <li>Manage multiple keys and wallets</li>
       </ul>
     </td>
@@ -129,14 +126,15 @@ Below is a selection of prominent non-custodial software wallets.
     <td>
       <ul style={{ paddingLeft: '16px', margin: 0 }}>
         <li>ADNL connection support</li>
-      <li>Cross-platform architecture</li>
-      <li><a href="https://github.com/ton-blockchain/bug-bounty">Bug bounty program</a></li>
-    </ul>
+        <li>Cross-platform architecture</li>
+        <li><a href="https://github.com/ton-blockchain/bug-bounty">Bug bounty program</a></li>
+        <li>Supports the `testnet` parameter in the browser</li>
+      </ul>
     </td>
   </tr>
   <tr>
     <td><a href="https://www.openmask.app/"><strong>OpenMask</strong></a></td>
-    <td>Open-source Chrome extension wallet focused on Web3 and dApp development.</td>
+    <td>Open-source Chrome extension wallet focused on Web3 and DApp development.</td>
     <td>Chrome</td>
     <td>
       <a href="https://github.com/OpenProduct/openmask-extension">GitHub</a><br />
@@ -144,7 +142,7 @@ Below is a selection of prominent non-custodial software wallets.
     </td>
     <td>
       <ul style={{ paddingLeft: '16px', margin: 0 }}>
-        <li>Desktop wallet optimized for dApp development</li>
+        <li>Chrome extension optimized for DApp development</li>
         <li>Multiple wallet support</li>
       </ul>
     </td>


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-concepts-dive-into-ton-ton-ecosystem-wallet-apps.mdx` into `main`.

Changed file(s):
- M: `docs/v3/concepts/dive-into-ton/ton-ecosystem/wallet-apps.mdx`

Related issues (from issues.normalized.md):
- [x] **225. Update Tonkeeper GitHub link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/wallet-apps.mdx?plain=1

The Tonkeeper "GitHub" link points to a 404 (https://github.com/tonkeeper/wallet); update it to https://github.com/tonkeeper.

---

- [x] **226. Normalize em dash spacing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/wallet-apps.mdx?plain=1

The article mixes spaced and unspaced em dashes; use spaced em dashes consistently (e.g., "seed phrase — a unique sequence...", "A software wallet — commonly referred...").

---

- [x] **227. Clarify Tonhub testnet instructions and links by platform**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/wallet-apps.mdx?plain=1

The Tonhub Testnet Access row implies a "Sandbox app" is required on both iOS and Android but links iOS to TON Development Wallet and Android to the regular app; change the label to "Requires TON Development Wallet (iOS)" and remove the Android "Sandbox" wording while clarifying testnet is available in the standard Android app.

---

- [x] **228. Correct OpenMask highlight to match Chrome extension**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/wallet-apps.mdx?plain=1

The highlight says "Desktop wallet optimized for dApp development" while Platforms lists Chrome; change the highlight to "Chrome extension optimized for dApp development."

---

- [x] **229. Improve TONDevWallet highlight phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/wallet-apps.mdx?plain=1

Revise "Local transaction emulation before submitting on-chain" to "Local transaction emulation before on-chain submission."

---

- [x] **230. Remove extraneous line break in MyTonWallet steps**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/wallet-apps.mdx?plain=1

Delete the standalone <br /> before step 1 in the MyTonWallet "Testnet Access" cell to remove unnecessary spacing.

---

- [ ] **231. Standardize table format across sections**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/wallet-apps.mdx?plain=1

Convert the HTML tables to Markdown tables across the page for consistency and easier maintenance.

---

- [x] **232. Standardize Telegram handle capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/wallet-apps.mdx?plain=1

Render all Telegram handles in lowercase for consistency (e.g., @wallet, @cryptobot, @tonrocketbot).

---

- [ ] **233. Add missing tonkeeper-test-environment anchor**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/wallet-apps.mdx?plain=1

Other docs link to #tonkeeper-test-environment which is missing here; add a subsection header "### Tonkeeper test environment {#tonkeeper-test-environment}" above the Tonkeeper Testnet Access instructions.

---

- [x] **234. Align mnemonic length to 24 words**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/wallet-apps.mdx?plain=1

Change the Overview wording from "12 or 24 words" to "a unique sequence of 24 words" to match corpus conventions.

---

- [x] **235. Restrict Tonkeeper platforms to mobile**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/wallet-apps.mdx?plain=1

Change the Tonkeeper platforms list to "iOS, Android" by removing "Chrome, Firefox."

---

- [ ] **236. Fix MyTonWallet description and remove unsupported claims**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/wallet-apps.mdx?plain=1

Replace the description with "Open-source browser wallet supporting tokens, NFTs, TON DNS, TON Sites, and TON Proxy," removing "Magic" and the unsupported TRON compatibility claim.

---

- [ ] **237. Restrict MyTonWallet platforms to browser extensions**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/wallet-apps.mdx?plain=1

Change MyTonWallet platforms to "Chrome, Firefox" by removing "iOS, Android."

---

- [ ] **238. Remove unsupported TON Wallet "testnet parameter" claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/wallet-apps.mdx?plain=1

Delete the highlight bullet "Supports the testnet parameter in the browser" since no canonical reference exists.

---

- [x] **239. Pluralize "Multi-signature wallet" heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/wallet-apps.mdx?plain=1

Rename the heading to "Multi-signature wallets" for consistency with other pluralized categories.

---

- [ ] **240. Use a single term for seed/recovery phrase**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/wallet-apps.mdx?plain=1

Define once as "seed phrase (also called recovery phrase)" and then use "seed phrase" consistently throughout the page.

---

- [ ] **241. Adjust everyday-wallets table column widths**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/concepts/dive-into-ton/ton-ecosystem/wallet-apps.mdx?plain=1

Increase the "Platforms" column to ~10% and "Links" to ~10% and reduce "Description" proportionally to improve readability.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.