### PR TITLE
Split: update docs/v3/contribute/localization-program/translation-style-guide.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/contribute/localization-program/translation-style-guide.mdx
+++ b/docs/v3/contribute/localization-program/translation-style-guide.mdx
@@ -8,11 +8,11 @@ This document serves as a general guide and is not specific to any language.
 
 ## Capturing the essence of the message
 
-When translating TON docs content, avoid literal translations.
+When translating TON Docs content, avoid literal translations.
 
 The translations must capture the essence of the message. This approach means rephrasing specific phrases or using descriptive translations instead of translating the content word for word.
 
-Different languages have different grammar rules, conventions, and word order. When translating, please be mindful of structuring sentences in the target languages, and avoid word-for-word translation of the English source, as this can lead to poor sentence structure and readability.
+Different languages have different grammar rules, conventions, and word order. When translating, please be mindful of structuring sentences in the target language, and avoid word-for-word translation of the English source, as this can lead to poor sentence structure and readability.
 
 Instead of translating the source text word for word, you should read the entire sentence and adapt it to fit the conventions of the target language.
 
@@ -32,24 +32,22 @@ In most cases, contributors can achieve this result by using short and simple wo
 
 ## Writing system
 
-All of the content should be translated using the correct writing system for your language and should not include any words written using Latin characters.
+Translate using your language’s writing system, except for standard acronyms, brand names, ISO codes, and proper names defined in the [Glossary](/v3/concepts/glossary).
 
-When translating the content, you should ensure that the translations are consistent and do not include any Latin characters.
-
-**Do not translate proper names defined by glossary**
+**Do not translate proper names defined in the [Glossary](/v3/concepts/glossary).**
 
 ## Translating page metadata
 
-Some pages contain metadata, such as 'title', 'lang', 'description', 'sidebar', etc.
+Some pages contain metadata, such as `title`, `lang`, `description`, `sidebar`, etc.
 
-When uploading new pages to Crowdin, we hide content that translators should never translate. This feature makes visible to translators in Crowdin only the text that should be translated.
+When uploading new pages to Crowdin, we hide content that translators should never translate. This feature makes only the text that should be translated visible to translators in Crowdin.
 
