### PR TITLE
Split: update docs/v3/contribute/participate.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/contribute/participate.mdx
+++ b/docs/v3/contribute/participate.mdx
@@ -1,56 +1,48 @@
 import Feedback from '@site/src/components/Feedback';
 
 
-# Contribution Guide
+# Participate: Tutorials
 
-:::danger
-This page is outdated and will be deleted soon.
-See the [How to contribute](/v3/contribute/).
-:::
-
-Here is a step-by-step guide of contributing to TON Documentation with Tutorials.
+Here is a step-by-step guide to contributing to the TON documentation with tutorials.
 
 :::tip opportunity
-You're lucky! It's a good opportunity to improve TON Ecosystem here.
+It's a good opportunity to improve the TON Ecosystem here.
 :::
 
-If you decide to write tutorial, you can get some reward for outstanding materials:
-- **Special TON Bounty NFT** for the most valuable contributing to TON
-- **Reward in TON** as payment for approved high-quality contribution like tutorial
+If you decide to write a tutorial, see the [TON Bounties program](https://github.com/ton-society/grants-and-bounties) for details on rewards.
 
-Let's see how you can participate in contributing process.
+Let's see how you can participate in the contribution process.
 
 ## Decide what you want to write
 
-Find or write a material which you want to describe.
+Find or write material you want to cover.
 1. Check a [list of issues on TON Docs GitHub](https://github.com/ton-community/ton-docs/issues) with `tutorial` label.
-2. _OR_ write your own idea on TON Docs GitHub with [tutorial template](https://github.com/ton-community/ton-docs/issues/new?assignees=&labels=feature+%3Asparkles%3A%2Ccontent+%3Afountain_pen%3A&template=suggest_tutorial.yaml&title=Suggest+a+tutorial).
+2. Alternatively, propose your own idea on TON Docs GitHub using the [tutorial template](https://github.com/ton-community/ton-docs/issues/new?assignees=&labels=feature+%3Asparkles%3A%2Ccontent+%3Afountain_pen%3A&template=suggest_tutorial.yaml&title=Suggest+a+tutorial).
 
 ## Describe a problem to get a reward
 
-Write a _ton-footstep_ to receive a funding for your contributing.
-1. Read about [TON Bounties](https://github.com/ton-society/grants-and-bounties/blob/main/bounties/BOUNTIES_PROGRAM_GUIDELINES.md) program more detailed.
-    1. **TLDR:** Use [Improve TVM Instructions article](https://github.com/ton-society/grants-and-bounties/issues/361) as an example.
-2. Write [your own bounty](https://github.com/ton-society/grants-and-bounties/issues/new/choose) to participate and wait for approve. [TON Bounties Creator Bot](https://t.me/footsteps_helper_bot) will help you.
-3. After received `approved` label start to write your tutorial.
+Create a TON Footsteps issue to request funding for your contribution.
+1. Read about the [TON Bounties](https://github.com/ton-society/grants-and-bounties/blob/main/bounties/BOUNTIES_PROGRAM_GUIDELINES.md) program in more detail.
+    1. **TL;DR:** Use the [Improve TVM Instructions article](https://github.com/ton-society/grants-and-bounties/issues/361) as an example.
+2. Write [your own bounty](https://github.com/ton-society/grants-and-bounties/issues/new/choose) to participate and wait for approval. [TON Bounties Creator Bot](https://t.me/footsteps_helper_bot) will help you.
+3. After receiving the `approved` label, start writing your tutorial.
 
 ## Writing a tutorial
 
 **Preparations**. Minimize future amount of requested changes, _save your time_:
-1. Follow [Tutorial Guidelines](/v3/contribute/contribution-rules) and check them with [Sample Tutorial Structure](/v3/contribute/tutorials/sample-tutorial)
-2. Read [Principles of a Good Tutorial](/v3/contribute/tutorials/principles-of-a-good-tutorial) to write amazing tutorial :)
-3. Inspire with [Mint your first Jetton](/v3/guidelines/dapps/tutorials/mint-your-first-token) example in sources.
-4. **Setup environment**. [Check the tutorial](/v3/contribute#online-one-click-contribution-setup) running your fork locally or using Gitpod.
-5. **Write tutorial**. Using the environment, see how tutorial looks like on your fork.
+1. Follow [Tutorial Guidelines](/v3/contribute/tutorials/guidelines/) and check them with [Sample Tutorial Structure](/v3/contribute/tutorials/sample-tutorial)
+2. Read [Principles of a Good Tutorial](/v3/contribute/tutorials/principles-of-a-good-tutorial) to write an amazing tutorial.
+3. Get inspired by the [‘Mint your first jetton’](/v3/guidelines/dapps/tutorials/mint-your-first-token) example in the sources.
+4. **Setup environment**. [Check the tutorial](/v3/contribute/#development) running your fork locally or using Gitpod.
+5. **Write the tutorial**; use the environment to preview how it looks on your fork.
 6. **Make a Pull Request**. Open PR to get some feedback from maintainers.
 7. Get merged!
 
 ## Receiving a reward
 
-1. After your PR in TON Docs got merged, please write in your ton-footsteps task.
-2. Follow a guide [How to complete ton-bounty?](https://github.com/ton-society/grants-and-bounties/blob/main/bounties/BOUNTIES_PROGRAM_GUIDELINES.md#got-assigned-submit-a-questbook-proposal) to complete bounty and get reward.
-3. In your task, you will be asked for a wallet to send a reward.
+1. After your PR to TON Docs has been merged, please comment in your TON Footsteps task.
+2. Follow the guide 'How to complete TON bounty' (https://github.com/ton-society/grants-and-bounties/blob/main/bounties/BOUNTIES_PROGRAM_GUIDELINES.md#got-assigned-submit-a-questbook-proposal) to complete the bounty and receive a reward.
+3. In your task, you will be asked for a wallet address to send the reward.
 4. Get rewarded!
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-contribute-participate.mdx` into `main`.

Changed file(s):
- M: `docs/v3/contribute/participate.mdx`

Related issues (from issues.normalized.md):
- [ ] **424. Rename title for clarity**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1#L4

Rename the page title from "Contribution Guide" to "Participate: Tutorials" to reduce ambiguity with nearby pages.

---

- [ ] **425. Remove outdated danger callout**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1#L6-L9

Remove the top “outdated” danger note that redirects to How to contribute, since this page provides its own current guidance.

---

- [ ] **426. Fix intro sentence and capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1#L11

Change “Here is a step-by-step guide of contributing to TON Documentation with Tutorials.” to “Here is a step-by-step guide to contributing to the TON documentation with tutorials.”

---

- [ ] **427. Add article in 'write a tutorial'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1#L17

Change “If you decide to write tutorial” to “If you decide to write a tutorial”.

---

- [ ] **428. Fix 'most valuable contributing' grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1#L18

Change “for the most valuable contributing to TON” to “for the most valuable contribution to TON”.

---

- [ ] **429. Remove unsupported reward claims and link to bounty page**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1#L19

Remove the “Reward in TON …” and any NFT reward claims and instead link readers to the canonical bounty program page for details on rewards.

---

- [ ] **430. Use 'contribution process' phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1#L21

Change “participate in contributing process” to “participate in the contribution process”.

---

- [ ] **431. Simplify 'Find or write a material'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1#L25

Change “Find or write a material which you want to describe.” to “Find or write material you want to cover.”

---

- [ ] **432. Rephrase alternative idea sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1#L27

Change “OR write your own idea on TON Docs GitHub with tutorial template” to “Alternatively, propose your own idea on TON Docs GitHub using the tutorial template.”

---

- [ ] **433. Standardize to 'TON Footsteps' and fix funding sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1#L31

Replace “ton-footstep” with “TON Footsteps” and reword to “Create a TON Footsteps issue to request funding for your contribution.”

---

- [ ] **434. Use 'in more detail' phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1#L32

Change “program more detailed” to “program in more detail”.

---

- [ ] **435. Use 'TL;DR:' formatting**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1#L33

Change “TLDR:” to “TL;DR:”.

---

- [ ] **436. Change 'wait for approve' to 'wait for approval'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1#L34

Replace “wait for approve” with “wait for approval”.

---

- [ ] **437. Fix 'After received …' sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1#L35

Change “After received `approved` label start to write your tutorial.” to “After receiving the `approved` label, start writing your tutorial.”

---

- [ ] **438. Fix 'Tutorial Guidelines' link target**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1#L40

Update the “Tutorial Guidelines” link target from “/v3/contribute/contribution-rules” to “/v3/contribute/tutorials/guidelines/”.

---

- [ ] **439. Remove emoticon and add article**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1#L41

Change “to write amazing tutorial :)” to “to write an amazing tutorial.”

---

- [ ] **440. Fix 'Jetton' example wording and casing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1#L42

Change to “Get inspired by the ‘Mint your first jetton’ example in the sources.”

---

- [ ] **441. Fix setup link anchor**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1#L43

Replace the broken “/v3/contribute#online-one-click-contribution-setup” link with “/v3/contribute/#development”.

---

- [ ] **442. Improve 'Write tutorial' preview sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1#L44

Change “Write tutorial. Using the environment, see how tutorial looks like on your fork.” to “Write the tutorial; use the environment to preview how it looks on your fork.”

---

- [ ] **443. Clarify PR step and add article**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1#L45

Change to “Open a pull request against main with a clear description to get feedback from maintainers.”

---

- [ ] **444. Fix post-merge instruction and Footsteps casing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1#L50

Change to “After your PR to TON Docs has been merged, please comment in your TON Footsteps task.”

---

- [ ] **445. Fix TON bounty naming and reward phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1#L51

Change to “Follow the guide ‘How to complete TON bounty’ … to complete the bounty and receive a reward.” (capitalize TON and remove the question mark in the link text).

---

- [ ] **446. Clarify 'asked for a wallet' phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1#L52

Change “asked for a wallet to send a reward” to “asked for a wallet address to send the reward”.

---

- [ ] **447. Align bounty program references to TON Footsteps**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1

Standardize this page to reference the TON Footsteps program for documentation bounties and update links/names accordingly, removing or contextualizing any “TON Bounties” references.

---

- [ ] **448. Enforce neutral tone and 'TON Ecosystem' capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/participate.mdx?plain=1

Remove colloquialisms (e.g., “You're lucky!”) and ensure “TON Ecosystem” is capitalized per the style guide.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.