### PR TITLE
Split: update docs/v3/contribute/docs/schemes-guidelines.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/contribute/docs/schemes-guidelines.mdx
+++ b/docs/v3/contribute/docs/schemes-guidelines.mdx
@@ -1,91 +1,82 @@
 import Feedback from '@site/src/components/Feedback';
 
-import ConceptImage from '@site/src/components/conceptImage';
 import ThemedImage from '@theme/ThemedImage';
 
-# Graphic Explanations Guidelines
+# Graphic explanation guidelines
 
 :::danger
 This page is outdated and will be deleted soon.
-See the [How to contribute](/v3/contribute/).
+See [How to contribute](/v3/contribute/).
 :::
 
 Maintaining consistency in documentation is crucial, and to achieve this, a specific standard for visualizing processes in smart contracts has been developed.
 
-## Graphic Explanation Notation
+## Graphic explanation notation
 
-### Message Processing Graph
+### Message processing graph
 
 To depict message processing, it's advisable to utilize a graphical representation resembling a smart contract graph, complete with labels for transactions and messages.
 
 If the order of transactions doesn't matter, you can omit their labels. This simplifies the diagram, making it easier to read and understand the details related to messages and contracts.
 
-#### Annotation Primitives
+#### Annotation primitives
 
 <ThemedImage
-  alt=""
+  alt="Annotation primitives for message-processing graphs"
   sources={{
   light: '/img/docs/scheme-templates/message-processing-graphs/Graphic-Explanations-Guidelines_1.png?raw=true',
   dark: '/img/docs/scheme-templates/message-processing-graphs/Graphic-Explanations-Guidelines_1_dark.png?raw=true',
 }}
 />
 
-<br />
+- Avoid using many different bright colors.
+- Use shape variations (e.g., dashed borders) to differentiate elements.
+- Display different transactions with distinct line styles (solid or dashed) for clarity.
 
-- Avoid using big quantity different and bright colors.
-- Use the modification of figures, such as using a dashed border line.
-- For better comprehension, different transactions could be displayed with distinct line styles (solid and dashed).
-
-#### Message Processing Example
-
-<br />
+#### Message processing example
 
 <ThemedImage
-  alt=""
+  alt="Example message-processing graph"
   sources={{
   light: '/img/docs/message-delivery/message_delivery_2.png?raw=true',
   dark: '/img/docs/message-delivery/message_delivery_2_dark.png?raw=true',
 }}
 />
 
-<br />
+Use the Visio source file for reference: [message_processing.vsdx](/schemes-visio/message_processing.vsdx).
 
-Learn references directly from Visio [message-processing.vsdx](/schemes-visio/message_processing.vsdx).
-
-### Formats and Colors
+### Formats and colors
 
 #### Fonts
 
-- **Inter** fonts family  for all text within diagrams.
+- Use the Inter font family for all text in diagrams.
 
-#### Colors - Light Mode
+#### Colors - light mode
 
-- Pencil Hand Drawn(default theme)
+- Pencil Hand Drawn (default theme)
 
-#### Colors - Dark Mode
+#### Colors - dark mode
 
 - Font `#e3e3e3`
 - Background `#232328`
-- Light Highlight(arrows and scheme borders) `#058dd2`
-- Dark Highlight(arrows and scheme borders) `#0088cc`
-- InnerBackGround(for nested blocks) `#333337`
+- Light highlight (arrows and scheme borders) `#058dd2`
+- Dark highlight (arrows and scheme borders) `#0088cc`
+- Inner background (for nested blocks) `#333337`
 
-#### Version Control Policy
+#### Version control policy
 
-- Set diagrams in the documentation by SVG format for schemes to ensure readability on various devices.
-- Store original files in the project's Git repository under the "/static/visio" directory, making them easier to modify in the future.
+- Use SVG format for diagrams to ensure readability on various devices.
+- Store original files in the project's Git repository under the `static/schemes-visio` directory (served at `/schemes-visio`), making them easier to modify in the future.
 
-### Sequence Diagram
+### Sequence diagram
 
 In the case of complex and repetitive communication schemes between 2-3 actors, it is advisable to use a sequence diagram. For messages, use the notation of a common synchronous message arrow.
 
 #### Example
 
-<br />
-
 <div class="text--center">
   <ThemedImage
