### PR TITLE
Split: update docs/v3/contribute/docs/guidelines.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/contribute/docs/guidelines.mdx
+++ b/docs/v3/contribute/docs/guidelines.mdx
@@ -1,29 +1,27 @@
 import Feedback from '@site/src/components/Feedback';
 
-# Common Documentation Principals
+# Common documentation principles
 
 :::danger
 This page is outdated and will be deleted soon.
-See the [How to contribute](/v3/contribute/).
+See [How to contribute](/v3/contribute/).
 :::
 
-For optimal user experience and clarity, please keep in mind the list of general and important requirements that we aim to apply to all documentation on docs.ton.org while creating new content.
+For clarity and a better user experience, follow these general requirements across the TON documentation when creating new content.
 
 
-## Documentation crafted for Professionals
-Documentations pages is primarily intended for documentation purposes and not as a tutorial, so it is important to minimize the use of personal examples or analogies in the text. It is crucial to ensure that the content is suitable for both professionals and non-professionals alike, while still providing valuable information.
+## Documentation crafted for professionals
+Documentation pages are primarily intended for reference, not tutorials. Minimize personal examples or analogies, and ensure the content is suitable for both professionals and non‑professionals.
 
 ## Use a consistent format
 To make it easier for readers to navigate through the documentation, it is important to use a consistent format throughout the document. Use headings, subheadings, bullet points, and numbered lists to break up the text and make it easier to read.
 
-## Provide examples in special section
-Providing examples can help readers better understand the content and how to apply it. If you are writing documentation page and need refer several examples, please create special section Examples right before References and See Also sections. Do not mix description and examples in documentation pages. 
-Use code snippets, screenshots, or diagrams to illustrate your points and make the documentation more engaging.
+## Provide examples in a dedicated section.
+If you are writing a documentation page and need to refer to several examples, create a dedicated Examples section right before the References and See also sections. Do not mix description and examples on documentation pages. Use code snippets, screenshots, or diagrams to illustrate your points.
 
 ## Keep it up to date
-Tech documentation can quickly become outdated due to changes in technology or software updates. It is important to review and update the documentation regularly to ensure that it remains accurate and relevant to the current version of the software.
+Technical documentation can quickly become outdated due to changes in technology or software updates. It is important to review and update the documentation regularly to ensure that it remains accurate and relevant to the current version of the software.
 
 ## Get feedback
 Before publishing the documentation, it is a good idea to get feedback from other contributors or users. This can help identify areas that may be confusing or unclear, and allow you to make improvements before the documentation is released.
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-contribute-docs-guidelines.mdx` into `main`.

Changed file(s):
- M: `docs/v3/contribute/docs/guidelines.mdx`

Related issues (from issues.normalized.md):
- [ ] **332. Correct H1 spelling and case**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/docs/guidelines.mdx?plain=1#L3

The H1 reads “Common Documentation Principals”; change to “Common documentation principles” (fix “principals” → “principles” and apply sentence case).

---

- [ ] **333. Remove article before link in callout**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/docs/guidelines.mdx?plain=1#L7

Change “See the [How to contribute](/v3/contribute/)” to “See [How to contribute](/v3/contribute/)”.

---

- [ ] **334. Streamline intro for clarity**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/docs/guidelines.mdx?plain=1#L10

Replace the verbose sentence with: “For clarity and a better user experience, follow these general requirements across the TON documentation when creating new content.”

---

- [ ] **335. Use sentence case in section heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/docs/guidelines.mdx?plain=1#L13

Change the heading “Documentation crafted for Professionals” to “Documentation crafted for professionals”.

---

- [ ] **336. Fix grammar in audience paragraph**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/docs/guidelines.mdx?plain=1#L14

Replace the paragraph with: “Documentation pages are primarily intended for reference, not tutorials. Minimize personal examples or analogies, and ensure the content is suitable for both professionals and non‑professionals.”

---

- [ ] **337. Make examples heading grammatical**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/docs/guidelines.mdx?plain=1#L19

Change “Provide examples in special section” to “Provide examples in a dedicated section.”

---

- [ ] **338. Fix grammar and capitalization in examples paragraph**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/docs/guidelines.mdx?plain=1#L20-L21

Revise to: “If you are writing a documentation page and need to refer to several examples, create a dedicated Examples section right before the References and See also sections. Do not mix description and examples on documentation pages. Use code snippets, screenshots, or diagrams to illustrate your points.” Normalize “See also” casing.

---

- [ ] **339. Use “Technical documentation” terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/docs/guidelines.mdx?plain=1#L24

Replace “Tech documentation” with “Technical documentation” for clarity and consistency.

---

- [ ] **340. Confirm or remove mandated section order**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/docs/guidelines.mdx?plain=1

This page prescribes placing “Examples” before “References” and “See also,” but the global guidelines don’t define this order; confirm the canonical order site‑wide or remove this prescription.

---

- [ ] **341. Add “See also” section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/docs/guidelines.mdx?plain=1

Add a “## See also” section with links to related resources (e.g., Style guide, Typography, Content standardization, How to contribute) per content standardization.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.