### PR TITLE
Split: update docs/v3/contribute/contribution-rules.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/contribute/contribution-rules.mdx
+++ b/docs/v3/contribute/contribution-rules.mdx
@@ -1,53 +1,55 @@
 import Feedback from '@site/src/components/Feedback';
 
-# Contribution Guidelines
+# Contribution rules
 
 :::danger
 This page is outdated and will be deleted soon.
-See the [How to contribute](/v3/contribute/).
+See [How to contribute](/v3/contribute/).
 :::
 
-Before contributing any docs.ton.org page, please review the following list of general and important requirements to guarantee a smooth experience.
+Before contributing to TON documentation, review the following general requirements to ensure a smooth experience.
 
 ## Naming
 
-- It is essential to ensure the correct use of _THE_ in the TON documentation. _TON Blockchain_ and _TON Ecosystem_ are capitalized terms, and therefore, do not require _THE_ in their usage.
-- We write _TON_ with regular nouns, and if it requires _THE_ according to English grammar, we use it. For instance: "_The_ TON Connect _protocol_ is a..."
+- Use “the” correctly in TON documentation. “TON Blockchain” and “TON Ecosystem” are proper names and do not take the definite article.
+- Use “TON” with common nouns; when English grammar requires the definite article, include “the” (e.g., “The TON Connect protocol is …”).
 
 :::info
-TON Blockchain...
+TON Blockchain
 
-TON Ecosystem...
+TON Ecosystem
 
-The TON Connect protocol...
+The TON Connect protocol
 :::
 
-Please refer to the actual TON brand assets [here](https://ton.org/en/brand-assets).
+Refer to the official [TON brand assets](https://ton.org/en/brand-assets).
 
-## Documentation References
+## Documentation references
 
-Every page in TON documentation should be finished with See Also section. Place there page, you think relates to current page without additional description.
+End every page with a “See also” section. List pages related to the current page; do not add descriptions.
 
 :::info
 
-```
-## See Also
-* [TON Contribution Guidelines](/v3/contribute/contribution-rules/)
-* [Tutorial Styling Guidelines](/v3/contribute/tutorials/guidelines/)
+```md
+## See also
+- [Style guide](/v3/contribute/style-guide/)
+- [Typography](/v3/contribute/typography/)
+- [Localization program overview](/v3/contribute/localization-program/overview/)
 ```
 
 :::
 
-## English Helpful Sources
+## English helpful sources
 
-The TON Ecosystem is being built for the entire world, so it's crucial that it's understandable for everyone on Earth. Here, we provide materials that are helpful for junior tech writers who want to improve their English skills.
+The TON Ecosystem is being built for the entire world, so it must be understandable to everyone. Here are materials that are helpful for junior tech writers who want to improve their English skills.
 
 - [Plural Nouns](https://www.grammarly.com/blog/plural-nouns/)
 - [Articles: A versus An](https://owl.purdue.edu/owl/general_writing/grammar/articles_a_versus_an.html)
 
-## See Also
+## See also
 
-- [TON Contribution Guidelines](/v3/contribute/contribution-rules/)
-- [Tutorial Styling Guidelines](/v3/contribute/tutorials/guidelines/)
+- [Style guide](/v3/contribute/style-guide/)
+- [Typography](/v3/contribute/typography/)
+- [Localization program overview](/v3/contribute/localization-program/overview/)
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-contribute-contribution-rules.mdx` into `main`.

Changed file(s):
- M: `docs/v3/contribute/contribution-rules.mdx`

Related issues (from issues.normalized.md):
- [x] **318. Align page title with filename terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/contribution-rules.mdx?plain=1#L3

The page title says "Contribution Guidelines" but the file is contribution-rules.mdx; align terminology by renaming the title to "Contribution rules" or renaming the file to contribution-guidelines.mdx (noting route changes if renamed).

---

- [x] **319. Fix danger callout link phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/contribution-rules.mdx?plain=1#L5-L8

Change “See the [How to contribute](/v3/contribute/)” to “See [How to contribute](/v3/contribute/).”

---

- [x] **320. Correct intro sentence grammar and terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/contribution-rules.mdx?plain=1#L10

Replace “Before contributing any docs.ton.org page…” with “Before contributing to TON documentation, review the following general requirements to ensure a smooth experience.”

---

- [x] **321. Clarify article usage guidance; avoid all caps**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/contribution-rules.mdx?plain=1#L14

Rewrite to avoid “THE” in all caps and clarify usage: “Use ‘the’ correctly in TON documentation. ‘TON Blockchain’ and ‘TON Ecosystem’ are proper names and do not take the definite article.”

---

- [x] **322. Clarify ‘TON’ usage with common nouns**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/contribution-rules.mdx?plain=1#L15

Rewrite for clarity: “Use ‘TON’ with common nouns; when English grammar requires the definite article, include ‘the’ (e.g., ‘The TON Connect protocol is …’).”

---

- [x] **323. Replace ellipses in naming examples**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/contribution-rules.mdx?plain=1#L17-L23

Remove ellipses and provide complete examples, e.g., “TON Blockchain,” “TON Ecosystem,” and “The TON Connect protocol.”

---

- [x] **324. Use descriptive link text for brand assets**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/contribution-rules.mdx?plain=1#L25

Replace “Please refer to the actual TON brand assets here” with “Refer to the official [TON brand assets](https://ton.org/en/brand-assets).”

---

- [x] **325. Use sentence case for ‘Documentation references’ heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/contribution-rules.mdx?plain=1#documentation-references

Change the H2 to “Documentation references” to follow sentence case.

---

- [x] **326. Fix grammar in ‘Documentation references’ guidance**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/contribution-rules.mdx?plain=1#L29-L30

Replace with: “End every page with a ‘See also’ section. List pages related to the current page; do not add descriptions.”

---

- [x] **327. Update ‘See also’ example snippet with language tag and canonical links**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/contribution-rules.mdx?plain=1#L33-L37

Add a language tag to the fenced block (e.g., md), use the heading “## See also,” and include canonical links: Style guide, Typography, and Localization program overview.

---

- [x] **328. Make ‘English helpful sources’ heading sentence case**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/contribution-rules.mdx?plain=1#L41

Change the H2 from “English Helpful Sources” to “English helpful sources.”

---

- [x] **329. Remove colloquial “everyone on Earth” phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/contribution-rules.mdx?plain=1#L43

Replace with neutral wording such as “The TON Ecosystem is being built for the entire world, so it must be understandable to everyone.”

---

- [x] **330. Use sentence case for ‘See also’ section heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/contribution-rules.mdx?plain=1#L48

Change the H2 to “See also.”

---

- [x] **331. Remove self-link from ‘See also’ and use canonical resources**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/contribution-rules.mdx?plain=1#L48-L51

Remove the self-referential link to this page and list relevant canonical resources instead (e.g., Style guide, Typography, Localization program overview).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.