### PR TITLE
Split: update docs/v3/contribute/tutorials/principles-of-a-good-tutorial.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/contribute/tutorials/principles-of-a-good-tutorial.mdx
+++ b/docs/v3/contribute/tutorials/principles-of-a-good-tutorial.mdx
@@ -4,33 +4,30 @@ import Feedback from '@site/src/components/Feedback';
 
 :::danger
 This page is outdated and will be updated soon.
-See the [How to contribute](/v3/contribute/).
+See [How to contribute](/v3/contribute/).
 :::
 
-Original comment with these principles by [talkol](https://github.com/talkol):
-
- - [Original comment on TON Footstep #7](https://github.com/ton-society/ton-footsteps/issues/7#issuecomment-1187581181)
+Original comment: [TON Footsteps #7](https://github.com/ton-society/ton-footsteps/issues/7#issuecomment-1187581181).
 
 Here is a summary of these points for new contributors.
 
 ## Principles
 
-1. The full flow should run on the user's client. There shouldn't be any third-party services involved. You need to do everything so that the user can simply clone the repository and immediately run it.
+1. The full flow should run on the user's device. Prefer fully client-side flows; if external services are required, document self-hosted alternatives and rationale. You need to do everything so that the user can simply clone the repository and immediately run it.
 
-2. The README should be VERY detailed. Do not assume the users know anything. If the tutorial requires it, it should also explain how to install the FunC compiler or Lite-client on your device. You can copy these parts from other tutorials in this documentation.
+2. The README should be very detailed. Do not assume users know anything. If the tutorial requires it, it should also explain how to install the FunC compiler or lite-client on your device. You can copy these parts from other tutorials in this documentation.
 
-3. It would be good if the repository included the whole source code for the contracts used, so that users could make minor changes to the standard code. For example, the Jetton smart contract allows users to experiment with custom behavior.
+3. Include the whole source code for the contracts used, so that users can make minor changes to the standard code. For example, the Jetton smart contract allows users to experiment with custom behavior.
 
-4. If it is possible, create a user-friendly interface that will allow users to deploy or run the project without having to download the code or configure anything. Notice that this should still be standalone and served from GitHub Pages to run 100% client-side on the user's device. Example: https://minter.ton.org/
+4. Create a user-friendly interface that allows users to deploy or run the project without having to download the code or configure anything. Note that this should still be standalone and served from GitHub Pages to run 100% client-side on the user's device. Example: [TON Minter](https://minter.ton.org/).
 
-5. Explain to users what every field choice means and explain best practices.
+5. Explain what each field and option means, and outline best practices.
 
-6. Explain everything there is to know about security. You must explain enough that creators do not make mistakes and create dangerous smart contracts/bots/websites—you are teaching them the best security practices.
+6. Explain key security considerations to help creators avoid dangerous smart contracts, bots, or websites. You must explain enough that creators do not make mistakes—you are teaching them the best security practices.
 
 7. Ideally, the repository should include well-written tests that show the reader how to best implement them in the context of your tutorial.
 
-8. The repository should have its own easy-to-understand compilation/deployment scripts. A user should be able to just `npm install` and use them.
+8. The repository should have its own easy-to-understand compilation/deployment scripts. Users should be able to install and run with one command, e.g., `npm install && npm run <script>`.
 
-9. Sometimes a GitHub repository is enough and there is no need to write a full article. Just a README with all the code you need in the repository. In this case, the code should be well-commented so that the user can easily read and understand it.
+9. Sometimes a GitHub repository is enough and there is no need to write a full article. A README with all the necessary code in the repository is sufficient. In this case, the code should be well-commented so that the user can easily read and understand it.
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-contribute-tutorials-principles-of-a-good-tutorial.mdx` into `main`.

Changed file(s):
- M: `docs/v3/contribute/tutorials/principles-of-a-good-tutorial.mdx`

Related issues (from issues.normalized.md):
- [ ] **493. Fix "How to contribute" link wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/principles-of-a-good-tutorial.mdx?plain=1#L7

Replace “See the [How to contribute](/v3/contribute/).” with “See [How to contribute](/v3/contribute/).”

---

- [ ] **494. Correct TON Footsteps link and remove duplicate "Original comment"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/principles-of-a-good-tutorial.mdx?plain=1#L12

Collapse the repeated “Original comment” lines and fix the name to plural: “Original comment: [TON Footsteps #7](https://github.com/ton-society/ton-footsteps/issues/7#issuecomment-1187581181).”

---

- [ ] **495. Standardize to "device" over "client"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/principles-of-a-good-tutorial.mdx?plain=1#L18

Change “The full flow should run on the user's client.” to “The full flow should run on the user's device.”

---

- [ ] **496. Replace ALL CAPS "VERY"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/principles-of-a-good-tutorial.mdx?plain=1#L20

Replace “VERY” with “very” in “The README should be VERY detailed.”

---

- [ ] **497. Remove article in "the users"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/principles-of-a-good-tutorial.mdx?plain=1#L20

Change “Do not assume the users know anything.” to “Do not assume users know anything.”

---

- [ ] **498. Use binary name "lite-client"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/principles-of-a-good-tutorial.mdx?plain=1#L20

Change “Lite-client” to “lite-client” (lowercase, hyphenated) in “…install the FunC compiler or lite-client on your device.”

---

- [ ] **499. Improve note wording; label TON Minter link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/principles-of-a-good-tutorial.mdx?plain=1#L24

Change “Notice that…” to “Note that…” and replace the bare URL with a labeled link: “Example: [TON Minter](https://minter.ton.org/).”

---

- [ ] **500. Clarify "every field choice" phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/principles-of-a-good-tutorial.mdx?plain=1#L26

Replace “Explain to users what every field choice means and explain best practices.” with “Explain what each field and option means, and outline best practices.”

---

- [ ] **501. Clarify npm usage to single-command run**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/principles-of-a-good-tutorial.mdx?plain=1#L32

Replace “A user should be able to just `npm install` and use them.” with “Users should be able to install and run with one command, e.g., `npm install && npm run <script>`.”

---

- [ ] **502. Fix sentence fragment in final principle**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/principles-of-a-good-tutorial.mdx?plain=1#L34

Replace “Just a README with all the code you need in the repository.” with a complete sentence, e.g., “A README with all the necessary code in the repository is sufficient.”

---

- [ ] **503. Clarify stance on third-party services**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/principles-of-a-good-tutorial.mdx?plain=1

Soften “There shouldn't be any third-party services involved.” to “Prefer fully client-side flows; if external services are required, document self-hosted alternatives and rationale.”

---

- [ ] **504. Tone down security claim; fix slash list**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/principles-of-a-good-tutorial.mdx?plain=1

Replace “Explain everything there is to know about security (smart contracts/bots/websites) …” with “Explain key security considerations to help creators avoid dangerous smart contracts, bots, or websites …”.

---

- [ ] **505. Use imperative mood in principles**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/principles-of-a-good-tutorial.mdx?plain=1

Rewrite tentative phrasing (e.g., “It would be good if…”, “If it is possible, create…”) into direct imperatives for consistency (e.g., “Include…”, “Create…”).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.