### PR TITLE
Split: update docs/v3/documentation/archive/hacktoberfest-2022/as-maintainer.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/archive/hacktoberfest-2022/as-maintainer.mdx
+++ b/docs/v3/documentation/archive/hacktoberfest-2022/as-maintainer.mdx
@@ -1,37 +1,37 @@
 import Feedback from '@site/src/components/Feedback';
 
-# Participate as a Maintainer
+# Participate as a maintainer
 
 The Hacktoberfest event is the best time of year to receive support from the community!
 
 If your repository is relevant to the TON Ecosystem, many contributors will be interested in it. Let's help them dive right into your project!
 
-## Prepare to party
+## Prepare your repository
 
 To handle contributors in the right way, you need to have a repository in good standing.
 
 Follow these best practices to prepare your project for contributions:
 
-1. Add the “hacktoberfest” topic to your repository to **OPT-IN TO HACKTOBERFEST** and indicate you are looking for contributions.
-2. Apply the “hacktoberfest” label to issues you want contributors to help you with in your GitHub or GitLab project.
+1. Add the `hacktoberfest` topic to your repository to opt in to Hacktoberfest and indicate you are looking for contributions.
+2. Apply the `hacktoberfest` label to issues you want contributors to help you with in your GitHub or GitLab project.
 3. Please read and use [the essential tips for new open source maintainers](https://blog.ton.org/essential-tips-for-new-open-source-maintainers) by TON Society.
-4. Prepare to accept legitimate pull/merge requests by merging them, leaving an overall approving review, or adding the "hacktoberfest-accepted" label.
-5. Reject any spam requests you receive by labeling them as “spam,” and close or label any other invalid contributions as "invalid."
+4. Prepare to accept legitimate pull requests (GitHub) or merge requests (GitLab) by merging them or leaving an overall approving review.
+5. Reject any spam requests you receive by labeling them as `spam`, and close or label any other invalid contributions as `invalid`.
 
-Here is an example of a full repository: [ton-community/ton-compiler](https://github.com/ton-community/ton-compiler)
+Here is an example of a well-prepared repository: [ton-community/ton-compiler](https://github.com/ton-community/ton-compiler)
 
 After that, feel free to add your repository to the list.
 
-## Rewards for Maintainers
+## Rewards for maintainers
 
 As a repository maintainer in the TON Ecosystem, you will be able to receive two types of rewards:
 
-1. [Hacktoberfest Reward Kit](https://hacktoberfest.com/participation/#maintainers) (_see REWARD FOR MAINTAINERS_)
-2. [Limited Hack-TON-berfest NFT](/v3/documentation/archive/hacktoberfest-2022#what-are-the-rewards) (_please, register the wallet address in the [@toncontests_bot](https://t.me/toncontests_bot)_)
+1. [Hacktoberfest Reward Kit](https://web.archive.org/web/20221001122609/https://hacktoberfest.com/participation/#maintainers) (_see REWARD FOR MAINTAINERS_)
+2. [Limited Hack-TON-berfest NFT](/v3/documentation/archive/hacktoberfest-2022/#what-are-the-rewards) (_please submit your wallet address to the [@toncontests_bot](https://t.me/toncontests_bot)_)
 
 ## How to join and be listed?
 
-To participate in Hack-TON-berfest follow this link:
+To participate in Hack-TON-berfest, follow this link:
 
 <span className="DocsMarkdown--button-group-content">
   <a href="https://airtable.com/shrgXIgZdBKKX64NL"
@@ -41,4 +41,3 @@ To participate in Hack-TON-berfest follow this link:
 </span>
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-archive-hacktoberfest-2022-as-maintainer.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/archive/hacktoberfest-2022/as-maintainer.mdx`

Related issues (from issues.normalized.md):
- [ ] **580. Use sentence case for H1**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/hacktoberfest-2022/as-maintainer.mdx?plain=1#L3

Change the title from “Participate as a Maintainer” to “Participate as a maintainer” to follow header capitalization guidelines.

---

- [ ] **581. Replace colloquial H2 with a clear action**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/hacktoberfest-2022/as-maintainer.mdx?plain=1#L9

Replace “Prepare to party” with a precise, professional heading such as “Prepare your repository” to improve clarity.

---

- [ ] **582. Remove all-caps emphasis**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/hacktoberfest-2022/as-maintainer.mdx?plain=1#L15

Replace the shouty phrase with normal casing, e.g., “Add the hacktoberfest topic to your repository to opt in to Hacktoberfest.”

---

- [ ] **583. Code-format labels/topics and fix label phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/hacktoberfest-2022/as-maintainer.mdx?plain=1#L15-L19

Replace quoted label/topic names with code formatting and move punctuation outside the code; rephrase to “label appropriately (for example, as `spam` or `invalid`)” and use code literals for all: `hacktoberfest`, `hacktoberfest-accepted`, `spam`, `invalid`.

---

- [ ] **584. Clarify PR/MR acceptance wording and avoid policy implication**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/hacktoberfest-2022/as-maintainer.mdx?plain=1#L18

Clarify “pull/merge requests” to “pull requests (GitHub) or merge requests (GitLab)” and state acceptance via merging or an approving review; remove or qualify mention of the `hacktoberfest-accepted` label to avoid implying official policy.

---

- [ ] **585. Replace “full repository” with a precise term**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/hacktoberfest-2022/as-maintainer.mdx?plain=1#L21

Change “example of a full repository” to a clearer phrase such as “example of a well-prepared repository” (e.g., link to ton-community/ton-compiler).

---

- [ ] **586. Use sentence case for “Rewards for Maintainers”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/hacktoberfest-2022/as-maintainer.mdx?plain=1#L25

Change the heading to “Rewards for maintainers” to follow header capitalization guidelines.

---

- [ ] **587. Fix broken Hacktoberfest link with archive snapshot**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/hacktoberfest-2022/as-maintainer.mdx?plain=1#L29

Update the “Hacktoberfest Reward Kit” link to a stable Web Archive snapshot, e.g., https://web.archive.org/web/20221001122609/https://hacktoberfest.com/participation/#maintainers.

---

- [ ] **588. Fix wallet instruction grammar and wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/hacktoberfest-2022/as-maintainer.mdx?plain=1#L30

Replace “please, register the wallet address in the [@toncontests_bot]” with “please submit your wallet address to the [@toncontests_bot]” to remove the unnecessary comma, add the possessive, and align wording with the overview.

---

- [ ] **589. Add trailing slash before internal anchor**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/hacktoberfest-2022/as-maintainer.mdx?plain=1#L30

Change “/v3/documentation/archive/hacktoberfest-2022#what-are-the-rewards” to “/v3/documentation/archive/hacktoberfest-2022/#what-are-the-rewards” to match link standards and avoid redirects.

---

- [ ] **590. Add comma after introductory clause**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/hacktoberfest-2022/as-maintainer.mdx?plain=1#L34

Change “To participate in Hack-TON-berfest follow this link:” to “To participate in Hack-TON-berfest, follow this link:” to improve readability.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.