### PR TITLE
Split: update docs/v3/contribute/localization-program/how-it-works.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/contribute/localization-program/how-it-works.mdx
+++ b/docs/v3/contribute/localization-program/how-it-works.mdx
@@ -4,14 +4,15 @@ import Feedback from '@site/src/components/Feedback';
 
 ![how it works](/img/localizationProgramGuideline/localization-program.png)
 
-The TownSquare Labs Localization Program comprises several key components. This chapter provides an overview of localization, helping you understand how it works and how to use it effectively.
+The TownSquare Labs Localization Program comprises several key components. This page provides an overview of localization, helping you understand how it works and how to use it effectively.
 
 Within this system, we integrate several applications to function seamlessly as a unified program:
 
 - **GitHub**: Hosts the documentation, synchronizes docs from the upstream repository, and syncs translations to specific branches.
 - **Crowdin**: Manages translation processes, including translating, proofreading, and setting language preferences.
-- **AI Systems**: Utilizes advanced AI to assist translators, ensuring smooth workflow.
+- **AI Systems**: Utilize advanced AI to assist translators, ensuring a smooth workflow.
 - **Customized Glossary**: This glossary guides translators and ensures AI generates accurate translations based on the project’s context. Users can also upload their glossaries as needed.
+- **Customized Glossary**: This glossary guides translators and ensures AI generates accurate translations based on the project’s context. Contributors can also upload their glossaries as needed.
 
 :::info
 This guide won't cover the entire process but will highlight the key components that make the TownSquare Labs Localization Program unique. You can explore the program further on your own.
