### PR TITLE
Split: update docs/v3/documentation/archive/compile.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/archive/compile.mdx
+++ b/docs/v3/documentation/archive/compile.mdx
@@ -1,51 +1,50 @@
 import Feedback from '@site/src/components/Feedback';
 
-# Compile and Build smart contracts on TON
+# Compile and build smart contracts on TON
 
-Here is a list of libraries and repos to build your smart contract.
+Here is a list of libraries and repositories to build smart contracts.
 
-**TLDR:**
+**TL;DR:**
 
-- In most cases, it's enough to use Blueprint SDK.
-- If you need more low-level approach, you can use ton-compiler or func-js.
+In most cases, using Blueprint is sufficient. If you need a more low-level approach, you can use ton-compiler or func-js.
 
 ## Blueprint
 
 ### Overview
 
-A development environment for TON blockchain for writing, testing, and deploying smart contracts. Read more in [Blueprint git repository](https://github.com/ton-community/blueprint).
+A development environment for the TON Blockchain for writing, testing, and deploying smart contracts. Read more in the [Blueprint repository](https://github.com/ton-org/blueprint).
 
 ### Installation
 
-Run the following in terminal to create a new project and follow the on-screen instructions:
+Run the following in the terminal to create a new project and follow the on-screen instructions:
 
 ```bash
 npm create ton@latest
 ```
 
-&nbsp;
+
 
 ### Features
 
-- Streamlined workflow for building, testing and deploying smart contracts
-- Dead simple deployment to mainnet/testnet using your favorite wallet (eg. Tonkeeper)
-- Blazing fast testing of multiple smart contracts in an isolated blockchain running in-process
+- Streamlined workflow for building, testing, and deploying smart contracts
+- Dead simple deployment to mainnet/testnet using your favorite wallet (e.g., Tonkeeper)
+- Blazing-fast testing of multiple smart contracts in an isolated in-process blockchain
 
 ### Tech stack
 
-1. Compiling FunC with https://github.com/ton-community/func-js (no CLI)
-2. Testing smart contracts with https://github.com/ton-community/sandbox
-3. Deploying smart contracts with [TON Connect 2](https://github.com/ton-connect), [Tonhub wallet](https://tonhub.com/) or a `ton://` deeplink
+1. Compiling FunC with [func-js](https://github.com/ton-community/func-js) (no CLI required)
+2. Testing smart contracts with [Sandbox](https://github.com/ton-org/sandbox)
+3. Deploying smart contracts with [TON Connect 2.0](https://github.com/ton-connect), [Tonhub wallet](https://tonhub.com/), or a `ton://` deeplink
 
 ### Requirements
 
 - [Node.js](https://nodejs.org) with a recent version like v18, verify version with `node -v`
 - IDE with TypeScript and FunC support like [Visual Studio Code](https://code.visualstudio.com/) with the [FunC plugin](https://marketplace.visualstudio.com/items?itemName=tonwhales.func-vscode)
 
-### How to use?
+### How to use
 
-- [Watch DoraHacks presentation with demo of working with blueprint](https://www.youtube.com/watch?v=5ROXVM-Fojo).
-- Read well detailed explanation in [Blueprint repo](https://github.com/ton-community/blueprint#create-a-new-project).
+- [Watch the DoraHacks presentation with a demo of working with Blueprint.](https://www.youtube.com/watch?v=5ROXVM-Fojo)
+- Read a detailed explanation in the [Blueprint repository](https://github.com/ton-org/blueprint#create-a-new-project).
 
 ## ton-compiler
 
@@ -71,11 +70,11 @@ npm install ton-compiler
 
 ### How to use
 
-This packages adds `ton-compiler` binary to a project.
+This package adds the `ton-compiler` binary to your project.
 
-FunC compilation is a multi-stage process. One is compiling Func to Fift code that is then compiled to a binary representation. Fift compiler already has Asm.fif bundled.
+FunC compilation is a multi-stage process. One is compiling FunC to Fift code that is then compiled to a binary representation. The Fift compiler already has `Asm.fif` bundled.
 
-FunC stdlib is bundled but could be disabled at runtime.
+FunC stdlib is bundled but can be disabled at runtime.
 
 #### Console Use
 
@@ -128,23 +127,23 @@ npm install @ton-community/func-js
 
 ### Features
 
-- No need to compile of download FunC binaries
-- Works both in Node.js & **WEB** (WASM support is required)
-- Compiles straight to BOC with code Cell
-- Assembly is returned fot debugging purposes
-- Does not depend on file-system
+- No need to compile or download FunC binaries
+- Works in both Node.js and the web (WASM support required)
+- Compiles straight to BOC with code cell
+- Assembly is returned for debugging purposes
+- Does not depend on the file system
 
 ### How to use
 
-Internally, this package uses both FunC compiler and Fift interpreter combined to single lib compiled to WASM.
+Internally, this package uses both the FunC compiler and the Fift interpreter, combined into a single library compiled to WASM.
 
 Simple schema:
 
-```bash
+```text
 (your code) -> WASM(FunC -> Fift -> BOC)
 ```
 
-Sources to the internal lib could be found [here](https://github.com/ton-blockchain/ton/tree/testnet/crypto/funcfiftlib).
+Sources for the internal library can be found [here](https://github.com/ton-blockchain/ton/tree/master/crypto/funcfiftlib).
 
 ### Usage example
 
@@ -194,11 +193,11 @@ Note that all FunC source file contents used in your project should be passed to
 ### Third-party contributors
 
 - [grozzzny/ton-compiler-groz](https://github.com/grozzzny/ton-compiler-groz) — TON FunC smart contract compiler.
-- [Termina1/tonc](https://github.com/Termina1/tonc) — TONC (TON Compiler). Uses WASM, so perfect for Linux.
+- [Termina1/tonc](https://github.com/Termina1/tonc) — TONC (TON Compiler). Uses WASM; works well on Linux.
 
 ## Other
 
-- [disintar/toncli](https://github.com/disintar/toncli) — one of the most popular approaches. You even can use it with Docker.
+- [disintar/toncli](https://github.com/disintar/toncli) — one of the most popular approaches. You can even use it with Docker.
 - [tonthemoon/ton](https://github.com/tonthemoon/ton) — _(closed beta)_ one-line TON binaries installer.
 - [delab-team/tlbcrc](https://github.com/delab-team/tlbcrc) — Package & CLI to generate opcodes by TL-B scheme
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-archive-compile.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/archive/compile.mdx`

Related issues (from issues.normalized.md):
- [ ] **535. Fix title capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/compile.mdx?plain=1#L3

Change the H1 to sentence case: "Compile and build smart contracts on TON".

---

- [ ] **536. Improve intro wording and plurality**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/compile.mdx?plain=1#L5

Rewrite as: "Here is a list of libraries and repositories to build smart contracts."

---

- [ ] **537. Standardize TL;DR label and wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/compile.mdx?plain=1#L9-L10

Use "TL;DR"; replace "Blueprint SDK" with "Blueprint"; and revise to: "In most cases, using Blueprint is sufficient. If you need a more low-level approach, you can use ton-compiler or func-js."

---

- [ ] **538. Update Blueprint naming, link, and TON Blockchain phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/compile.mdx?plain=1#L16-L18

Use "the TON Blockchain" (capital B, with article) and update the Blueprint link to https://github.com/ton-org/blueprint.

---

- [ ] **539. Remove non-breaking space entity**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/compile.mdx?plain=1#L26

Delete the standalone "&nbsp;" and rely on normal Markdown spacing.

---

- [ ] **540. Fix “e.g.” punctuation and add serial comma**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/compile.mdx?plain=1#L31

Change "(eg. Tonkeeper)" to "(e.g., Tonkeeper)" and use a serial comma in "building, testing, and deploying".

---

- [ ] **541. Fix Tech stack links and TON Connect naming**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/compile.mdx?plain=1#L36-L38

Convert bare URLs to Markdown links, update the Sandbox link to https://github.com/ton-org/sandbox, change "TON Connect 2" to "TON Connect 2.0", and clarify "(no CLI)" to "(no CLI required)".

---

- [ ] **542. Normalize “How to use” heading and bullets**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/compile.mdx?plain=1#L45-L48

Change the heading to "How to use"; bullet 1 → "Watch the DoraHacks presentation with a demo of working with Blueprint."; bullet 2 → "Read a detailed explanation in the Blueprint repository." and update the link to https://github.com/ton-org/blueprint#create-a-new-project.

---

- [ ] **543. Correct ton-compiler grammar and terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/compile.mdx?plain=1#L74-L78

Use "This package adds the `ton-compiler` binary to your project.", "FunC to Fift", "The Fift compiler already has `Asm.fif` bundled.", and "can be disabled at runtime."

---

- [ ] **544. Capitalize “Fift” in example comments**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/compile.mdx?plain=1

In console examples, change "# Compile to fift" to "# Compile to Fift" (both occurrences).

---

- [ ] **545. Avoid top-level await in code example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/compile.mdx?plain=1#L101-L110

Wrap the example in an async function and invoke it (or note ESM/top-level await support) to ensure it runs in common environments.

---

- [ ] **546. Fix func-js features typos and style**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/compile.mdx?plain=1#L131-L135

Change to: "No need to compile or download FunC binaries"; "Works in both Node.js and the web (WASM support required)"; "code cell"; "for debugging purposes"; and "does not depend on the file system".

---

- [ ] **547. Clarify internals sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/compile.mdx?plain=1#L139

Revise to: "Internally, this package uses both the FunC compiler and the Fift interpreter, combined into a single library compiled to WASM."

---

- [ ] **548. Use plain text code block for schematic**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/compile.mdx?plain=1

Change the schematic "(your code) -> WASM(FunC -> Fift -> BOC)" code block language from bash to text (or omit a language).

---

- [ ] **549. Improve “Sources” phrasing and link stability**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/compile.mdx?plain=1#L147

Change to "Sources for the internal library can be found here" and link to a stable branch or pinned commit instead of a mutable branch like testnet.

---

- [ ] **550. Clean up usage examples and remove unused variable**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/compile.mdx?plain=1#L155-L167, L175-L181

Use "You can get the compiler version", change the comment to "the rest of the files included in main.fc, if any", and either log/use the `version` variable or remove it.

---

- [ ] **551. Tweak “Other” section phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/compile.mdx?plain=1#L201-L203

Change "You even can use it with Docker." to "You can even use it with Docker."

---

- [ ] **552. Add article before “terminal”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/compile.mdx?plain=1

Change "Run the following in terminal" to "Run the following in the terminal."

---

- [ ] **553. Hyphenate and tighten testing sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/compile.mdx?plain=1

Change to "Blazing-fast testing of multiple smart contracts in an isolated in-process blockchain."

---

- [ ] **554. Neutralize Linux note tone**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/compile.mdx?plain=1

Change "Uses WASM, so perfect for Linux." to "Uses WASM; works well on Linux."

---

- [ ] **555. Review outdated status label**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/compile.mdx?plain=1

Remove or update the "(closed beta)" label for `tonthemoon/ton` if it is no longer current.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.