### PR TITLE
Split: update docs/v3/contribute/tutorials/sample-tutorial.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/contribute/tutorials/sample-tutorial.mdx
+++ b/docs/v3/contribute/tutorials/sample-tutorial.mdx
@@ -4,7 +4,7 @@ import Feedback from '@site/src/components/Feedback';
 
 :::danger
 This page is outdated and will be updated soon.
-See the [How to contribute](/v3/contribute/).
+See [How to contribute](/v3/contribute/).
 :::
 
 ## Introduction
@@ -18,7 +18,7 @@ This section is for you to explain the context of this tutorial and why it is im
 
 _For example:_
 
-> A smart contract is just a computer program that runs on TON Blockchain, or more specifically on its [TVM](/v3/documentation/tvm/tvm-overview) (_TON Virtual Machine_). The contract is made of code (_compiled TVM instructions_) and data (_persistent state_) that are stored at some address on TON.
+> A smart contract is just a computer program that runs on TON Blockchain, or more specifically on its [TVM](/v3/documentation/tvm/tvm-overview/) (_TON Virtual Machine_). The contract is made of code (_compiled TVM instructions_) and data (_persistent state_) that are stored at some address on TON.
 
 ## Prerequisites
 
@@ -28,37 +28,37 @@ This section is for you to explain any prior knowledge needed or any existing tu
 
 _For example:_
 
-> In this tutorial, we're going to mint Jetton on testnet. Before we continue, make sure that your [testnet](/v3/documentation/smart-contracts/getting-started/testnet) wallet has sufficient balance.
+> In this tutorial, we're going to mint Jetton on testnet. Before we continue, make sure that your [testnet](/v3/documentation/smart-contracts/getting-started/testnet/) wallet has sufficient balance.
 
 ## Requirements
 
 The Requirements heading **must** be H2: `## Requirements`
 
-**OPTIONAL :** Embed any video content in this section if your tutorial has any.
+**Optional:** Embed any video content in this section if your tutorial has any.
 
-Any technology that needs to be installed **prior** to starting the tutorial and that the tutorial will not cover (`TON Wallet Extension`, `node`, etc.). Do not list packages that will be installed during the tutorial.
+Any technology that needs to be installed **prior** to starting the tutorial and that the tutorial will not cover (`TON Wallet extension`, `node`, etc.). Do not list packages that will be installed during the tutorial.
 
 _For example:_
 
-- We'll need the TON Wallet extension in this tutorial; install it from [HERE](https://chrome.google.com/webstore/detail/ton-wallet/nphplpgoakhhjchkkhmiggakijnkhfnd).
-- Make sure to have NodeJS 12.0.1+ installed.
+- We'll need the TON Wallet extension in this tutorial; install it from the [Chrome Web Store](https://chrome.google.com/webstore/detail/ton-wallet/nphplpgoakhhjchkkhmiggakijnkhfnd).
+- Make sure to have Node.js v18 or higher installed.
 
-## Body of the Tutorial
+## Getting started
 
 - Please do not use "Body of the Tutorial" as a heading, use your own heading that is relevant to the material.
   - "Getting started" is acceptable if you can't think of anything else 😉
 - Add any text content necessary to guide readers through your tutorial, and _**remember to proofread your content**_ for spelling and grammar before you submit your tutorial.
