### PR TITLE
Split: update docs/v3/contribute/content-standardization.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/contribute/content-standardization.mdx
+++ b/docs/v3/contribute/content-standardization.mdx
@@ -47,7 +47,7 @@ Present tense is standard, but future and past tenses are allowed in specific ca
 - After setup, the system will send a confirmation email.
 - If payment fails, the user will get a notification.
 
-*Avoid the future tense for immediate behavior or unreleased features. Also, avoid *would*.*
+*Avoid the future tense for immediate behavior or unreleased features. Also, avoid "would".*
 
 *Avoid:*
 - The system will check the file format.
@@ -351,18 +351,18 @@ Contributors can use the following examples to format various types of math expr
 For systems of equations, use `LaTeX` formatting for clarity:
 
 ```mdx
-<BlockMath math={`\\begin{cases}
-x + y = 10 \\\\
+<BlockMath math={`\begin{cases}
+x + y = 10 \\
 2x - y = 4
-\\end{cases}`} />
+\end{cases}`} />
 ```
 
 This renders the system of equations as:
 
-<BlockMath math={`\\begin{cases}
-x + y = 10 \\\\
+<BlockMath math={`\begin{cases}
+x + y = 10 \\
 2x - y = 4
-\\end{cases}`} />
+\end{cases}`} />
 
 
 ### Exponential functions
@@ -370,12 +370,10 @@ x + y = 10 \\\\
 For exponential functions, you can use the following format:
 
 ```mdx
-<InlineMath math="e^{x} = \lim\limits_{n\to \infty} \left( 1 + rac{x}{n} 
-ight)^n" />
+<InlineMath math="e^{x} = \\lim\\limits_{n\\to \\infty} \\left( 1 + \\frac{x}{n} \\right)^n" />
 ```
 
-This renders the equation: <InlineMath math="e^{x} = \lim\limits_{n\to \infty} \left( 1 + rac{x}{n} 
-ight)^n" />
+This renders the equation: <InlineMath math="e^{x} = \\lim\\limits_{n\\to \\infty} \\left( 1 + \\frac{x}{n} \\right)^n" />
 
 
 ### Fractions
@@ -383,30 +381,30 @@ ight)^n" />
 To represent fractions, use `\frac{numerator}{denominator}`:
 
 ```mdx
-<InlineMath math="\frac{a}{b}"/>
+<InlineMath math="\\frac{a}{b}"/>
 ```
 
-This renders the fraction: <InlineMath math="\frac{a}{b}"/>
+This renders the fraction: <InlineMath math="\\frac{a}{b}"/>
 
 ### Summation
 
 For summation notation, use the following `LaTeX` formatting:
 
 ```mdx
-<BlockMath math="\sum_{i=1}^{n} i^2" />
+<BlockMath math="\\sum_{i=1}^{n} i^2" />
 ```
 
-This renders the summation: <BlockMath math="\sum_{i=1}^{n} i^2" />
+This renders the summation: <BlockMath math="\\sum_{i=1}^{n} i^2" />
 
 ### Logarithmic expressions
 
 For logarithmic equations, use the following `LaTeX` syntax:
 
 ```mdx
-<InlineMath math="\log_{b}(x)" />
+<InlineMath math="\\log_{b}(x)" />
 ```
 
-This renders the logarithmic expression: <InlineMath math="\log_{b}(x)" />
+This renders the logarithmic expression: <InlineMath math="\\log_{b}(x)" />
 
 
 ## Terminology

--- a/docs/v3/contribute/content-standardization.mdx
+++ b/docs/v3/contribute/content-standardization.mdx
@@ -31,9 +31,9 @@ This makes documentation clear and easy to follow.
 - This guideline provides an overview of the contribution process.
 - The system checks the file format and shows an error if it is invalid.
 
-*Avoid future or past tense for immediate or typical actions.*
+_Avoid future or past tense for immediate or typical actions._
 
-**Avoid:**
+_Avoid:_
 - The system will check the file format.
 - The user clicked the button.
 
@@ -47,13 +47,12 @@ Present tense is standard, but future and past tenses are allowed in specific ca
 - After setup, the system will send a confirmation email.
 - If payment fails, the user will get a notification.
 
-*Avoid the future tense for immediate behavior or unreleased features. Also, avoid *would*.*
+_Avoid the future tense for immediate behavior or unreleased features. Also, avoid "would"._
 