@@ -26,35 +27,35 @@ Our repository utilizes several branches to manage documentation and translation
 - **`dev`**  
   The `dev` branch runs GitHub Actions to handle synchronization tasks. You can find the workflow configurations in the [**`.github/workflows`**](https://github.com/TownSquareXYZ/ton-docs/tree/dev/.github/workflows) directory:
 
-  - **`sync-fork.yml`**: This workflow synchronizes documentation from the upstream repository. It runs daily at 00:00.
+  - **`sync-fork.yml`**: This workflow synchronizes documentation from the upstream repository. It runs on a daily schedule.
   - **`sync-translations.yml`**: This workflow synchronizes updated translations to the respective language branches for preview purposes on the corresponding websites.
 
 - **`main`**  
-  This branch stays in sync with the upstream repository through GitHub Actions, which runs on the `dev` branch. It also updates specific codes we intend to propose to the original repository.
+  This branch stays in sync with the upstream repository through GitHub Actions, which runs on the `dev` branch. It also updates specific code we intend to propose to the original repository.
 
 - **`l10n_main`**  
-  This branch includes all changes from the `main` branch and translations from Crowdin. All modifications in this branch are periodically committed to the upstream repository using a new sub-branch named `l10n_main_[some data]`.
+  This branch includes all changes from the `main` branch and translations from Crowdin. All modifications in this branch are periodically committed to the upstream repository using a new sub-branch named `l10n_main_<suffix>`.
 
 - **`l10n_feat` or `l10n_feat_[specific functions]`**  
-  This branch will include changes to code or documentation related to the translation system. Once you finalize all content, the changes in this branch will be merged into `l10_main`.
+  This branch will include changes to code or documentation related to the translation system. Once you finalize all content, the changes in this branch will be merged into `l10n_main`.
 
 - **`[lang]_preview`**  
   These branches are designated for specific language previews, such as `ko_preview` for Korean and `ja_preview` for Japanese. They allow us to preview the website in different languages.
 
 By maintaining these branches and using GitHub Actions, we efficiently manage the synchronization of our documentation and translation updates, ensuring that our multilingual content is always up to date.
 
-## How to set up a new crowdin project
+## How to set up a new Crowdin project
 
 1. Log in to your [**Crowdin account**](https://accounts.crowdin.com/login).
 2. Click `Create new project` in the menu.
 ![Create new project](/img/localizationProgramGuideline/howItWorked/create-new-project.png)
-3. Set your Project name and Target languages. You can change the languages in the settings later.
+3. Set your `Project name` and `Target languages`. You can change the languages in the settings later.
 ![Create project setting](/img/localizationProgramGuideline/howItWorked/create-project-setting.png)
 4. Go to the project you just created, select the Integrations tab, click the `Add Integration` button, search for `GitHub`, and install it.
 ![install-github-integration](/img/localizationProgramGuideline/howItWorked/install-github-integration.png)
 5. Before configuring GitHub integrations on Crowdin, specify which files to upload to Crowdin to avoid uploading unnecessary files:
 
-    1. Create a **crowdin.yml** file in the root of **your GitHub repo** with the basic configuration:
+    1. Create a `crowdin.yml` file in the root of **your GitHub repo** with the basic configuration:
 
       ```yml
       project_id: <Your project id>
@@ -67,21 +68,21 @@ By maintaining these branches and using GitHub Actions, we efficiently manage th
     2. Get the correct configuration values:
         - **project_id**: In your Crowdin project, go to the Tools tab, select API, and find the **project_id** there.
         ![select-api-tool](/img/localizationProgramGuideline/howItWorked/select-api-tool.png)
-        ![projectId](/img/localizationProgramGuideline/howItWorked/projectId.png)
+        ![Project ID](/img/localizationProgramGuideline/howItWorked/projectId.png)
         - **preserve_hierarchy**: Maintains the GitHub directory structure on the Crowdin server.
         - **source** and **translation**: Specify the paths for the files to upload to Crowdin and where the translated files should be output.   
 
           For an example, refer to the [**config file**](https://github.com/TownSquareXYZ/ton-docs/blob/localization/crowdin.yml).   
-          Find more in the [**Crowdin configuration documentation**](https://developer.crowdin.com/configuration-file/).
+          Find more details in the [**Crowdin configuration documentation**](https://developer.crowdin.com/configuration-file/).
 
 6. Configure Crowdin to connect to your GitHub repo:
     1. Click `Add Repository` and select `Source and translation files mode`.
     ![select-integration-mode](/img/localizationProgramGuideline/howItWorked/select-integration-mode.png)
     2. Connect your GitHub account and search for the repo you want to translate.
     ![search-repo](/img/localizationProgramGuideline/howItWorked/search-repo.png)
-    3. Select the branch on the left to generate a new branch where Crowdin will post the translations.
+    3. Select the source branch and configure the branch where translations are pushed.
     ![setting-branch](/img/localizationProgramGuideline/howItWorked/setting-branch.png)
-    4. Choose the frequency for updating translations to your GitHub branch, then click save to enable the integration.
+    4. Choose the frequency for updating translations to your GitHub branch, then click `Save` to enable the integration.
     ![frequency-save](/img/localizationProgramGuideline/howItWorked/frequency-save.png)
 
 Find more details in the [**GitHub integration documentation**](https://support.crowdin.com/github-integration/).
@@ -92,7 +93,7 @@ Find more details in the [**GitHub integration documentation**](https://support.
 
 ### What is a glossary?
 
-Sometimes, AI translators can't recognize untranslatable and specific terms. For instance, we don't want "Rust" translated when referring to the programming language. To prevent such mistakes, we use a glossary to guide translations.
+Sometimes, AI translators can't recognize untranslatable or domain‑specific terms. For instance, we don't want "Rust" translated when referring to the programming language. To prevent such mistakes, we use a glossary to guide translations.
 
 A **glossary** allows you to create, store, and manage project-specific terminology in one place, ensuring that terms are translated correctly and consistently.
 
@@ -102,18 +103,19 @@ You can reference our [**ton-i18n-glossary**](https://github.com/TownSquareXYZ/t
 ### How to set up a glossary for a new language?
 
 Most translation platforms support glossaries. In Crowdin, after setting up a glossary, each term appears as an underlined word in the Editor. Hover over the term to see its translation, part of speech, and definition (if provided).
-![github-glossary](/img/localizationProgramGuideline/howItWorked/github-glossary.png)
-![crowdin-glossary](/img/localizationProgramGuideline/howItWorked/crowdin-glossary.png)
+![GitHub glossary](/img/localizationProgramGuideline/howItWorked/github-glossary.png)
+![Crowdin glossary](/img/localizationProgramGuideline/howItWorked/crowdin-glossary.png)
 
 In DeepL, upload your glossary, which will be used automatically during AI translation.
 
-We have created [**a program for glossary**](https://github.com/TownSquareXYZ/ton-i18n-glossary) that auto-uploads updates.
+We have created [**a program for the glossary**](https://github.com/TownSquareXYZ/ton-i18n-glossary) that auto-uploads updates.
 
 To add a term to the glossary:
-1. If the English term already exists in the glossary, find the corresponding line and column for the language you want to translate, input the translation, and upload it.
-2. To upload a new glossary, clone the project and run:
+1. If the English term already exists in the glossary, find the corresponding line and column for the language you want to translate, input the translation, and save your changes and submit them to the glossary repository per the contribution process.
+2. To upload a new glossary, clone the project, change into the cloned directory, and run:
 
 ```bash
+cd <cloned project directory>
 npm i
 ```
 ```bash
@@ -122,7 +124,7 @@ npm run generate -- <glossary name you want>
 
 Repeat step 1 to add the new term.
 
-## How to take advantage of AI translation copilot?
+## How to take advantage of AI translation copilot
 
 AI translation copilot helps break down language barriers with several advantages:
 
@@ -131,7 +133,7 @@ AI translation copilot helps break down language barriers with several advantage
 - **Robust Scalability**: AI systems continuously learn and improve, enhancing translation quality over time. 
 
 We use DeepL for AI translation in our Crowdin project:
-1. Select Machine Translation in the Crowdin menu and click edit on the DeepL line.
+1. Select `Machine Translation` in the Crowdin menu and click `Edit` on the DeepL line.
 ![select-deepl](/img/localizationProgramGuideline/howItWorked/select-deepl.png)
 2. Enable DeepL support and input the DeepL Translator API key.
       > [How to get DeepL Translator API key](https://www.deepl.com/pro-api?cta=header-pro-api)
@@ -140,12 +142,11 @@ We use DeepL for AI translation in our Crowdin project:
 
 3. Our DeepL setup uses a customized glossary. Check [**ton-i18n-glossary**](https://github.com/TownSquareXYZ/ton-i18n-glossary) for details on uploading the glossary.
 
-4. In the repo, click Pre-translation and select via Machine Translation.
+4. In Crowdin, click `Pre-translation` and select via `Machine Translation`.
 ![pre-translation](/img/localizationProgramGuideline/howItWorked/pre-translation.png)
-5. Choose DeepL as the Translation Engine, select the target languages, and select the translated files.
+5. Choose DeepL as the translation engine, select the target languages, and select the files to translate.
 ![pre-translate-config](/img/localizationProgramGuideline/howItWorked/pre-translate-config.png)
 
 That's it! Now, you can take a break and wait for the pre-translation to complete.
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-contribute-localization-program-how-it-works.mdx` into `main`.

Changed file(s):
- M: `docs/v3/contribute/localization-program/how-it-works.mdx`

Related issues (from issues.normalized.md):
- [ ] **356. Use "page" instead of "chapter" in intro**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-it-works.mdx?plain=1

Replace “This chapter provides …” with “This page provides …” (or “This guide provides …”) to reflect the document type.

---

- [ ] **357. Fix subject–verb agreement in "AI Systems" bullet**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-it-works.mdx?plain=1

Change “AI Systems: Utilizes advanced AI to assist translators, ensuring smooth workflow.” to “AI Systems: Utilize advanced AI to assist translators, ensuring a smooth workflow.”

---

- [ ] **358. Use "code" instead of "codes" in branches overview**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-it-works.mdx?plain=1

Change “updates specific codes we intend to propose” to “updates specific code we intend to propose.”

---

- [ ] **359. Clarify l10n_main sub-branch placeholder**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-it-works.mdx?plain=1

Replace the vague placeholder “l10n_main_[some data]” with a clear form like “l10n_main_<date>” or “l10n_main_<suffix>.”

---

- [ ] **360. Fix branch name to l10n_main**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-it-works.mdx?plain=1

Change the incorrect branch name “l10_main” to “l10n_main” for consistency.

---

- [ ] **361. Capitalize "Crowdin" in heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-it-works.mdx?plain=1

Update the H2 to “How to set up a new Crowdin project.”

---

- [ ] **362. Format "crowdin.yml" as code**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-it-works.mdx?plain=1

Change “Create a crowdin.yml file …” to “Create a `crowdin.yml` file …” to format the filename as code.

---

- [ ] **363. Say "Find more details" for clarity**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-it-works.mdx?plain=1

Change “Find more in the Crowdin configuration documentation” to “Find more details in the Crowdin configuration documentation.”

---

- [ ] **364. Format UI labels consistently (backticks + casing)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-it-works.mdx?plain=1

Wrap UI labels in backticks and use exact casing, e.g., `Save` (line 84), `Edit` (line 134), `Pre-translation`, `Machine Translation`, `Project name`, and `Target languages`.

---

- [ ] **365. Say "untranslatable or domain‑specific terms"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-it-works.mdx?plain=1

Change “can’t recognize untranslatable and specific terms” to “can’t recognize untranslatable or domain‑specific terms.”

---

- [ ] **366. Add article: "program for the glossary"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-it-works.mdx?plain=1

Change “a program for glossary that auto-uploads updates” to “a program for the glossary that auto‑uploads updates.”

---

- [ ] **367. Say "In Crowdin" for Pre-translation step**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-it-works.mdx?plain=1

Change “In the repo, click Pre-translation …” to “In Crowdin, click Pre-translation …”

---

- [ ] **368. Say "select the files to translate"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-it-works.mdx?plain=1

Change “select the translated files” to “select the files to translate.”

---

- [ ] **369. Clarify Crowdin branch selection wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-it-works.mdx?plain=1#how-to-set-up-a-new-crowdin-project

Replace “Select the branch on the left to generate a new branch where Crowdin will post the translations” with “Select the source branch and configure the branch where translations are pushed.”

---

- [ ] **370. Remove question mark from AI copilot heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-it-works.mdx?plain=1#how-to-take-advantage-of-ai-translation-copilot

Change the H2 to “How to take advantage of AI translation copilot” (no question mark) for consistency.

---

- [ ] **371. Improve image alt text casing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-it-works.mdx?plain=1

Make alt texts human‑readable and correctly cased, e.g., change “projectId” to “Project ID” and “github-glossary” to “GitHub glossary.”

---

- [ ] **372. Add cd step before npm commands**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-it-works.mdx?plain=1#glossary

After cloning the glossary project, add a step to change into the cloned directory before running commands, e.g., `cd <cloned project directory>` before `npm i` and `npm run generate -- <glossary name you want>`.

---

- [ ] **373. Clarify "upload it" destination for glossary term**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-it-works.mdx?plain=1#glossary

Replace the vague “upload it” with an explicit submission step, e.g., “save your changes and submit them to the glossary repository per the contribution process.”

---

- [ ] **374. Generalize schedule wording for sync-fork.yml**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-it-works.mdx?plain=1#branches-overview

Change “runs daily at 00:00” to a less brittle phrasing such as “runs on a daily schedule” (or verify the exact timing).

---

- [ ] **375. Use role term "contributors" instead of "Users"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-it-works.mdx?plain=1

Replace “Users can also upload their glossaries” with role‑consistent wording such as “Contributors can also upload their glossaries” (or the appropriate defined role).

---

- [ ] **376. Align branch prefix naming (l10n_feat vs i18n_feat)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-it-works.mdx?plain=1#branches-overview

Clarify or standardize the feature branch prefix (this page uses `l10n_feat` while another page uses `i18n_feat`); choose one convention and update this page accordingly.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.