### PR TITLE
Split: update docs/v3/contribute/localization-program/how-to-contribute.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/contribute/localization-program/how-to-contribute.mdx
+++ b/docs/v3/contribute/localization-program/how-to-contribute.mdx
@@ -10,7 +10,7 @@ Localization contribution is open to everyone. Here are a few steps you need to 
 
 1. Log in to your [Crowdin](https://crowdin.com) account or sign up.
 2. Select the language you want to contribute to.
-3. Familiarize yourself with the [How to use crowdin](/v3/contribute/localization-program/how-to-contribute/) guide and the [Translation style guide](/v3/contribute/localization-program/translation-style-guide/) for tips and best practices.
+3. Familiarize yourself with the [How it works](/v3/contribute/localization-program/how-it-works/) guide, the [Crowdin online editor guide](https://support.crowdin.com/online-editor/), and the [Translation style guide](/v3/contribute/localization-program/translation-style-guide/) for tips and best practices.
 4. Use machine translations to aid your work, but do not rely solely on them.
 5. Preview all translation results on the website after proofreading.
 
@@ -28,14 +28,14 @@ All tasks are performed in **side-by-side** mode in the Crowdin Editor. To enabl
 Here are the **roles** you can assume in the system:
 
 - **Language Coordinator** – Manages project features within assigned languages.
-- **Developer** – Uploads files, edits translatable text, connects integrations and uses the API.
+- **Developer** – Uploads files, edits translatable text, configures integrations and uses the API.
 - **Proofreader** – Translates and approves strings.
 - **Translator** (in-house or community) – Translates strings and votes on translations added by others.
 
 The localization project is hosted on [Crowdin](https://crowdin.com/project/ton-docs).
 
 
-### Language coordinator guidelines
+### Language Coordinator guidelines
 - Translate and approve strings
 - Pre-translate project content
 - Manage project members and join requests
@@ -47,16 +47,17 @@ The localization project is hosted on [Crowdin](https://crowdin.com/project/ton-
 
 ### Developer guidelines
 - **Update footer configuration for your language:**
-  1. Fork our [repository](https://github.com/TownSquareXYZ/ton-docs/tree/i18n_feat).
+  1. Fork our [repository](https://github.com/TownSquareXYZ/ton-docs/tree/l10n_feat).
   2. Locate the file [**`src/theme/Footer/config.ts`**](https://github.com/TownSquareXYZ/ton-docs/blob/main/src/theme/Footer/config.ts).
   3. Copy the value of the variable **`FOOTER_COLUMN_LINKS_EN`** to **`FOOTER_COLUMN_LINKS_[YOUR_LANG]`**.
-  4. Translate the values of the keys **`headerLangKey`** and **`langKey`** to your language, as we did for Mandarin in **`FOOTER_COLUMN_LINKS_CN`**.
+  4. Translate the values of the keys **`headerLangKey`** and **`langKey`** to your language, as we did for Chinese (zh) in **`FOOTER_COLUMN_LINKS_CN`**.
+  4. Translate the values of the keys **`headerLangKey`** and **`langKey`** to your language, as we did for Chinese (zh) in **`FOOTER_COLUMN_LINKS_CN`**.
   5. Add a new property to **`FOOTER_LINKS_TRANSLATIONS`**:
-      - Set **the key** as your [**ISO language code**](https://www.andiamo.co.uk/resources/iso-language-codes/) (**two letters**, **lowercase**).
+      - Set **the key** as your site locale key (e.g., `zh-CN`, `pt-BR`). Do not constrain to two lowercase letters.
       - **The value** should be the new variable you created for your language.
-  6. Run the command **`yarn start:local [YOUR_IOS_LANG_CODE]`** to preview the new footer in your language.   
+  6. Run the command **`yarn start:local [YOUR_ISO_LANG_CODE]`** to preview the new footer in your language.   
         (e.g., **`yarn start:local ru`** for a preview of the **Russian** footer)
-  7. If everything looks good, create a pull request to the **`i18n_feat`** branch.
+  7. If everything looks good, create a pull request to the **`l10n_feat`** branch.
 - **Upload files**
 - **Edit translatable text**
 - **Connect integrations** (e.g., add GitHub integration)
@@ -66,7 +67,7 @@ The localization project is hosted on [Crowdin](https://crowdin.com/project/ton-
 ### Proofreader guidelines
 
 As a **Proofreader**, you'll work on files with a **blue progress bar**.
-![proofread step1](/img/localizationProgramGuideline/proofread-step1.png)
+![Crowdin – Proofreader view with blue progress bar](/img/localizationProgramGuideline/proofread-step1.png)
 Click on a file to enter the editing interface.
 
 #### Contribution flow
@@ -87,11 +88,13 @@ You can also review the approved lines:
   2. If an approved line has issues, click the ☑️ button to revert it to needing proofreading.
 :::
 
-3. To move to the following file, click the file name at the top, select the new file from the pop-up window, and continue proofreading.
-![to next](/img/localizationProgramGuideline/redirect-to-next.png)
+3. To move to the next file, click the file name at the top, select the new file from the pop-up window, and continue proofreading.
+![Select next file dialog](/img/localizationProgramGuideline/redirect-to-next.png)
+3. To move to the next file, click the file name at the top, select the new file from the pop-up window, and continue proofreading.
+![Select next file dialog](/img/localizationProgramGuideline/redirect-to-next.png)
 
 #### Previewing your work
-The preview website displays all approved content within one hour. Check [**our repo**](https://github.com/TownSquareXYZ/ton-docs/pulls) for the **preview** link in the newest PR.
+The preview website displays approved content after synchronization. Check [**our repo**](https://github.com/TownSquareXYZ/ton-docs/pulls) for the **preview** link in the newest PR.
 ![preview link](/img/localizationProgramGuideline/preview-link.png)
 
 ### Translator guidelines
@@ -108,7 +111,7 @@ Follow these steps for a successful translation process:
 2. Ensure you're in [**side-by-side mode**](#side-by-side-mode). Filter by **Untranslated** strings.
 ![translator filter](/img/localizationProgramGuideline/translator-filter.png)
 
-3. Your workspace has four parts:
+3. Your workspace has three parts:
    - **Top left:** Input your translation based on the source string.
    - **Bottom left:** Preview the translated file. Maintain the original format.
    - **Bottom right:** Suggested translations from Crowdin. Click to use, but verify for accuracy, especially with links.
@@ -124,13 +127,12 @@ Follow these steps for a successful translation process:
 If you are a community manager, follow these steps:
 
 1. Add a new branch named `[lang]_localization` (e.g., `ko_localization` for Korean) on [TownSquareXYZ/ton-docs](https://github.com/TownSquareXYZ/ton-docs).
-2. **Contact the Vercel owner of this repo** to add the new language to the menu.
-3. Create a PR request to the dev branch. **Do not merge to dev**; this is for preview purposes only.
+2. Open an issue in this repository requesting the language be added to the site menu (or contact the Vercel owner for menu updates).
+3. Open a pull request from `[lang]_localization` to `dev`; do not merge—this PR is for preview only.
 
 Once you complete these steps, you can see the preview of your language in the PR request.
 ![ko preview](/img/localizationProgramGuideline/ko_preview.png)
 
-When your language is ready for the TON docs, create an issue, and we'll set your language into the production environment.
+When your language is ready for the TON docs, create an issue, and we'll enable your language in the production environment.
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-contribute-localization-program-how-to-contribute.mdx` into `main`.

Changed file(s):
- M: `docs/v3/contribute/localization-program/how-to-contribute.mdx`

Related issues (from issues.normalized.md):
- [ ] **377. Fix prerequisite link and capitalize Crowdin**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-to-contribute.mdx?plain=1#L13

Replace the self-link with [How it works](/v3/contribute/localization-program/how-it-works/) and capitalize "Crowdin" in the surrounding text.

---

- [ ] **378. Replace "connects integrations" with natural verb**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-to-contribute.mdx?plain=1#L31

Change "connects integrations" to "configures integrations" for natural phrasing.

---

- [ ] **379. Use "Chinese (zh)" terminology in examples**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-to-contribute.mdx?plain=1#L53-L56

In prose and examples, refer to the language as "Chinese (zh)" and use "zh" when mentioning language codes; keep repository identifiers like FOOTER_COLUMN_LINKS_CN unchanged.

---

- [ ] **380. Align mapping key guidance to ISO codes**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-to-contribute.mdx?plain=1#L55-L56

Update the guide and implementation to use ISO 639-1 codes for mapping (e.g., map "zh" to the Chinese footer config instead of "mandarin") so the docs and code match.

---

- [ ] **381. Correct "IOS" to "ISO" in placeholder**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-to-contribute.mdx?plain=1#L57

Replace "[YOUR_IOS_LANG_CODE]" with "[YOUR_ISO_LANG_CODE]" (ISO language code).

---

- [ ] **382. Use "next file" consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-to-contribute.mdx?plain=1#L90, #L119

Use "next file" phrasing in both instances (e.g., "To move to the next file, ...") for consistency.

---

- [ ] **383. Correct workspace parts count**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-to-contribute.mdx?plain=1#L111-L114

Change "Your workspace has four parts:" to "Your workspace has three parts:" to match the listed items (unless a fourth part is added).

---

- [ ] **384. Replace "PR request" and improve preposition**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-to-contribute.mdx?plain=1#L128

Replace "Create a PR request" with "Create a PR" or "Create a pull request," and change "Do not merge to dev" to "Do not merge into dev."

---

- [ ] **385. Use "in the production environment" phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-to-contribute.mdx?plain=1#L133

Rephrase "we'll set your language into the production environment" to "we'll enable your language in the production environment."

---

- [ ] **4492. Fix Crowdin prerequisites link and style guide URL**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-to-contribute.mdx?plain=1

In Prerequisites step 3, replace the circular self-link and wrong text “How to use crowdin” with “Crowdin online editor guide” linking to https://support.crowdin.com/online-editor/, capitalize “Crowdin,” and use the canonical Translation style guide path without a trailing slash: /v3/contribute/localization-program/translation-style-guide.

---

- [ ] **4493. Capitalize role in heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-to-contribute.mdx?plain=1

Change the heading “Language coordinator guidelines” to “Language Coordinator guidelines” to match role capitalization used elsewhere.

---

- [ ] **4494. Align branch name to l10n_feat**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-to-contribute.mdx?plain=1

In Developer guidelines steps 1 and 7, replace “i18n_feat” with “l10n_feat” to match the documented branch naming.

---

- [ ] **4495. Fix ISO placeholder typo**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-to-contribute.mdx?plain=1

Change “YOUR_IOS_LANG_CODE” to “YOUR_ISO_LANG_CODE” in Developer guidelines step 6.

---

- [ ] **4496. Correct parts count in translator workspace**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-to-contribute.mdx?plain=1

Change “Your workspace has four parts” to “three parts” to match the three listed areas (Top left, Bottom left, Bottom right).

---

- [ ] **4497. Remove unverified ‘within one hour’ SLA**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-to-contribute.mdx?plain=1

Replace “The preview website displays all approved content within one hour.” with a non-time-specific statement such as “The preview website displays approved content after synchronization.”

---

- [ ] **4498. Replace vague contact instruction with actionable step**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-to-contribute.mdx?plain=1

Change “Contact the Vercel owner of this repo” to “Open an issue in this repository requesting the language be added to the site menu” (or specify a concrete, maintained contact channel).

---

- [ ] **4499. Clarify pull request instruction**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-to-contribute.mdx?plain=1

Replace “Create a PR request to the dev branch” with “Open a pull request from [lang]_localization to dev; do not merge—this PR is for preview only.”

---

- [ ] **4500. Standardize terminology to ‘Chinese (Simplified)’**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-to-contribute.mdx?plain=1

Replace “Mandarin” with “Chinese (Simplified)” to align with the style guide (e.g., zh-CN).

---

- [ ] **4501. Improve non-descriptive image alt text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-to-contribute.mdx?plain=1

Replace terse alts like “proofread step1,” “to next,” and “manage-members” with descriptive, context-aware text (e.g., “Crowdin – Proofreader view with blue progress bar,” “Select next file dialog,” “Crowdin – Manage project members screen”) to improve accessibility.

---

- [ ] **4502. Correct ISO code guidance**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/how-to-contribute.mdx?plain=1

Replace “ISO language code should be two letters, lowercase” with guidance that matches actual locale keys, e.g., “Use the site locale key (e.g., zh-CN, pt-BR); do not constrain to two lowercase letters.”

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.