### PR TITLE
Split: update docs/v3/contribute/maintainers.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/contribute/maintainers.mdx
+++ b/docs/v3/contribute/maintainers.mdx
@@ -4,7 +4,7 @@ import Feedback from '@site/src/components/Feedback';
 
 ## Active team
 
-Below is an alphabetical list of the current members of the TON documentation team.
+Below is the current member of the TON documentation team.
 
 ### Alex Golev
 
@@ -13,13 +13,13 @@ Onboarding Lead at TON Studio
 -   Telegram: [@alexgton](https://t.me/alexgton)
 -   GitHub: [Reveloper](https://github.com/Reveloper)
 
-## Acknowledgements
+## Acknowledgments
 
 TON documentation was created by [tolya-yanot](https://github.com/tolya-yanot) and [EmelyanenkoK](https://github.com/EmelyanenkoK).
 
-Over time, TON documentation has benefitted from the intellect and dedication of [numerous external contributors](https://github.com/ton-community/ton-docs/graphs/contributors). We extend our heartfelt gratitude to each of them.
+Over time, TON documentation has benefited from the intellect and dedication of [numerous external contributors](https://github.com/ton-community/ton-docs/graphs/contributors). We extend our heartfelt gratitude to each of them.
 
-However, we would like to acknowledge the substantial contributions made by the following individuals especially. Their respective contributions have greatly enriched the quality and depth of our documentation:
+In particular, we acknowledge the substantial contributions of the following individuals. Their respective contributions have greatly enriched the quality and depth of our documentation:
 
 -   [akifoq](https://github.com/akifoq): early contributions
 -   [amnch1](https://github.com/amnch1): fixes
@@ -33,8 +33,8 @@ However, we would like to acknowledge the substantial contributions made by the 
 -   [ProgramCrafter](https://github.com/ProgramCrafter): content
 -   [siandreev](https://github.com/siandreev): content
 -   [SpyCheese](https://github.com/SpyCheese): early contributions
--   [SwiftAdviser](https://github.com/SwiftAdviser): content, user-friendly docs inventor
--   [Tal Kol](https://github.com/talkol): early contributions
+-   [SwiftAdviser](https://github.com/SwiftAdviser): content; documentation usability improvements
+-   [talkol](https://github.com/talkol): early contributions
 -   [TrueCarry](https://github.com/TrueCarry): content
 -   [xssnick](https://github.com/xssnick): content
 
@@ -48,4 +48,3 @@ We sincerely appreciate each contributor who has helped make TON documentation a
 - [Localization program](/v3/contribute/localization-program/overview/)
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-contribute-maintainers.mdx` into `main`.

Changed file(s):
- M: `docs/v3/contribute/maintainers.mdx`

Related issues (from issues.normalized.md):
- [ ] **418. Use American spelling in heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/maintainers.mdx?plain=1#L16

Change the H2 heading "Acknowledgements" to "Acknowledgments" to follow American English per the style guide.

---

- [ ] **419. Use "benefited" (American spelling)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/maintainers.mdx?plain=1#L20

Replace "has benefitted" with "has benefited" (American English, single “t”).

---

- [ ] **420. Rephrase sentence ending with "especially"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/maintainers.mdx?plain=1#L22

Replace the sentence ending in "especially" with "In particular, we acknowledge the substantial contributions of the following individuals." to improve clarity and emphasis.

---

- [ ] **421. Clarify "user-friendly docs inventor" descriptor**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/maintainers.mdx?plain=1#L36

Replace "user-friendly docs inventor" with "content; documentation usability improvements" for clarity and consistency (e.g., "- [SwiftAdviser](https://github.com/SwiftAdviser): content; documentation usability improvements").

---

- [ ] **422. Standardize link text to GitHub username**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/maintainers.mdx?plain=1#L37

Use the GitHub username as the link text for consistency (e.g., change to "- [talkol](https://github.com/talkol): early contributions").

---

- [ ] **423. Fix pluralization of "members"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/maintainers.mdx?plain=1

If only one person is listed, change the sentence to "Below is the current member of the TON documentation team."

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.