-Please be especially careful when translating strings where the source text is 'en'. This represents the language page, which is available and should be translated to the [ISO language code for your language](https://www.andiamo.co.uk/resources/iso-language-codes/). These strings should always be translated using Latin characters, not the writing script, native to the target language.
+Please be especially careful when translating strings where the source text is 'en'. This represents the language page, which is available and should be translated to the [ISO language code for your language](https://www.andiamo.co.uk/resources/iso-language-codes/). These strings should always be entered using Latin characters, not the writing system native to the target language.
 
 Some examples of language codes for the most widely spoken languages:
 
 - English - en
-- Chinese Simplified - zh-CN
+- Simplified Chinese - zh-CN
 - Russian - ru
 - Korean - ko
 - Polish - pl
@@ -83,7 +81,7 @@ Example of how to translate DApps:
 
 Some terms might not have established translations in other languages but are widely known by their original English names. Such terms include newer concepts, like proof-of-work, proof-of-stake, Beacon Chain, staking, etc.
 
-While translating these terms can sound unnatural, since the English version is a basis for other languages, it is highly recommended that they be translated.
+While translating these terms can sound unnatural, since the English version serves as the basis for other languages, it is highly recommended that they be translated.
 
 Feel free to get creative, use descriptive translations, or translate them literally.
 
@@ -91,15 +89,15 @@ Most terms should be translated instead of leaving some in English, as this new 
 
 ## Buttons & CTAs
 
-Do not translate the website's contents, such as buttons.
+Translate the website’s UI text, including buttons.
 
-You may identify button text by viewing the context screenshots connected with most strings or by checking the context in the editor, which includes the phrase ‘’button’’.
+You may identify button text by viewing the context screenshots connected with most strings or by checking the context in the editor, which includes the phrase `button`.
 
 Button translations should be as short as possible to prevent formatting mismatches. Additionally, button translations, i.e., presenting a command or request, should be imperative.
 
 ## Translating for inclusivity
 
-TON docs visitors come from all over the world and from different backgrounds. Therefore, the language on the website should be neutral, welcoming to everyone, and not exclusive.
+TON Docs visitors come from all over the world and from different backgrounds. Therefore, the language on the website should be neutral, welcoming to everyone, and not exclusive.
 
 Gender neutrality is an essential aspect of this. Use the formal address form and avoid gender-specific words in the translations.
 
@@ -111,11 +109,11 @@ Finally, the language should be suitable for all audiences and ages.
 
 When translating, it is crucial to follow the grammar rules, conventions, and formatting used in your language instead of copying from the source. The source text follows English grammar rules and conventions, which do not apply to many other languages.
 
-You should be aware of the rules for your language and translate accordingly. If you need help, contact us; we will help you with resources on translating elements for your language.
+You should be aware of the rules for your language and translate accordingly. If you need help, [contact us](https://t.me/+c-0fVO4XHQsyOWM8); we will help you with resources on translating elements for your language.
 
 Some examples of what to be particularly mindful of:
 
-### Punctuation, formatting
+### Punctuation and formatting
 
 #### Capitalization
 
@@ -126,11 +124,7 @@ Some examples of what to be particularly mindful of:
 #### Spacing
 
 - Orthography rules define the use of spaces for each language. Because spaces are used everywhere, these rules are some of the most distinct, and spaces are some of the most mistranslated elements.
-- Some common differences in spacing between English and other languages:
-  - Space before units of measure and currencies. Example: USD, EUR, kB, MB
-  - Space before degree signs. Example: °C, ℉
-  - Space before some punctuation marks, especially the ellipsis. Example: Then… in summary
-  - Space before and after slashes. Example: if / else
+You should be aware that spacing rules vary by language. Spacing before units, degree signs, certain punctuation (e.g., the ellipsis), and around slashes differs across languages. Follow your language’s orthographic rules.
 
 #### Lists
 
@@ -151,8 +145,8 @@ Some examples of what to be particularly mindful of:
 
 #### Hyphens and dashes
 
-- In English, a hyphen `-` is used to join words or different parts of a word, while a dash `—` indicates a range or a pause.
-  - Example: TON — is ... proof-of-stake.
+- In English, use an en dash (–) for ranges and an em dash (—) for pauses.
+  - Example: Use an em dash—like this—to indicate a pause.
 - Many languages have different rules for using hyphens and dashes that should be observed.
 
 ### Formats
@@ -166,7 +160,7 @@ Some examples of what to be particularly mindful of:
     - French – **1 000,50**
 - The percent sign is another critical consideration when translating numbers. Write numbers in the typical format for the corresponding language.
   - Example: **100%**, **100 %**, or **%100**.
-- Finally, negative numbers can be displayed differently, depending on the language
+- Finally, negative numbers can be displayed differently, depending on the language.
   - Example: -100, 100-, (100) or [100].
 
 #### Dates


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-contribute-localization-program-translation-style-guide.mdx` into `main`.

Changed file(s):
- M: `docs/v3/contribute/localization-program/translation-style-guide.mdx`

Related issues (from issues.normalized.md):
- [ ] **397. Capitalize “TON Docs” consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/translation-style-guide.mdx?plain=1#L11,L102

Replace “TON docs” with “TON Docs” throughout the page for consistency with house style.

---

- [ ] **398. Use singular “target language”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/translation-style-guide.mdx?plain=1#L15

Change “the target languages” to “the target language” for grammatical consistency.

---

- [ ] **399. Narrow ban on Latin characters in “Writing system”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/translation-style-guide.mdx?plain=1#L35-L37

Replace the blanket ban with “Translate using your language’s writing system, except for standard acronyms, brand names, ISO codes, and proper names defined in the [Glossary](/v3/concepts/glossary).”

---

- [ ] **400. Add article and link in glossary note**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/translation-style-guide.mdx?plain=1#L39

Change “Do not translate proper names defined by glossary” to “Do not translate proper names defined in the [Glossary](/v3/concepts/glossary).”

---

- [ ] **401. Code-format metadata keys**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/translation-style-guide.mdx?plain=1#L43

Format metadata keys as code literals: `title`, `lang`, `description`, `sidebar`, etc., instead of quotes.

---

- [ ] **402. Fix word order in Crowdin note**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/translation-style-guide.mdx?plain=1#L45

Change to “This feature makes only the text that should be translated visible to translators in Crowdin.”

---

- [ ] **403. Use “writing system” and say “entered”; remove comma**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/translation-style-guide.mdx?plain=1#L47

Replace “writing script, native to the target language” with “writing system native to the target language,” and change “should always be translated using Latin characters” to “should always be entered using Latin characters.”

---

- [ ] **404. Use “and” in heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/translation-style-guide.mdx?plain=1#L49

Change “### Punctuation, formatting” to “### Punctuation and formatting.”

---

- [ ] **405. Use “Simplified Chinese”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/translation-style-guide.mdx?plain=1#L52

Change “Chinese Simplified – zh‑CN” to “Simplified Chinese – zh‑CN.”

---

- [ ] **406. Replace misleading spacing examples**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/translation-style-guide.mdx?plain=1#L61-L64

Replace the bullets with a single advisory that spacing before units, degree signs, certain punctuation (e.g., ellipsis), and around slashes varies by language; instruct translators to follow their language’s orthographic rules.

---

- [ ] **407. Add “the” before “end punctuation”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/translation-style-guide.mdx?plain=1#L64

Change “forget end punctuation” to “forget the end punctuation.”

---

- [ ] **408. Clarify abbreviation guidance; keep English abbreviations**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/translation-style-guide.mdx?plain=1#L72-L76

Resolve the contradiction by stating not to translate English abbreviations into localized forms; provide a descriptive translation and keep the English abbreviation in brackets.

---

- [ ] **409. Say “serves as the basis”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/translation-style-guide.mdx?plain=1#L86

Replace “since the English version is a basis for other languages” with “since the English version serves as the basis for other languages.”

---

- [ ] **410. Translate UI text (buttons)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/translation-style-guide.mdx?plain=1#L94

Replace “Do not translate the website's contents, such as buttons.” with “Translate the website’s UI text, including buttons.”

---

- [ ] **411. Code-format literal “button”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/translation-style-guide.mdx?plain=1#L96

Replace the mismatched quotes around the word with code formatting: `button`.

---

- [ ] **412. Link “contact us” to TON Docs Club chat**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/translation-style-guide.mdx?plain=1#L116

Link “contact us” to the TON Docs Club Telegram chat referenced in docs/v3/contribute/README.mdx.

---

- [ ] **413. Fix degree symbols and temperature notation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/translation-style-guide.mdx?plain=1#L131,L195

Use the degree sign (°) not the masculine ordinal indicator; change mixed examples to “°C, °F” and update “50ºF”/“50 ºF” to “50°F”/“50 °F” consistently.

---

- [ ] **414. Differentiate en dash vs em dash; replace example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/translation-style-guide.mdx?plain=1#L154-L155

Specify “Use an en dash (–) for ranges and an em dash (—) for pauses,” and replace the ungrammatical example with “Use an em dash—like this—to indicate a pause.”

---

- [ ] **415. Add missing period**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/translation-style-guide.mdx?plain=1#L169

Add a period at the end of “Finally, negative numbers can be displayed differently, depending on the language.”

---

- [ ] **416. Standardize English date examples**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/translation-style-guide.mdx?plain=1#L176-L177

Use “1 January 2022” for UK English and “January 1, 2022” for US English (no ordinals); update the examples accordingly.

---

- [ ] **417. Neutralize currency examples; note locale variance**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/localization-program/translation-style-guide.mdx?plain=1#L186-L190

Replace inconsistent currency samples with neutral contrasts (e.g., “$100” vs “100 €”; “$100.50” vs “100,50 €”) and add a note that symbol placement and spacing are language-dependent.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.