-    alt=""
+    alt="Sequence diagram example with two actors"
     sources={{
   light: '/img/docs/message-delivery/message_delivery_7.png?raw=true',
   dark: '/img/docs/message-delivery/message_delivery_7_dark.png?raw=true',
@@ -93,10 +84,8 @@ In the case of complex and repetitive communication schemes between 2-3 actors, 
   />
 </div>
 
-<br />
+### Scheme references
 
-### Scheme References
-
-- [message-processing.vsdx](/schemes-visio/message_processing.vsdx)
+- [message_processing.vsdx](/schemes-visio/message_processing.vsdx)
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-contribute-docs-schemes-guidelines.mdx` into `main`.

Changed file(s):
- M: `docs/v3/contribute/docs/schemes-guidelines.mdx`

Related issues (from issues.normalized.md):
- [x] **342. Remove unused ConceptImage import**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/docs/schemes-guidelines.mdx?plain=1#L3

ConceptImage is imported but not used; delete the import line to avoid dead code and lint warnings.

---

- [x] **343. Make H1 sentence case and correct wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/docs/schemes-guidelines.mdx?plain=1#L6

Change the H1 from “Graphic Explanations Guidelines” to “Graphic explanation guidelines” (fix pluralization and use sentence case), and convert all section headings to sentence case for consistency.

---

- [x] **344. Fix admonition link text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/docs/schemes-guidelines.mdx?plain=1#L10

Remove the article: change “See the [How to contribute](/v3/contribute/).” to “See [How to contribute](/v3/contribute/).”

---

- [x] **345. Add descriptive alt text to diagrams**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/docs/schemes-guidelines.mdx?plain=1#L25-L31, #L43-L49, #L86-L94

Replace empty alt attributes with concise descriptions, e.g., L25–31: alt="Annotation primitives for message-processing graphs"; L43–49: alt="Example message-processing graph"; L86–94: alt="Sequence diagram example with two actors".

---

- [x] **346. Remove <br /> used for spacing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/docs/schemes-guidelines.mdx?plain=1#L33, #L41, #L51, #L84, #L96

Delete <br /> tags used for layout and use CSS/MDX structure (margins, wrappers, or utility classes) to manage spacing.

---

- [x] **347. Fix grammar in color-usage bullet**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/docs/schemes-guidelines.mdx?plain=1#L35

Change “Avoid using big quantity different and bright colors.” to “Avoid using many different bright colors.”

---

- [x] **348. Clarify figure differentiation wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/docs/schemes-guidelines.mdx?plain=1#L36

Change “Use the modification of figures, such as using a dashed border line.” to “Use shape variations (e.g., dashed borders) to differentiate elements.”

---

- [x] **349. Use imperative tense for line styles**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/docs/schemes-guidelines.mdx?plain=1#L37

Change “could be displayed” guidance to imperative: “Display different transactions with distinct line styles (solid or dashed) for clarity.”

---

- [x] **350. Fix Visio reference phrasing and file name**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/docs/schemes-guidelines.mdx?plain=1#L53

Rephrase to “Use the Visio source file for reference: [message_processing.vsdx](/schemes-visio/message_processing.vsdx).” and ensure the visible file name matches the target (update all occurrences).

---

- [x] **351. Correct fonts bullet grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/docs/schemes-guidelines.mdx?plain=1#L59

Change to “Use the Inter font family for all text in diagrams.” (fix pluralization and extra space).

---

- [x] **352. Standardize theme/color label casing and spacing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/docs/schemes-guidelines.mdx?plain=1#L63, #L69-L71

Fix labels to: “Pencil Hand Drawn (default theme)”, “Light highlight (arrows and scheme borders)”, “Dark highlight (arrows and scheme borders)”, and “Inner background (for nested blocks)”; add terminal periods for consistency if the list uses periods elsewhere.

---

- [x] **353. Correct source file storage path and format**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/docs/schemes-guidelines.mdx?plain=1#L76

Change the storage path to `static/schemes-visio` (served at `/schemes-visio`) and format paths with backticks instead of quotes.

---

- [ ] **354. Clarify SVG recommendation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/docs/schemes-guidelines.mdx?plain=1

Replace “Set diagrams in the documentation by SVG format for schemes to ensure readability on various devices.” with “Use SVG format for diagrams to ensure readability on various devices.”

---

- [ ] **355. Rename “Scheme references” to “See also”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/docs/schemes-guidelines.mdx?plain=1

Rename the related-resources section to “See also” per the standard “See also” section convention.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.