### PR TITLE
Split: update docs/v3/contribute/tutorials/guidelines.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/contribute/tutorials/guidelines.mdx
+++ b/docs/v3/contribute/tutorials/guidelines.mdx
@@ -1,6 +1,6 @@
 import Feedback from '@site/src/components/Feedback';
 
-# Tutorial Styling Guidelines
+# Tutorial styling guidelines
 
 :::danger
 This page is outdated and will be updated soon.
@@ -19,15 +19,15 @@ It is important that you take some time to become familiar with the tutorial str
 Before you start writing, *read the guidelines below*! They will help you ensure the level of standardization and quality that will make the review process much faster.
 :::
 
-Also, be sure to refer to the [**sample tutorial structure**](/v3/contribute/tutorials/sample-tutorial) we have provided.
+Also, be sure to refer to the [**sample tutorial structure**](/v3/contribute/tutorials/sample-tutorial/) we have provided.
 
 
 1. To begin, fork and then clone the [ton-docs](https://github.com/ton-community/ton-docs/) repository on GitHub and create a new branch in your local repository.
 2. Write your tutorial keeping quality and readability in mind! Have a look at the existing tutorials to see what you should aim for.
 3. When you're ready to submit it for review, [open a Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) from your branch. We will be notified, and the review process will begin:
     1. **Please make every effort to submit only the final draft of your tutorial**. Some typos and grammar fixes are acceptable, but if there are significant changes to be made before we can publish the tutorial, it will take much longer to review and have you make the necessary changes.
-4. Once we've reviewed your submission and you've made all necessary changes, we'll merge the Pull Request and publish the tutorial on TON Documentation. We'll contact you shortly after this to arrange your payment!
-5. Once it is published, remember to **promote** your tutorial on social media! The [documentation maintainers](/v3/contribute/maintainers) can help to amplify this promotion as long as you cooperate with us.
+4. Once we've reviewed your submission and you've made all necessary changes, we'll merge the Pull Request and publish the tutorial on TON Documentation. For rewards, see Participate → [Receiving a reward](/v3/contribute/participate/#receiving-a-reward).
+5. Once it is published, remember to **promote** your tutorial on social media! The [documentation maintainers](/v3/contribute/maintainers/) can help to amplify this promotion as long as you cooperate with us.
 
 To summarize, the workflow is as follows:  
 1. ***Fork and Clone*** the **`ton-docs`** repository
@@ -48,37 +48,36 @@ Regarding other word combinations like "TON + noun" (e.g., "the TON world," "the
 
 ## General tips
 
-- **Do not copy and paste pre-existing content**. Plagiarism is a serious issue and will not be tolerated. If the tutorial is inspired by some existing content, reference it and link to it. When linking to other tutorials/resources, use TON Docs resources if possible.
+- **Do not copy and paste pre-existing content**. Plagiarism is a serious issue and will not be tolerated. If the tutorial is inspired by some existing content, reference it and link to it. When linking to other tutorials or resources, prefer internal links to canonical TON Docs pages and use a "See also" section for related pages; link externally only when necessary.
 - **Include any walkthrough videos or video content** in the PR by uploading it to Google Drive.
 - **Account funding from faucets must be clearly explained**, including which account is being funded, from where, and why. Do not assume learners can accomplish this task on their own!
-- **Display sample outputs** in the form of Terminal snippets or screenshots to help learners understand what to expect. Trim long outputs.
-- **Take an error-driven approach** where you bump into errors on purpose to teach learners how to debug them. For example, if you need to fund an account to be able to deploy a contract, first try and deploy without funding, observe the error that is returned, then fix the error (by funding the account) and try again.
+- **Display sample outputs** in the form of terminal snippets or screenshots to help learners understand what to expect. Trim long outputs.
+- **Take an error-driven approach** where you bump into errors on purpose to teach learners how to debug them. For example, if you need to fund an account to be able to deploy a contract, first try to deploy without funding, observe the error that is returned, then fix the error (by funding the account) and try again.
 - **Add potential errors and troubleshooting.** Of course, the tutorial shouldn't list every possible error, but it should make an effort to catch the important or most common ones.
-- **Use React or Vue** for the client-side.
+- React or Vue are common choices, but use what best fits the tutorial.
 - **Before making the PR, run the code by yourself first** to avoid any obvious errors and make sure it works as expected.
 - **Avoid including external/cross-links** to different sources between tutorials. If your tutorial is longer, we can discuss how to turn it into a longer course or Pathway.
-- **Provide** **pictures or screenshots** to illustrate the complicated processes where needed.
-- Upload your images to the `static` directory of the learn-tutorials repository — **DO NOT** use hotlinks to external sites, as this can result in broken images.
-- **Image links must** **be in markdown format** and you must **ONLY** use the raw GitHub URL of the static directory in the repository: `![name of your image](https://raw.githubusercontent.com/ton-community/ton-docs/main/static/img/tutorials/<your image filename>.png?raw=true)`
-    - Remember to add `?raw=true` at the end of the URL.
+- Provide pictures or screenshots to illustrate complex processes where needed.
+- Store images in this repository under `static/img/` — do not use hotlinks to external sites.
+- Link images using site-root paths, for example: `![Alt text](/img/tutorials/<your-image-filename>.png)`
 
 ## How to structure your tutorial
 
 :::info Sample tutorial structure
-Feel free to check out the [sample tutorial structure](/v3/contribute/tutorials/sample-tutorial) to see it with your own eyes.
+Feel free to check out the [sample tutorial structure](/v3/contribute/tutorials/sample-tutorial/) to see it with your own eyes.
 :::
 
-- The **Title** should be direct and clear, summarizing the tutorial's goal. Do not add the tutorial title as a heading inside the document; instead, use the markdown document filename. 
+- The **Title** should be direct and clear, summarizing the tutorial's goal. Start each page with a sentence-case H1 heading. 
   - *For example*: If your tutorial was titled "_Step by step guide for writing your first smart contract in FunC_," the filename should be:  
-  `step-by-step-guide-for-writing-your-first-smart-contract-in-func.md`
+  `step-by-step-guide-for-writing-your-first-smart-contract-in-func.mdx`
 - Include an **Introduction** section explaining *why* this tutorial matters and what the context of the tutorial is. Don't assume that it is obvious.
 - Include a **Prerequisites** section explaining any *prior knowledge* required or any existing tutorials that need to be completed first, any tokens that are needed, etc.
 - Include a **Requirements** section explaining any *technologies that must be installed* **prior** to starting the tutorial and that the tutorial will not cover, such as the TON Wallet extension, Node.js, etc. Do not list packages that will be installed during the tutorial.
-- Use **subheadings** (H2: ##) to break down your explanations within the body of the tutorial. Keep the Table of Contents in mind when using subheadings, and try to keep them on point.
+- Use **subheadings** (H3: ###) under major H2 sections to break down your explanations within the body of the tutorial. Keep the Table of Contents in mind when using subheadings, and try to keep them on point.
     - If the content below a subheading is short (for example, only a single paragraph and a code block), consider using bold text instead of a subheading.
 - Include a **Conclusion** section that summarizes what was learned, reinforces key points, and also congratulates the learner for completing the tutorial.
-- (***Optional***) Include a **What's Next** section pointing to good follow-up tutorials or other resources (projects, articles, etc.).
-- (***Optional***) Include an **About The** **Author** section at the end. Your bio should include a link to your GitHub profile (which will have your name, website, etc.) and a link to your Telegram profile (so that users can contact/tag you for help and questions).
+- (***Optional***) Include a **See also** section pointing to good follow-up tutorials or other resources (projects, articles, etc.).
+- (***Optional***) Include an H2 About the Author section at the end. Your bio should include a link to your GitHub profile (which will have your name, website, etc.) and a link to your Telegram profile (so that users can contact/tag you for help and questions).
 - A **References** section **must** be present if you have taken any help in writing this tutorial from other documents, GitHub repos, or other tutorials. Credit sources by adding their name and a link to the document when possible (if it is not a digital document, include an ISBN or other means of reference).
 
 ## Style Guide
@@ -88,7 +87,7 @@ Feel free to check out the [sample tutorial structure](/v3/contribute/tutorials/
     - _For example_: "We have successfully deployed our contract."
   - When providing direct instructions, feel free to use “you”, “your”, etc.
     - _For example_: “*Your file should look like this:*”.
-- **Use Markdown properly** throughout your tutorial. Refer to [GitHub's markdown guide](https://guides.github.com/features/mastering-markdown/) as well as the [sample tutorial structure](/v3/contribute/tutorials/sample-tutorial).
+- **Use Markdown properly** throughout your tutorial. Refer to our [style guide](/v3/contribute/style-guide/) and [typography](/v3/contribute/typography/) pages, as well as the [sample tutorial structure](/v3/contribute/tutorials/sample-tutorial/).
 - **Do not use pre-formatted text for emphasis**, *for example*:
     - ❌ "TON counter `smart contract` named `counter.fc`" is incorrect.
     - ✅ "TON counter **smart contract** named `counter.fc`" is correct.
@@ -116,25 +115,20 @@ Feel free to check out the [sample tutorial structure](/v3/contribute/tutorials/
 - **Remember to leave a blank line** before and after all code blocks.  
   *For example*:
 
-```jsx  
-  
-// test-application/src/filename.jsx  
-  
+```jsx
+// test-application/src/filename.jsx
 import { useEffect, useState } from 'react';
-  
-```  
+```
 
-  
-- **Use a linter & prettifier** before pasting your code into the code blocks. We recommend `eslint` for JavaScript/React. Use `prettier` for code formatting.
+- **Use a linter and formatter** before pasting your code into the code blocks. We recommend ESLint for JavaScript/React. Use Prettier for code formatting.
 - **Avoid the overuse of bullet points**, numbered lists, or complicated text formatting. The use of **bold** or *italic* emphasis is allowed but should be kept to a minimum.
 
-# **App setup**
+## App setup
 
 - Web3 projects will typically include several existing code libraries. Be sure to account for this when writing your tutorial. Where possible, provide a GitHub repository as a starting point to make it easier for learners to get started.
 - If you are *not* using a GitHub repo to contain the code used in your tutorial, remember to explain to readers how to create a folder to keep the code organized. 
-*For example*: `mkdir example && cd example`
+  *For example*: `mkdir example && cd example`
 - If you use `npm init` to initialize a project directory, explain the prompts or use the `-y` flag.
-- If you use `npm install` use the `-save` flag.
+- If you use `npm install`, dependencies are saved by default (npm v5+); no flag is needed.
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-contribute-tutorials-guidelines.mdx` into `main`.

Changed file(s):
- M: `docs/v3/contribute/tutorials/guidelines.mdx`

Related issues (from issues.normalized.md):
- [ ] **471. Avoid slash shorthand in prose**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/guidelines.mdx?plain=1#L51

Change "tutorials/resources" to "tutorials or resources" to avoid slash shorthand.

---

- [ ] **472. Use lowercase “terminal”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/guidelines.mdx?plain=1#L54

Change "Terminal snippets" to "terminal snippets" per sentence case.

---

- [ ] **473. Replace “try and” with “try to”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/guidelines.mdx?plain=1#L55

Change "first try and deploy" to "first try to deploy" for correct grammar.

---

- [ ] **474. Remove redundant bolding in sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/guidelines.mdx?plain=1#L60

Remove adjacent bold spans and leave as plain text, e.g., "Provide pictures or screenshots to illustrate complex processes where needed."

---

- [ ] **475. Standardize image storage and linking**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/guidelines.mdx?plain=1#L61-L63

Replace references to a separate "learn-tutorials" repo with this repo and instruct to store images under static/img and link them via site-root paths (e.g., /img/...); do not use raw GitHub URLs or ?raw=true.

---

- [ ] **476. Fix “About the Author” capitalization and formatting**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/guidelines.mdx?plain=1#L81

Use "About the Author" (lowercase "the") as an H2 with no bolding.

---

- [ ] **477. Update Markdown guidance links**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/guidelines.mdx?plain=1#L91

Replace the outdated GitHub Guides link with the current GitHub Docs URL or, preferably, link to our internal style and typography pages.

---

- [ ] **478. Clean code fence and remove trailing spaces**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/guidelines.mdx?plain=1#L119-L125

Start the example fence with exactly ```jsx, end with ```, and remove all trailing spaces inside the block.

---

- [ ] **479. Use standard tooling terms and capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/guidelines.mdx?plain=1#L128

Replace "linter & prettifier" with "linter and formatter," capitalizing tool names (e.g., ESLint, Prettier).

---

- [ ] **480. Fix “App setup” heading level and formatting**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/guidelines.mdx?plain=1#L131

Change "# **App setup**" to "## App setup" with no bold to maintain a single H1 and avoid formatting in headings.

---

- [ ] **481. Remove outdated npm --save guidance**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/guidelines.mdx?plain=1#L137

Correct "-save" to "--save" and note that since npm v5 dependencies are saved by default, use "npm install <package>" without the flag.

---

- [ ] **482. Use sentence case in page H1**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/guidelines.mdx?plain=1

Change "# Tutorial Styling Guidelines" to "# Tutorial styling guidelines" per typography rules.

---

- [ ] **483. Require an H1 at the start of each page**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/guidelines.mdx?plain=1

Remove the instruction to omit an H1 and state that each page must start with a sentence-case H1 heading.

---

- [ ] **484. Align subheading levels with sample tutorial**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/guidelines.mdx?plain=1

Recommend H3 for subheadings under major H2 sections to match the sample tutorial.

---

- [ ] **485. Use .mdx in filename example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/guidelines.mdx?plain=1

Change the example filename extension from .md to .mdx (e.g., step-by-step-guide-for-writing-your-first-smart-contract-in-func.mdx).

---

- [ ] **486. Remove blanket payment promise**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/guidelines.mdx?plain=1

Delete the guarantee of payment for merged tutorials and instead link to the rewards/bounties process (e.g., Participate > Receiving a reward).

---

- [ ] **487. Add trailing slashes to internal links**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/guidelines.mdx?plain=1

Update internal links like /v3/contribute/tutorials/sample-tutorial and /v3/contribute/maintainers to include trailing slashes to avoid redirects.

---

- [ ] **488. Clarify guidance on cross-linking**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/guidelines.mdx?plain=1

Rephrase to prefer internal links to canonical docs and to use a "See also" section for related pages, linking externally only when necessary.

---

- [ ] **489. Standardize related-links section name**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/guidelines.mdx?plain=1

Recommend using "## See also" instead of "What's Next" for the related resources section.

---

- [ ] **490. Clarify article usage for TON entities**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/guidelines.mdx?plain=1

Clarify whether "TON Blockchain" and "TON Ecosystem" take the article "the" and align this page with the chosen convention.

---

- [ ] **491. Soften prescriptive framework requirement**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/guidelines.mdx?plain=1

Change "Use React or Vue for the client-side" to a non-prescriptive note (e.g., "React or Vue are common choices, but use what best fits the tutorial").

---

- [ ] **492. Nest example under list item correctly**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/guidelines.mdx?plain=1

Indent the "For example: mkdir example && cd example" line under its bullet (or format as a code block) so it belongs to the list item.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.