### PR TITLE
Split: update docs/v3/documentation/archive/hacktoberfest-2022/as-contributor.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/archive/hacktoberfest-2022/as-contributor.mdx
+++ b/docs/v3/documentation/archive/hacktoberfest-2022/as-contributor.mdx
@@ -2,33 +2,33 @@ import Feedback from '@site/src/components/Feedback';
 
 # Participate as a Contributor
 
-To become a contributor who receives a limited _Hack-TON-berfest NFT_, please set up your own [TON Wallet](https://ton.org/wallets) and verify your GitHub account.
+To become a contributor who receives a Limited Hack-TON-berfest NFT, please set up your own [TON Wallet](https://ton.org/wallets) and verify your GitHub account.
 
 ## Start your journey
 
-1. Set up any wallet from the [ton.org/wallets](https://ton.org/wallets) page. ([TON Wallet extension](https://chrome.google.com/webstore/detail/ton-wallet/nphplpgoakhhjchkkhmiggakijnkhfnd), for example.)
-2. Please provide your wallet address to the [@toncontests_bot](https://t.me/toncontests_bot) in Telegram.
-3. Validate your GitHub account in the same bot.
+1. Set up any wallet from the [ton.org/wallets](https://ton.org/wallets) page. ([TON Wallet extension](https://chromewebstore.google.com/detail/ton-wallet/nphplpgoakhhjchkkhmiggakijnkhfnd), for example.)
+2. Please provide your wallet address to the [@toncontests_bot](https://t.me/toncontests_bot) on Telegram.
+3. Validate your GitHub account with the same bot.
 
-After these steps you are ready to contribute and receive a [limited Hack-TON-berfest NFT](/v3/documentation/archive/hacktoberfest-2022#what-are-the-rewards).
+After these steps, you are ready to contribute and receive a [Limited Hack-TON-berfest NFT](/v3/documentation/archive/hacktoberfest-2022#what-are-the-rewards).
 
-Welcome to the club, this is just the beginning!
+Welcome to the club. This is just the beginning!
 
 ## New to contributing to open source?
 
-Hacktoberfest is a great place to start dipping your toes into open source contributions for the first time. There are plenty of streams, posts, guides, and discussions about to get started. You’ll be joining many folks who are also starting their journey this month!
+Hacktoberfest is a great place to start dipping your toes into open source contributions for the first time. There are plenty of streams, posts, guides, and discussions about how to get started. You’ll be joining many folks who are also starting their journey this month!
 
-- [Basic information about Hacktoberfest for beginners](https://hacktoberfest.com/participation/#beginner-resources)
+- [Basic information about Hacktoberfest for beginners](https://hacktoberfest.com/resources)
 - [Guide to making your first contribution](https://dev.to/codesandboxio/how-to-make-your-first-open-source-contribution-2oim) by Ceora Ford
 - [Practice the workflow to make your first contribution](https://github.com/firstcontributions/first-contributions)
-- [Overcoming imposter syndrome in open source contribution](https://blackgirlbytes.dev/conquering-the-fear-of-contributing-to-open-source)
+- [Overcoming imposter syndrome in open source contributions](https://blackgirlbytes.dev/conquering-the-fear-of-contributing-to-open-source)
 
 ## How can I contribute to TON?
 
 The TON Ecosystem has several organizations and repositories:
 
 <span className="DocsMarkdown--button-group-content">
-  <a href="/hacktonberfest" className="Button Button-is-docs-primary">
+  <a href="https://github.com/ton-community/awesome-ton" className="Button Button-is-docs-primary">
     List of projects looking for contributors
   </a>
 </span>


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-archive-hacktoberfest-2022-as-contributor.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/archive/hacktoberfest-2022/as-contributor.mdx`

Related issues (from issues.normalized.md):
- [ ] **569. Standardize “Limited Hack‑TON‑berfest NFT” styling**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/hacktoberfest-2022/as-contributor.mdx?plain=1#L5,L13

Use consistent styling for the term across this page: capitalize “Limited” and standardize emphasis (either italicize both instances or keep both plain), aligning with the chosen cross‑doc style.

---

- [ ] **570. Update Chrome Web Store link to canonical URL**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/hacktoberfest-2022/as-contributor.mdx?plain=1#L9

Replace the legacy chrome.google.com/webstore URL with the canonical URL: https://chromewebstore.google.com/detail/ton-wallet/nphplpgoakhhjchkkhmiggakijnkhfnd.

---

- [ ] **571. Use “on Telegram” preposition**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/hacktoberfest-2022/as-contributor.mdx?plain=1#L10

Change “…@toncontests_bot in Telegram” to “…@toncontests_bot on Telegram.”

---

- [ ] **572. Replace “in the same bot” with “with the same bot”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/hacktoberfest-2022/as-contributor.mdx?plain=1#L11

Revise “Validate your GitHub account in the same bot.” to “Validate your GitHub account with the same bot.”

---

- [ ] **573. Add comma after introductory phrase**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/hacktoberfest-2022/as-contributor.mdx?plain=1#L13

Insert a comma after the introductory clause: “After these steps, you are ready to contribute and receive a Limited Hack‑TON‑berfest NFT.”

---

- [ ] **574. Fix comma splice in welcome sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/hacktoberfest-2022/as-contributor.mdx?plain=1#L15

Change “Welcome to the club, this is just the beginning!” to “Welcome to the club. This is just the beginning!”

---

- [ ] **575. Fix grammar: “about to get started”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/hacktoberfest-2022/as-contributor.mdx?plain=1#L19

Revise “There are plenty of streams, posts, guides, and discussions about to get started.” to “There are plenty of streams, posts, guides, and discussions about how to get started.”

---

- [ ] **576. Update broken Hacktoberfest beginner resources link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/hacktoberfest-2022/as-contributor.mdx?plain=1#L21

Replace the 404ing https://hacktoberfest.com/participation/#beginner-resources with a current, working beginner resources URL on the official Hacktoberfest site.

---

- [ ] **577. Fix broken projects list link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/hacktoberfest-2022/as-contributor.mdx?plain=1#L31-L33

The “List of projects looking for contributors” button points to /hacktonberfest; update the href to a valid destination or add a redirect in redirects.js to a correct page.

---

- [ ] **578. Pluralize “contribution” in link text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/hacktoberfest-2022/as-contributor.mdx?plain=1

Change “Overcoming imposter syndrome in open source contribution” to “Overcoming imposter syndrome in open source contributions.”

---

- [ ] **579. Standardize Hacktoberfest domain across pages**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/hacktoberfest-2022/as-contributor.mdx?plain=1

Choose a canonical domain (hacktoberfest.com or hacktoberfest.digitalocean.com) and update this page’s Hacktoberfest links accordingly for cross‑doc consistency.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.