-  - [Grammarly](http://grammarly.com) is a good free program that can help you avoid grammar mistakes.
+  - [Grammarly](https://www.grammarly.com/) is a good free program that can help you avoid grammar mistakes.
 
 ### Key points
 
 - Do not use "Body of the Tutorial" as a heading!
 
-- **Keep all subheadings at H3,** don't go for H4 or any lower.
+- Use H2 for major sections and H3 for subsections; avoid H4+ unless necessary.
   - In Markdown syntax, two hashmarks are used for H2 headings: ##
   - Three hashmarks are used for H3 headings: ###
 
-- Add only necessary comments to code blocks. **Do not** add # style comments to terminal input code blocks.
+- Use \```bash for terminal commands and \```text for terminal output; avoid inline '#' comments in command snippets.
 
 - Add all relevant code blocks:
     - Markdown syntax for code blocks consists of three backticks at the beginning and end of the code block.  Also, make sure that there is a newline before and after the backticks in all code blocks. *For example*:
@@ -68,23 +68,23 @@ _For example:_
         someFunctionCall();  
         \```  
         
-    - ALL code blocks ***must*** have a syntax highlight type. Use ```text if you are not sure.
+    - ALL code blocks ***must*** have a syntax highlight type. Use \```text if you are not sure.
     - \```text must be used for terminal output, terminal commands, and plaintext.
-    - \```javascript *or* ```js can be used for any JavaScript code.
-    - \```typescript or ```ts can be used for any TypeScript code.
-    - \```jsx is for ReactJS code.
-    - \```cpp is for Func code.
+    - \```javascript *or* \```js can be used for any JavaScript code.
+    - \```typescript or \```ts can be used for any TypeScript code.
+    - \```jsx is for React code.
+    - \```func is for FunC code.
     - Use \```graphql when highlighting GraphQL syntax.
     - Use \```json when highlighting valid JSON. (For invalid JSON examples use \```text instead.)
-    - \```bash should *only* be used in code blocks where you need to have # style comments. This must be done carefully because in many situations the # character will render as a markdown heading. Typically, the Table of Contents will be affected if this occurs.
-- Do not use `pre-formatted text` for emphasis; instead, use only **bold** or *italic* text.
+    - \```bash for terminal commands; \```text for terminal output.
+ - Do not use preformatted text for emphasis; use **bold** or *italic* instead.
 - Add images or code blocks to reflect the expected terminal output.
 
 - Take an error-driven approach when writing your tutorial. Add common errors and troubleshooting steps. _For example:_
 
 > **Unable to connect to Testnet due to an error when executing the
 > `node deploy:testnet` command.**
->
+
 > Let's look at some common causes:
 >
 > - Make sure you have enough funds in your generated testnet wallet in `.env`. If not, please add some testnet coins from the faucet giver.
@@ -102,24 +102,22 @@ _For example_:
 
 Please remember that this code is not meant for production; there are still a few other things to consider if you wanted to deploy this to mainnet, such as disabling the transfer method if the token is listed on the market, and so on.
 
->
+## See also
 
-## See Also
-
-The Next Steps heading **must** be H2: `## See Also`
+The ‘See also’ heading **must** be H2: `## See also`
 
 Use this section to explain what can be done next after this tutorial to continue learning.
 Feel free to add recommended projects and articles relating to this tutorial.
 If you're working on any other advanced tutorials, you can briefly mention them here.
 Typically, only related pages from docs.ton.org are placed here.
 
-## About the Author _(Optional)_
+## About the author (optional)
 
-The About the Author heading **must** be H2: `## About the Author`
+The ‘About the author’ heading **must** be H2: `## About the author`
 
 Keep it short. One or two lines at most. You can include a link to your GitHub profile + Telegram profile. Please refrain from adding your LinkedIn or Twitter here.
 
-## References _(Optional)_
+## References
 
 The References heading **must** be H2: `## References`
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-contribute-tutorials-sample-tutorial.mdx` into `main`.

Changed file(s):
- M: `docs/v3/contribute/tutorials/sample-tutorial.mdx`

Related issues (from issues.normalized.md):
- [ ] **506. Remove unnecessary article in link text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/sample-tutorial.mdx?plain=1#L5-L7

The sentence "See the [How to contribute](/v3/contribute/)." uses an unnecessary article; remove "the" so it reads "See [How to contribute](/v3/contribute/)."

---

- [ ] **507. Fix spacing/case: "Optional:" label**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/sample-tutorial.mdx?plain=1#L37

"OPTIONAL :" has an extra space and shouty caps; change to sentence case with no extra space: "Optional:" (or bold "**Optional:**").

---

- [ ] **508. Standardize "TON Wallet extension" casing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/sample-tutorial.mdx?plain=1#L39-L44

Use consistent casing in running text by lowercasing "extension": replace "TON Wallet Extension" with "TON Wallet extension" throughout this section.

---

- [ ] **509. Replace non-descriptive "HERE" link text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/sample-tutorial.mdx?plain=1#L43

Replace "[HERE]" with descriptive link text, e.g., "install it from the Chrome Web Store" (keep the same URL).

---

- [ ] **510. Update Node.js version and brand**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/sample-tutorial.mdx?plain=1#L44

Replace "NodeJS 12.0.1+" with "Node.js v18 or higher" to reflect supported LTS and correct branding.

---

- [ ] **511. Rename "Body of the Tutorial" heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/sample-tutorial.mdx?plain=1#L46-L55

Replace the H2 "Body of the Tutorial" with a relevant, specific title in sentence case (for example, "Getting started") to align with guidance.

---

- [ ] **512. Use HTTPS for Grammarly link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/sample-tutorial.mdx?plain=1#L51

Change "http://grammarly.com" to the secure, canonical "https://www.grammarly.com/".

---

- [ ] **513. Correct subheading guidance wording and levels**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/sample-tutorial.mdx?plain=1#L57

Replace "Keep all subheadings at H3, don't go for H4 or any lower." with "Use H2 for major sections and H3 for subsections; avoid H4+ unless necessary."

---

- [ ] **514. Escape inline triple‑backtick examples in prose**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/sample-tutorial.mdx?plain=1#L71-L79

Escape all inline triple‑backtick examples to avoid unintended code fences (use \```text, \```js, \```ts), or refer to language labels in inline code (for example, "Use `text` if you are not sure.").

---

- [ ] **515. Use "React" instead of "ReactJS"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/sample-tutorial.mdx?plain=1#L75

Change "ReactJS" to "React" (e.g., "\```jsx is for React code.").

---

- [ ] **516. Replace "pre-formatted" with "preformatted text"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/sample-tutorial.mdx?plain=1#L80

Replace "pre-formatted" with "preformatted text" and adjust the sentence to "Do not use preformatted text for emphasis; use bold or italic instead."

---

- [ ] **517. Remove stray empty blockquote**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/sample-tutorial.mdx?plain=1#L105

Delete the lone ">" line that renders an empty blockquote.

---

- [ ] **518. Fix “See also” heading and guidance**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/sample-tutorial.mdx?plain=1#L107-L114

Make the wording and example self-consistent and sentence case: "The ‘See also’ heading must be H2: `## See also`", and ensure the actual section uses "## See also".

---

- [ ] **519. Remove italics and use sentence case in headings**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/sample-tutorial.mdx?plain=1#L116-L120, #L122-L130

Remove italics from headings and use sentence case: change "## About the Author _(Optional)_" to "## About the author (optional)" (or note optionality in body) and keep "## References" plain.

---

- [ ] **520. Fix FunC syntax highlight label**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/sample-tutorial.mdx?plain=1

Change the instruction "```cpp is for Func code." to "\```func is for FunC code." and use the correct "FunC" spelling.

---

- [ ] **521. Add trailing slashes to internal links**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/sample-tutorial.mdx?plain=1

Add trailing slashes to internal links: change "/v3/documentation/tvm/tvm-overview" to "/v3/documentation/tvm/tvm-overview/" and "/v3/documentation/smart-contracts/getting-started/testnet" to "/v3/documentation/smart-contracts/getting-started/testnet/".

---

- [ ] **522. Unify terminal snippet guidance**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/contribute/tutorials/sample-tutorial.mdx?plain=1

Standardize to "Use \```bash for terminal commands and \```text for terminal output; avoid inline '#' comments in command snippets."

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.