-**Avoid:**
+_Avoid:_
 
 - The system will check the file format.
 - The API would return an error.
-
 
 **Past tense:** for describing past events like changelogs or logs.
 
@@ -61,14 +60,12 @@ Present tense is standard, but future and past tenses are allowed in specific ca
 - Version 2.1 fixed a validation issue.
 - The user submitted the form at 2 pm and got a 500 error.
 
-*Avoid past tense in general documentation — it can imply outdated info.*
+_Avoid past tense in general documentation — it can imply outdated info._
 
-**Avoid:**
+_Avoid:_
 
 - The system checked the user’s location.
 - The user clicked the button.
-
-
 
 ### Use active voice
 
@@ -88,9 +85,9 @@ _This isn't an easy one, especially for non-native English speakers. If you aren
 
 ### Grammar
 
-This documentation uses [cspell](https://cspell.org/) to correct grammar during development.
+This documentation uses [cspell](https://cspell.org/) to check spelling during development.
 
-The `cspell` will check the spelling and automatically suggest corrections in case of mistakes before creating a new commit. Feel free to add specific words to the [cspell.json](https://github.com/ton-community/ton-docs/blob/doc_editor_guidelines/cspell.json) config and include them in the verification dictionary.
+`cspell` will check the spelling and automatically suggest corrections in case of mistakes before creating a new commit. Feel free to add specific words to the [cspell.json](https://github.com/ton-community/ton-docs/blob/main/cspell.json) config and include them in the verification dictionary.
 
 ### Date format
 
@@ -118,7 +115,7 @@ Adhering to these guidelines creates a unified approach to presenting dates, fos
 
 #### In the Guidelines section:
 - Emojis and icons are allowed to make content more engaging and friendly.
-- Use them purposefully and consistently, preferring functional icons such as: ✅ Success, ⚠️ Warning, ❌ Error.
+- Use them purposefully and consistently, preferring functional icons such as ✅ Success, ⚠️ Warning, ❌ Error.
 - Always use icons with supporting text — don’t rely on icons alone to convey meaning.
 - Avoid overly decorative or emotional emojis that don’t add meaning.
 - When in doubt, skip the icon. Clarity, consistency, and neutrality come first.
@@ -128,7 +125,7 @@ Adhering to these guidelines creates a unified approach to presenting dates, fos
 
 ### Linking to internal pages
 
-When linking to another page on TON documentation, use the relative path over the absolute path.
+Use a site-relative path (rooted at “/”) instead of a full URL when linking to another page in the TON documentation.
 
 #### Correct link:
 
@@ -142,7 +139,7 @@ Read more about [smart contracts](/v3/documentation/smart-contracts/overview/)
 Read more about [smart contracts](https://docs.ton.org/v3/documentation/smart-contracts/overview)
 ```
 
-Don't hard-code the language path (for example, `/mandarin/`) in any links. This maintains consistent capability across different language versions of the site.
+Don't hard-code the language path (for example, `/zh-CN/`) in any links. This maintains consistent capability across different language versions of the site.
 
 #### Correct link:
 
@@ -153,7 +150,7 @@ Read more about [smart contracts](/v3/documentation/smart-contracts/overview/)
 #### Incorrect link:
 
 ```md
-Read more about [smart contracts](/mandarin/v3/documentation/smart-contracts/overview)
+Read more about [smart contracts](/zh-CN/v3/documentation/smart-contracts/overview)
 ```
 
 Set a trailing slash on internal documentation links to avoid redirects, which hurt site performance.
@@ -172,13 +169,13 @@ Read more about [smart contracts](/v3/documentation/smart-contracts/overview)
 
 ### Article authors
 
-When citing articles by a specific author or organization, use the article's name as a link, followed by a dash and the author's name italicized.
+When citing articles by a specific author or organization, use the article's name as a link, followed by an em dash and the author's name italicized.
 
 #### Correct description:
 
 ```md
 - [How to shard your TON smart contract and why](https://blog.ton.org/how-to-shard-your-ton-smart-contract-and-why-studying-the-anatomy-of-tons-jettons) — _Tal Kol_
-- [TON Teleport BTC Whitepaper](https://tgbtc.gitbook.io/docs/whitepaper/abstract) – _RSquad Blockchain Lab_
+- [TON Teleport BTC Whitepaper](https://tgbtc.gitbook.io/docs/whitepaper/abstract) — _RSquad Blockchain Lab_
 ```
 
 #### Incorrect description:
@@ -232,22 +229,22 @@ TON documentation supports theme-specific images. Follow these steps to add them
 
 2. Import the `ThemedImage` module in the header.
 
-```js
+```mdx
 import ThemedImage from "@theme/ThemedImage";
 ```
 
 3. Set the links for both images according to the example:
 
-```js
-<br></br>
+```mdx
+<br />
 <ThemedImage
-  alt=""
+  alt="Message delivery diagram"
   sources={{
     light: '/img/docs/message-delivery/message_delivery_2.svg?raw=true',
     dark: '/img/docs/message-delivery/message_delivery_2_dark.svg?raw=true',
   }}
 />
-<br></br>
+<br />
 ```
 
 ### Annotation specification
@@ -259,14 +256,13 @@ If the transaction order isn't essential, omit their labels. This approach simpl
 ### Annotation primitives
 
 <ThemedImage
-  alt=""
+  alt="Message processing diagram"
   sources={{
     light:
       "/img/docs/scheme-templates/message-processing-graphs/Graphic-Explanations-Guidelines_1.png?raw=true",
     dark: "/img/docs/scheme-templates/message-processing-graphs/Graphic-Explanations-Guidelines_1_dark.png?raw=true",
   }}
 />
-<br></br>
 
 - Avoid using a large variety of bright colors.
 - Modify figures by applying techniques such as a dashed border.
@@ -280,39 +276,35 @@ The message processing schemes offer additional context for readers seeking a cl
 
 #### Example
 
-<br></br>
 <ThemedImage
-  alt=""
+  alt="Message delivery flow"
   sources={{
     light: "/img/docs/message-delivery/message_delivery_2.png?raw=true",
     dark: "/img/docs/message-delivery/message_delivery_2_dark.png?raw=true",
   }}
 />
-<br></br>
 
 ### Sequence diagram
 
-Use a sequence diagram for complex and repetitive communication schemes between 2-3 actors. For messages, use the notation of a typical synchronous message arrow.
+Use a sequence diagram for complex and repetitive communication schemes between 2–3 actors. For messages, use the notation of a typical synchronous message arrow.
 
 #### Example
 
-<br></br>
-<div class="text--center">
+<div className="text--center">
   <ThemedImage
-    alt=""
+    alt="Message sequence diagram"
     sources={{
       light: "/img/docs/message-delivery/message_delivery_7.png?raw=true",
       dark: "/img/docs/message-delivery/message_delivery_7_dark.png?raw=true",
     }}
   />
 </div>
-<br></br>
 
 ### Scheme formats and colors
 
 #### Format:
 
-- Use a PNG format for the diagrams in the documentation to ensure readability on various devices.
+- Use PNG format for the diagrams in the documentation to ensure readability on various devices.
 
 #### Fonts:
 
@@ -348,6 +340,7 @@ Import the required components at the top of your `.mdx` file:
 import { BlockMath, InlineMath } from 'react-katex';
 import 'katex/dist/katex.min.css';
 ```
+
 These imports allow you to render `LaTeX` math expressions:
 - `BlockMath` is used for centered, standalone formulas.
 - `InlineMath` is used for short expressions inside the regular text.
@@ -379,10 +372,12 @@ x + y = 10 \\\\
 For exponential functions, you can use the following format:
 
 ```mdx
-<InlineMath math="e^{x} = \lim\limits_{n\to \infty} \left( 1 + \frac{x}{n} \right)^n" />
+<InlineMath math="e^{x} = \lim\limits_{n\to \infty} \left( 1 + rac{x}{n} 
+ight)^n" />
 ```
 
-This renders the equation: <InlineMath math="e^{x} = \lim\limits_{n\to \infty} \left( 1 + \frac{x}{n} \right)^n" />
+This renders the equation: <InlineMath math="e^{x} = \lim\limits_{n\to \infty} \left( 1 + rac{x}{n} 
+ight)^n" />
 
 
 ### Fractions
@@ -398,9 +393,11 @@ This renders the fraction: <InlineMath math="\frac{a}{b}"/>
 ### Summation
 
 For summation notation, use the following `LaTeX` formatting:
+
 ```mdx
 <BlockMath math="\sum_{i=1}^{n} i^2" />
 ```
+
 This renders the summation: <BlockMath math="\sum_{i=1}^{n} i^2" />
 
 ### Logarithmic expressions

--- a/docs/v3/contribute/content-standardization.mdx
+++ b/docs/v3/contribute/content-standardization.mdx
@@ -118,9 +118,7 @@ Adhering to these guidelines creates a unified approach to presenting dates, fos
 
 #### In the Guidelines section:
 - Emojis and icons are allowed to make content more engaging and friendly.
-- Use them purposefully and consistently, preferring functional icons such as:
-
-✅ Success, ⚠️ Warning, ❌ Error.
+- Use them purposefully and consistently, preferring functional icons such as: ✅ Success, ⚠️ Warning, ❌ Error.
 - Always use icons with supporting text — don’t rely on icons alone to convey meaning.
 - Avoid overly decorative or emotional emojis that don’t add meaning.
 - When in doubt, skip the icon. Clarity, consistency, and neutrality come first.
@@ -158,7 +156,7 @@ Read more about [smart contracts](/v3/documentation/smart-contracts/overview/)
 Read more about [smart contracts](/mandarin/v3/documentation/smart-contracts/overview)
 ```
 
-Set a trailing slash to all links. This approach keeps links consistent and avoids redirects, which hurts site performance.
+Set a trailing slash on internal documentation links to avoid redirects, which hurt site performance.
 
 #### Correct link:
 
@@ -336,7 +334,7 @@ Use a sequence diagram for complex and repetitive communication schemes between 
 
 #### Version control policy:
 
-- Store the original files in the project's Git repository under the `/static/visio` directory to facilitate future modifications.
+- Store the original files under `/static/schemes-visio` to facilitate future modifications.
 - Learn [Visio](https://www.microsoft.com/en-us/microsoft-365/visio/flowchart-software) references directly from [Visio sources](https://github.com/ton-community/ton-docs/tree/main/static/schemes-visio/).
 
 
@@ -346,7 +344,7 @@ To include mathematical expressions in documentation, use the [react-katex](http
 
 Import the required components at the top of your `.mdx` file:
 
-```
+```mdx
 import { BlockMath, InlineMath } from 'react-katex';
 import 'katex/dist/katex.min.css';
 ```
@@ -361,7 +359,7 @@ Contributors can use the following examples to format various types of math expr
 
 For systems of equations, use `LaTeX` formatting for clarity:
 
-```
+```mdx
 <BlockMath math={`\\begin{cases}
 x + y = 10 \\\\
 2x - y = 4
@@ -380,7 +378,7 @@ x + y = 10 \\\\
 
 For exponential functions, you can use the following format:
 
-```
+```mdx
 <InlineMath math="e^{x} = \lim\limits_{n\to \infty} \left( 1 + \frac{x}{n} \right)^n" />
 ```
 
@@ -389,9 +387,9 @@ This renders the equation: <InlineMath math="e^{x} = \lim\limits_{n\to \infty} \
 
 ### Fractions
 
-To represent fractions, use `\frac{numerator}{denominator}:`
+To represent fractions, use `\frac{numerator}{denominator}`:
 
-```
+```mdx
 <InlineMath math="\frac{a}{b}"/>
 ```
 
@@ -400,7 +398,7 @@ This renders the fraction: <InlineMath math="\frac{a}{b}"/>
 ### Summation
 
 For summation notation, use the following `LaTeX` formatting:
-```
+```mdx
 <BlockMath math="\sum_{i=1}^{n} i^2" />
 ```
 This renders the summation: <BlockMath math="\sum_{i=1}^{n} i^2" />
@@ -409,7 +407,7 @@ This renders the summation: <BlockMath math="\sum_{i=1}^{n} i^2" />
 
 For logarithmic equations, use the following `LaTeX` syntax:
 
-```
+```mdx
 <InlineMath math="\log_{b}(x)" />
 ```
 
@@ -507,7 +505,7 @@ When referring to the TON Mainnet (i.e. not referring to a Testnet) use the prop
 **Incorrect usage:**
 
 - Masterchain
-- Work Chain
+- Master Chain
 
 ### BaseChain
 
@@ -548,7 +546,7 @@ The smart contract is a common noun and should only be capitalized at the beginn
 - Smart contract
 - smart contract
 
-** Incorrect usage:**
+**Incorrect usage:**
 
 - Smart Contract
 
@@ -623,9 +621,8 @@ When using these words, refer to them in lowercase unless they are the first wor
 
 ### BoC, bag of cells
 
-- Use either the abbreviation **BoC** or the full term **bag of cells**.
+- When abbreviated, write **BoC** (not **BOC** or **boc**); you may also use the full term **bag of cells** where appropriate.
 - **Bag of cells** is capitalized only when it starts a sentence or heading. In all other cases, write **bag of cells** in lowercase.
-- Always abbreviate **BoC**. Do not use **BOC** or **boc**.
 
 **Correct usage:**
 
@@ -644,9 +641,7 @@ When using these words, refer to them in lowercase unless they are the first wor
 ## See also
 
 - [How to contribute](/v3/contribute/)
-- [Content standardization](/v3/contribute/content-standardization/)
 - [Typography](/v3/contribute/typography/)
 - [Localization program](/v3/contribute/localization-program/overview/)
 
 <Feedback />
-

--- a/docs/v3/contribute/content-standardization.mdx
+++ b/docs/v3/contribute/content-standardization.mdx
@@ -31,9 +31,9 @@ This makes documentation clear and easy to follow.
 - This guideline provides an overview of the contribution process.
 - The system checks the file format and shows an error if it is invalid.
 
-_Avoid future or past tense for immediate or typical actions._
+*Avoid future or past tense for immediate or typical actions.*
 
-_Avoid:_
+*Avoid:*
 - The system will check the file format.
 - The user clicked the button.
 
@@ -47,10 +47,9 @@ Present tense is standard, but future and past tenses are allowed in specific ca
 - After setup, the system will send a confirmation email.
 - If payment fails, the user will get a notification.
 
-_Avoid the future tense for immediate behavior or unreleased features. Also, avoid "would"._
+*Avoid the future tense for immediate behavior or unreleased features. Also, avoid *would*.*
 
-_Avoid:_
-
+*Avoid:*
 - The system will check the file format.
 - The API would return an error.
 
@@ -60,10 +59,9 @@ _Avoid:_
 - Version 2.1 fixed a validation issue.
 - The user submitted the form at 2 pm and got a 500 error.
 
-_Avoid past tense in general documentation — it can imply outdated info._
+*Avoid past tense in general documentation — it can imply outdated info.*
 
-_Avoid:_
-
+*Avoid:*
 - The system checked the user’s location.
 - The user clicked the button.
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-contribute-content-standardization.mdx` into `main`.

Changed file(s):
- M: `docs/v3/contribute/content-standardization.mdx`

Related issues (from issues.normalized.md):
- [x] **299. Standardize emphasis and remove nested italics**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/content-standardization.mdx?plain=1#L50

Use a single emphasis marker across the page (prefer underscores) and avoid nesting italics with the same marker; e.g., rewrite the sentence to avoid nested italics and quote “would” instead; also align earlier italics at L34 and L87 to use underscores.

---

- [x] **300. Correct cspell description and link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/content-standardization.mdx?plain=1#L91-L94

Change to “This documentation uses cspell to check spelling during development” and update the link to https://github.com/ton-community/ton-docs/blob/main/cspell.json.

---

- [x] **301. Clarify internal link rule to site-relative paths**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/content-standardization.mdx?plain=1#L131-L139

Reword to: “Use a site-relative path (rooted at ‘/’) instead of a full URL” to match the provided examples.

---

- [ ] **302. Replace nonexistent '/mandarin/' locale example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/content-standardization.mdx?plain=1#L147-L159

Replace “/mandarin/” with a generic or real locale path, e.g., “/<locale>/” such as “/zh-CN/”, and advise not to hard‑code the locale.

---

- [x] **303. Standardize author dash to em dash**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/content-standardization.mdx?plain=1#L182-L184

State and apply one style: use an em dash (—) before the author credit in both examples.

---

- [x] **304. Use MDX/JSX fence for ThemedImage example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/content-standardization.mdx?plain=1#L237-L253

Change the code fence from “```js” to “```mdx” (or “```jsx”) for accurate syntax highlighting.

---

- [x] **305. Add descriptive alt text to ThemedImage**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/content-standardization.mdx?plain=1#L237-L253

Replace alt="" with a brief descriptive alt for non‑decorative images (keep empty alt only for decorative content).

---

- [x] **306. Fix invalid <br> tags**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/content-standardization.mdx?plain=1#L244-L252, L271, L285, L293, L301, L311

Replace “<br></br>” with the self‑closing “<br />” or remove and use spacing utilities.

---

- [x] **307. Use className instead of class in JSX**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/content-standardization.mdx?plain=1#L302-L310

Change “class” to “className” in JSX wrappers around components (e.g., ThemedImage) to avoid attribute mismatches.

---

- [x] **308. Improve PNG phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/content-standardization.mdx?plain=1#L317

Change “Use a PNG format” to “Use PNG format” (or “Use the PNG format”).

---

- [ ] **309. Fix Visio sources directory path**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/content-standardization.mdx?plain=1#L339-L341

Update to: “Store the original files under ‘/static/schemes-visio’.”

---

- [x] **310. Add languages to math code fences**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/content-standardization.mdx?plain=1#L349-L352, L364-L369, L383-L385, L394-L396, L403-L405, L412-L414

Add an explicit language (e.g., mdx or jsx) to these code fences for readability and highlighting.

---

- [x] **311. Move colon outside fraction code span**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/content-standardization.mdx?plain=1#L392-L396

Change “use `\frac{numerator}{denominator}:`” to “use `\frac{numerator}{denominator}`:”.

---

- [x] **312. Fix MasterChain incorrect usage examples**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/content-standardization.mdx?plain=1#L507-L511

Remove “Work Chain” from the incorrect list and use relevant variants like “Masterchain” or “Master Chain.”

---

- [x] **313. Remove extra space in bold label**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/content-standardization.mdx?plain=1#L551-L553

Fix formatting by removing the extra space after “**” so it reads “**Incorrect usage:**”.

---

- [ ] **314. Clarify BoC abbreviation guidance**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/content-standardization.mdx?plain=1#L626-L628

Clarify to: “When abbreviated, write ‘BoC’ (not ‘BOC’ or ‘boc’); you may also use the full term ‘bag of cells’ where appropriate.”

---

- [ ] **315. Remove self-referential 'See also' link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/content-standardization.mdx?plain=1#L644-L649

Remove the link to the current page from the “See also” list to avoid self-reference.

---

- [ ] **316. Limit trailing slash rule to internal links**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/content-standardization.mdx?plain=1

Revise to: “Set a trailing slash on internal documentation links to avoid redirects, which hurt site performance.”

---

- [ ] **317. Fix emoji line as list item**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/content-standardization.mdx?plain=1

Make the “✅ Success, ⚠️ Warning, ❌ Error.” line part of the preceding bullet (or a new bullet) to maintain list formatting.

---

### overview (r1) — run_20250828_142245_60d34168

- [x] **4318. Internal links missing trailing slash**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/fift/overview.mdx?plain=1

Internal links should include a trailing slash to avoid redirects and keep links consistent. Update: - `/v3/documentation/tvm/tvm-overview` → `/v3/documentation/tvm/tvm-overview/` - `/v3/documentation/smart-contracts/contracts-specs/examples#fift-smart-contracts` → `/v3/documentation/smart-contracts/contracts-specs/examples/#fift-smart-contracts` Reference: docs/v3/contribute/content-standardization.mdx#linking-to-internal-pages ("Set a trailing slash to all links").

---

- [x] **4320. Author attribution formatting and handle casing are inconsistent**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/fift/overview.mdx?plain=1

The line `created - _@MarcoDaTr0p0je & @Wikimar_` does not follow the project’s author citation style and uses `@Wikimar` (lowercase “m”), which differs from usage elsewhere (`@WikiMar`). Use the standard author citation style (link — _Author_) by removing the standalone “created” line and attributing authors after the corresponding links: - `- [His majesty Fift](…youtube playlist…) — _@MarcoDaTr0p0je_` - `- [Russian version](…playlist…) — _@WikiMar_` References: - Formatting guidance: docs/v3/contribute/content-standardization.mdx#article-authors. - Handle casing consistency: docs/v3/documentation/smart-contracts/overview.mdx (RU version references `@WikiMar`).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.