### PR TITLE
Split: update docs/v3/contribute/README.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/contribute/README.mdx
+++ b/docs/v3/contribute/README.mdx
@@ -6,9 +6,9 @@ Learn how to submit content to TON Documentation here.
 
 ## Contribution guidelines
 
-### Documentation maintain community
+### Documentation maintainer community
 
-TON Documentation is entirely open source. Community enthusiasts and early TON contributors have played a key role in creating this open-source TON documentation by turning their notes into detailed pages.
+TON Documentation is entirely open source. Community enthusiasts and early TON contributors have played a key role in creating this open source TON documentation by turning their notes into detailed pages.
 
 It was initially written by TON [contributors](/v3/contribute/maintainers/) and supported by [TON Studio](https://tonstudio.io/).
 We aim to educate users about TON through explicit, easily searchable content that appeals to technical experts and casual readers.
@@ -17,17 +17,18 @@ We aim to educate users about TON through explicit, easily searchable content th
 ### How to contribute
 
 :::info
-This documentation is written in English. Please refer to [localization program](/v3/contribute/localization-program/how-to-contribute/) for other languages.
+This documentation is written in English. Please refer to the [localization program](/v3/contribute/localization-program/how-to-contribute/) for other languages.
 :::
 
-1. Clone a current version from the [ton-docs](https://github.com/ton-community/ton-docs) GitHub repository.
-1. Determine an area for contribution according to [Style guide](/v3/contribute/style-guide/) and open a related [issue](https://github.com/ton-community/ton-docs/issues).
-2. Familiarize yourself with [Content standardization](/v3/contribute/content-standardization/) and [Typography](/v3/contribute/typography/).
-3. Open a pull request against the `main` branch with a clear description and concise updates according to the template.
+1. Clone the current version from the [ton-docs](https://github.com/ton-community/ton-docs) GitHub repository.
+2. Choose an area to contribute according to [the Style guide](/v3/contribute/style-guide/) and open a related [issue](https://github.com/ton-community/ton-docs/issues).
+3. Familiarize yourself with [Content standardization](/v3/contribute/content-standardization/) and [Typography](/v3/contribute/typography/).
+4. Before submitting your pull request, complete and verify each milestone in the description checklist.
+5. Open a pull request against the `main` branch with a clear description and concise updates according to the template.
 
 #### Pull request template
 
-```md
+```markdown
 
 ## Description
 
@@ -43,7 +44,6 @@ Closes [link to issue].
 - [ ] I have reviewed and formatted the text in the article according to [Typography](https://docs.ton.org/v3/contribute/typography/).
 
 ```
-4. Before submitting your pull request, complete and verify each milestone in the description checklist.
 
 :::info
 To avoid excessive rework, read the contribution guidelines in the [Style guide](/v3/contribute/style-guide/), [Content standardization](/v3/contribute/content-standardization/), and [Typography](/v3/contribute/typography/) before contributing. Don't worry about minor issues; maintainers will help you fix them during the review process.
@@ -51,23 +51,23 @@ To avoid excessive rework, read the contribution guidelines in the [Style guide]
 
 ### Development
 
-- Learn the documentation development flow from a [ton-docs/README.md](https://github.com/ton-community/ton-docs?tab=readme-ov-file#set-up-your-environment-%EF%B8%8F) document.
+- Learn the documentation development flow from the [ton-docs/README.md](https://github.com/ton-community/ton-docs#readme) document.
 
 #### Best practices for pull requests
 
 1. **Keep your pull request small**. Minor pull requests (~300 lines of diff) are easier to review and more likely to get merged. Make sure the pull request does only one thing; otherwise, please split it.
 2. **Use descriptive titles**. It would be best to follow the commit message style.
-3. **Test your changes**. Run build locally, and make sure you have no crashes.
-4. **Use soft wrap**: Don't wrap lines at 80 characters; configure your editor to soft-wrap.
+3. Build locally and ensure it succeeds without crashes.
+4. **Use soft wrap**: Don't wrap lines at 80 characters; configure your editor to soft wrap.
 
 
-## Communicate to other developers
+## Communicate with other developers
 
 - [Ask questions related to TON documentation in the TON Docs Club chat in Telegram.](https://t.me/+c-0fVO4XHQsyOWM8)
-- [Get familiar with the most frequently asked questions in the TON Developers.](https://t.me/tondev_eng)
-- [Create an issue with your ideas on improvement.](https://github.com/ton-community/ton-docs/issues)
-- [Find and take available bounties for the documentation.](https://github.com/ton-society/ton-footsteps/issues?q=documentation) 
-- [See docs-ton on GitHub.](https://github.com/ton-community/ton-docs)
+- [Get familiar with frequently asked questions in the TON Developers chat.](https://t.me/tondev_eng)
+- [Create an issue with your ideas for improvements.](https://github.com/ton-community/ton-docs/issues)
+- [Find and take available bounties for the documentation.](https://github.com/ton-society/ton-footsteps/issues?q=documentation)
+- [See ton-docs on GitHub.](https://github.com/ton-community/ton-docs)
 
 ## See also
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-contribute-README.mdx` into `main`.

Changed file(s):
- M: `docs/v3/contribute/README.mdx`

Related issues (from issues.normalized.md):
- [x] **282. Capitalize 'TON Documentation' consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/README.mdx?plain=1#L4

Standardize capitalization in the info callout to "TON Documentation" to match usage elsewhere.

---

- [x] **283. Fix section title grammar: 'Contribute rules'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/README.mdx?plain=1#L7

Change the heading to "## Contribution guidelines" to use a correct noun phrase.

---

- [x] **284. Fix subheading grammar: 'Documentation maintain community'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/README.mdx?plain=1#L9

Change the subheading to "### Documentation maintainer community" for proper phrasing.

---

- [x] **285. Standardize hyphenation to 'open source'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/README.mdx?plain=1#L11-L13

Replace "open-source TON documentation" with "open source TON documentation" for consistency with common style.

---

- [x] **286. Add article: 'refer to the localization program'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/README.mdx?plain=1#L20

Change to "Please refer to the localization program for other languages."

---

- [x] **287. Keep ordered list contiguous across code block**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/README.mdx?plain=1#L23-L26,L46

Make the steps one continuous ordered list using "1." for each item, and move "Before submitting your pull request…" above the "Pull request template" subsection so the code block does not split the list.

---

- [x] **288. Change wording: 'Clone a current version'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/README.mdx?plain=1#L23

Change to "Clone the current version from the ton-docs GitHub repository."

---

- [x] **289. Change wording: 'Determine an area for contribution'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/README.mdx?plain=1#L24

Change to "Choose an area to contribute to according to the Style guide, and open a related issue."

---

- [x] **290. Use 'markdown' language for code block**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/README.mdx?plain=1#L30

Change the fenced code block language from "md" to "markdown" for better syntax highlighting compatibility.

---

- [x] **291. Use stable README link and improve phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/README.mdx?plain=1#L54

Change to "Learn the documentation development flow in the ton-docs README." and link to https://github.com/ton-community/ton-docs#readme (or a stable section anchor).

---

- [x] **292. Clarify build instruction phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/README.mdx?plain=1#L60

Change to "Build locally and ensure it succeeds without crashes."

---

- [x] **293. Standardize to 'soft wrap'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/README.mdx?plain=1#L61

Use "soft wrap" (no hyphen) consistently in both mentions.

---

- [x] **294. Use 'with' in section title preposition**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/README.mdx?plain=1#L64

Change the section title to "## Communicate with other developers".

---

- [x] **295. Fix phrasing about TON Developers chat**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/README.mdx?plain=1#L67

Change to "Get familiar with frequently asked questions in the TON Developers chat."

---

- [x] **296. Use 'for improvements' phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/README.mdx?plain=1#L68

Change to "Create an issue with your ideas for improvements."

---

- [x] **297. Remove trailing whitespace**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/README.mdx?plain=1#L69

Delete the trailing space at the end of the line to satisfy formatting linters.

---

- [x] **298. Correct repository name to 'ton-docs'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/README.mdx?plain=1#L70

Change the link text from "docs-ton" to "ton-docs" while keeping the existing URL.

---

- [x] **412. Link “contact us” to TON Docs Club chat**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/translation-style-guide.mdx?plain=1#L116

Link “contact us” to the TON Docs Club Telegram chat referenced in docs/v3/contribute/README.mdx.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.