### PR TITLE
Split: update docs/v3/documentation/archive/mining.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/archive/mining.mdx
+++ b/docs/v3/documentation/archive/mining.mdx
@@ -7,39 +7,39 @@ This information may be outdated and no longer relevant. You can skip it.
 :::
 
 
-## <a id="introduction"></a>Introduction
+## <a id="introduction" />Introduction
 
 This document provides an introduction to the process of mining Toncoin using PoW givers. Please visit [ton.org/mining](https://ton.org/mining) for up-to-date status of TON mining.
 
-## <a id="quick-start"></a>Quick start
+## <a id="quick-start" />Quick start
 
 To start mining right away:
 
 1. Get a [computer suitable for mining](#hardware).
-2. Install [Ubuntu](https://ubuntu.com) 20.04 desktop or server distribution.
-3. Install [mytonctrl](https://github.com/igroman787/mytonctrl#installation-ubuntu) in `lite` mode.
-4. Check your hardware and [expected mining income](/v3/documentation/archive/mining#income-estimates) by running `emi` command within `mytonctrl`.
-5. If you do not yet have one, create `wallet address` using one of the [wallets](https://www.ton.org/wallets).
-6. Define your `wallet address` as a mining target by executing `set minerAddr "..."` in `mytonctrl`.
-7. Chose a giver contract from the list available on [ton.org/mining](https://ton.org/mining) and set your miner to mine it by executing `set powAddr "..."` in `mytonctrl`.
-8. Start mining by executing `mon` in `mytonctrl`
+2. Install [Ubuntu](https://ubuntu.com) 20.04 or 22.04 (or Debian 11).
+3. Install [mytonctrl](https://github.com/ton-blockchain/mytonctrl) in `lite` mode.
+4. Check your hardware and [expected mining income](/v3/documentation/archive/mining#hardware-estimates) by running the `emi` command within `mytonctrl`.
+5. If you do not yet have one, create a wallet address using one of the [wallets](https://www.ton.org/wallets).
+6. Define your wallet address as a mining target by executing `set minerAddr "..."` in `mytonctrl`.
+7. Choose a giver contract from the list available on [ton.org/mining](https://ton.org/mining) and set your miner to mine it by executing `set powAddr "..."` in `mytonctrl`.
+8. Start mining by executing `mon` in `mytonctrl`.
 9. Check the CPU load on your computer; the process called `pow-miner` should use most of your CPU.
 10. Wait to get lucky; the output of step 4 should have told you approximately what your chances are to mine a block.
 
 ## <a id="basics" />Basics
 
-Toncoin is distributed by `PoW Givers`, which are smart contracts with specific amounts of Toncoin assigned to them. Currently, there are 10 active PoW givers on the TON Network. Each giver distributes coins in blocks of 100 TON. To earn one of these blocks, your computer must solve a complex mathematical challenge faster than other miners. If another miner solves the problem before you, your machine's work is discarded, and a new round begins.
+Toncoin is distributed by PoW givers, which are smart contracts with specific amounts of Toncoin assigned to them. Reward amounts and current status are defined by the contracts. To earn a reward, your computer must solve a complex mathematical challenge faster than other miners. If another miner solves the problem before you, your machine's work is discarded, and a new round begins.
 
-Mining profits are not gradual; they come in batches of 100 TON for each successfully solved giver challenge. This means that if your machine has a 10% chance to calculate a block within 24 hours (see step 4 of [Quick start](/v3/documentation/archive/mining#quick-start)) then you will probably need to wait for \~10 days before you will get a 100 TON reward.
+Mining profits are not gradual; rewards are received in batches when a giver challenge is successfully solved. This means that if your machine has a 10% chance to calculate a block within 24 hours (see step 4 of [Quick start](/v3/documentation/archive/mining#quick-start)) then you will probably need to wait for ~10 days before you get a reward.
 
-The process of mining is largely automated by `mytonctrl`. Detailed information about the mining process can be found in the PoW givers documentation (archived).
+The process of mining is largely automated by `mytonctrl`. Detailed information about the mining process can be found in the [PoW givers documentation (archived)](/v3/documentation/archive/pow-givers).
 
 ## <a id="advanced" />Advanced
 
 If you're serious about mining and want to operate multiple machines or a mining farm, it's essential to learn about TON and how mining works. Refer to the [TON documentation](/v3/documentation/ton-documentation) for detailed information. Here is some general advice:
 
-- **DO** run your own node / lite server on a separate machine; this will ensure that your mining farm does not depend on external lite servers that can go down or not process your queries in a timely fashion.
-- **DO NOT** bombard public lite servers with `get_pow_params` queries, if you have custom scripts that poll givers status in high frequency you **must** use your own lite server. Clients that violate this rule risk having their IPs blacklisted on public lite servers.
+- **DO** run your own node/lite server on a separate machine; this will ensure that your mining farm does not depend on external lite servers that can go down or not process your queries in a timely fashion.
+- **DO NOT** bombard public lite servers with `get_pow_params` queries. If you have custom scripts that poll givers' status at a high frequency, you **must** use your own lite server. Clients that violate this rule risk having their IP addresses blacklisted on public lite servers.
 - **DO** try to understand how the mining process works; most larger miners use their own scripts that offer many advantages over `mytonctrl` in environments with multiple mining machines.
 
 ## <a id="hardware" />Miner hardware
@@ -52,15 +52,15 @@ A modern CPU with [Intel SHA Extension](https://en.wikipedia.org/wiki/Intel_SHA_
 
 #### GPU
 
-Yes! You can mine TON using GPU. There is a version of a PoW miner that is capable to use both Nvidia and AMD GPUs; you can find the code and instructions on how to use it in the [POW Miner GPU](https://github.com/tontechio/pow-miner-gpu/blob/main/crypto/util/pow-miner-howto.md) repository.
+Yes! You can mine TON using GPU. There is a version of a PoW miner that is capable of using both NVIDIA and AMD GPUs; you can find the code and instructions in the [PoW Miner GPU](https://github.com/tontechio/pow-miner-gpu/blob/main/crypto/util/pow-miner-howto.md) repository.
 
-As for now, one needs to be tech-savvy to use this, but we are working on a more user-friendly solution.
+For now, using it requires advanced setup; no simplified workflow is provided here.
 
 #### Memory
 
 Almost the entire mining process happens in the L2 cache of the CPU. That means that memory speed and size play no role in mining performance. A dual AMD EPYC system with a single DIMM on one memory channel will mine just as fast as one with 16 DIMMs occupying all channels.
 
-Please do note that this applies to the plain mining process **only**, if your machine also runs full node or other processes, then things change! But this is outside the scope of this guide.
+Please note that this applies to the plain mining process only. If your machine also runs a full node or other processes, then things change.
 
 #### Storage
 
@@ -68,11 +68,11 @@ A miner running in lite mode uses minimal storage space and does not store data.
 
 #### Network
 
-Plain miner needs the ability to open outgoing connections to the Internet.
+A plain miner needs the ability to open outgoing connections to the Internet.
 
 #### FPGA / ASIC
 
-See [can I use FPGA / ASICs?](/v3/documentation/archive/mining#can-i-use-my-btceth-rig-to-mine-ton)
+See [can I use FPGA / ASICs?](/v3/documentation/archive/mining#faq-hw-asic)
 
 ### <a id="hardware-cloud" />Cloud machines
 
@@ -98,22 +98,22 @@ Est. monthly income:                437.7 TON
 
 ### <a id="faq-general" />General
 
-#### <a id="faq-general-posorpow" />Is TON PoS or PoW network?
+#### <a id="faq-general-posorpow" />Is TON a PoS or PoW network?
 
 TON Blockchain operates on a Proof-of-Stake (PoS) consensus. Mining is not required to create new blocks.
 
 #### <a id="faq-general-pow" />So how come TON is Proof-of-Work?
 
-Well, the reason is that the initial issue of 5 billion Toncoins were transferred to ad hoc Proof-of-Work Giver smart contracts.
+Well, the reason is that the initial issue of 5 billion Toncoins was transferred to ad hoc Proof-of-Work Giver smart contracts.
 Mining is used to obtain Toncoins from this smart contract.
 
 #### <a id="faq-general-supply" />How many coins are left for mining?
 
-The most actual information is available on [ton.org/mining](https://ton.org/mining), see `bleed` graphs. PoW Giver contracts have their limits and will dry out once users mine all the available Toncoins.
+The most up-to-date information is available on [ton.org/mining](https://ton.org/mining), see `bleed` graphs. PoW Giver contracts have their limits and will dry out once users mine all the available Toncoins.
 
 #### <a id="faq-general-mined" />How many coins have been mined already?
 
-As of August 2021, about 4.9BN Toncoins have been mined.
+As of August 2021, about 4.9 billion Toncoins have been mined.
 
 #### <a id="faq-general-whomined" />Who has mined those coins?
 
@@ -123,7 +123,7 @@ Coins have been mined to over 70,000 wallets. The owners of these wallets remain
 
 Not at all. All you need is [adequate hardware](#hardware) and to follow the steps outlined in the [quick start](#quick-start) section.
 
-#### <a id="faq-general-pissed" />Is there another way to mine?
+#### <a id="faq-general-alternative" />Is there another way to mine?
 
 Yes, there is a third-party app—[TON Miner Bot](https://t.me/TonMinerBot).
 
@@ -133,7 +133,7 @@ Yes, there is a third-party app—[TON Miner Bot](https://t.me/TonMinerBot).
 
 #### <a id="faq-general-howmany" />How many miners are out there?
 
-We cannot say this. All we know is the total hashrate of all miners on the network. However, there are graphs on [ton.org/mining](https://ton.org/mining) that attempt to estimate quantity of machines of certain type needed to provide approximate total hashrate.
+We cannot answer this. We only know the total hashrate of all miners on the network. However, there are graphs on [ton.org/mining](https://ton.org/mining) that estimate the number of machines of certain types needed to provide the approximate total hashrate.
 
 #### <a id="faq-general-noincome" />Do I need Toncoin to start mining?
 
@@ -141,11 +141,11 @@ No, you do not. Anyone can start mining without owning a single Toncoin.
 
 #### <a id="faq-mining-noincome" />Why does my wallet balance not increase, even after hours of mining?
 
-TON are mined in blocks of 100, you either guess a block and receive 100 TON or receive nothing. Please see [basics](#basics).
+Toncoin is mined via rewards defined by the specific PoW giver contract; you either receive a reward when you find a valid solution or receive nothing. Please see [basics](#basics).
 
 #### <a id="faq-mining-noblocks" />I've been mining for days and I see no results, why?
 
-Did you check your current [Income estimates](/v3/documentation/archive/mining#income-estimates)? If field `Est. 24h chance to mine a block` is less than 100%, then you need to be patient. Also, please note that a 50% chance to mine a block within 24 hours does not automatically mean that you will mine one within 2 days; 50% applies to each day separately.
+Did you check your current [Income estimates](/v3/documentation/archive/mining#hardware-estimates)? If field `Est. 24h chance to mine a block` is less than 100%, then you need to be patient. Also, please note that a 50% chance to mine a block within 24 hours does not automatically mean that you will mine one within 2 days; 50% applies to each day separately.
 
 #### <a id="faq-mining-pools" />Are there mining pools?
 
@@ -161,17 +161,17 @@ It does not really matter which giver you choose. The difficulty tends to fluctu
 
 No, all miners take different roads to find the solution. A faster machine has a higher probability of success, but it doesn't guarantee victory!
 
-#### <a id="faq-hw-machine" />How much income will my machine generate?
+#### <a id="faq-hw-income" />How much income will my machine generate?
 
-Please see [Income estimates](/v3/documentation/archive/mining#income-estimates).
+Please see [Income estimates](/v3/documentation/archive/mining#hardware-estimates).
 
 #### <a id="faq-hw-asic" />Can I use my BTC/ETH rig to mine TON?
 
-No, TON uses a single SHA256 hashing method which is different from BTC, ETH, and others. ASICS or FPGAs which are built for mining other cryptos will not help.
+No, TON uses a single SHA256 hashing method which is different from BTC, ETH, and others. ASICs or FPGAs which are built for mining other cryptos will not help.
 
 #### <a id="faq-hw-svsm" />What is better, a single fast machine or several slow ones?
 
-This is controversial. See: miner software launches threads for each core on the system, and each core gets its own set of keys to process, so if you have one machine capable to run 64 threads and 4 x machines capable to run 16 threads each, then they will be exactly as successful assuming that the speed of each thread is the same.
+This is controversial. See: miner software launches threads for each core on the system, and each core gets its own set of keys to process, so if you have one machine capable to run 64 threads and 4 machines capable to run 16 threads each, then they will be exactly as successful assuming that the speed of each thread is the same.
 
 In the real world, however, CPUs with lower core count are usually clocked higher, so you will probably have better success with multiple machines.
 
@@ -181,24 +181,24 @@ No, they will not. Each machine mines on its own, but the solution finding proce
 
 #### <a id="faq-hw-CPU" />Can I mine using ARM CPUs?
 
-Depending on the CPU, AWS Graviton2 instances are indeed very capable miners and are able to hold price/performance ratio alongside AMD EPYC-based instances.
+Depending on the CPU, AWS Graviton2 instances can be very capable miners and offer a price/performance ratio comparable to AMD EPYC–based instances.
 
 ### <a id="faq-software" />Software
 
-#### <a id="faq-software-os" />Can I mine using Windows/xBSD/some other OS?
+#### <a id="faq-software-os" />Can I mine using Windows/BSD variants/some other OS?
 
-Of course, [TON source code](https://github.com/ton-blockchain/ton) has been known to be built on Windows, xBSD and other OSes. However, there is no comfortable automated installation, as under Linux with `mytonctrl`, you will need to install the software manually and create your own scripts. For FreeBSD, there is a [port](https://github.com/sonofmom/freebsd_ton_port) source code that allows quick installation.
+Of course, [TON source code](https://github.com/ton-blockchain/ton) has been known to be built on Windows, BSD variants and other OSes. However, there is no convenient automated installation as there is under Linux with `mytonctrl`; you will need to install the software manually and create your own scripts. For FreeBSD, there is a [port](https://github.com/sonofmom/freebsd_ton_port) source code that allows quick installation.
 
 #### <a id="faq-software-node1" />Will my mining become faster if I run mytonctrl in full node mode?
 
 Calculation process by itself will not be faster, but you will gain some stability and, most importantly, flexibility if you operate your own full node/lite server.
 
-#### <a id="faq-software-node2" />What do I need to / how can I operate a full node?
+#### <a id="faq-software-node2" />What do I need to operate a full node, and how can I do so?
 
 This is out of scope of this guide, please consult [Run a full node](/v3/guidelines/nodes/running-nodes/full-node) and/or [mytonctrl instructions](https://github.com/igroman787/mytonctrl).
 
 #### <a id="faq-software-build" />Can you help me to build software on my OS?
 
-This is out of scope of this guide, please consult [Run a full node](/v3/guidelines/nodes/running-nodes/full-node) as well as [Mytonctrl installation scripts](https://github.com/igroman787/mytonctrl/blob/master/scripts/toninstaller.sh#L44) for information about dependencies and process.
+This is out of scope of this guide, please consult [Run a full node](/v3/guidelines/nodes/running-nodes/full-node) as well as [mytonctrl installation scripts](https://github.com/igroman787/mytonctrl/blob/master/scripts/toninstaller.sh#L44) for information about dependencies and process.
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-archive-mining.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/archive/mining.mdx`

Related issues (from issues.normalized.md):
- [ ] **591. Make heading anchor tags consistent**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L10-L11,L14-L15,L29,L37,L45

Use a consistent anchor format in headings (prefer self-closing <a id="..." /> everywhere, or remove manual anchors and rely on automatic slugs).

---

- [ ] **592. Standardize ‘PoW givers’ capitalization and formatting**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L12,L31

Use the same casing and no code formatting: change backticked ‘PoW Givers’ to plain ‘PoW givers’ everywhere.

---

- [ ] **593. Add article before emi command**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L21

Change ‘by running `emi` command’ to ‘by running the `emi` command’.

---

- [ ] **594. Remove code formatting from ‘wallet address’ and add article**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L22-L23

Change ‘create `wallet address`’ to ‘create a wallet address’ and ‘Define your `wallet address`’ to ‘Define your wallet address’.

---

- [ ] **595. Fix typo ‘Chose’ to ‘Choose’**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L24

In Quick start item 7, change ‘Chose a giver contract…’ to ‘Choose a giver contract…’.

---

- [ ] **596. Add missing period to Step 8**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L25

Add a terminal period to Quick start item 8 for consistency.

---

- [ ] **597. Fix phrasing ‘before you will get’**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L33

Change to ‘… then you will probably need to wait for ~10 days before you get a 100 TON reward.’

---

- [ ] **598. Remove spaces around slash**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L41

Change ‘node / lite server’ to ‘node/lite server’.

---

- [ ] **599. Fix comma splice and grammar in DO NOT bullet**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L42

Split into sentences and adjust grammar/possessive: ‘… queries. If you have custom scripts that poll givers’ status at a high frequency, you must use your own lite server. Clients that violate this risk having their IP addresses blacklisted on public lite servers.’

---

- [ ] **600. Fix GPU section grammar, branding, and tone**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L55-L57

Use ‘capable of using’ and brand casing ‘NVIDIA’; standardize link text to ‘PoW Miner GPU’; rephrase forward‑looking wording to a neutral statement (e.g., ‘For now, using it requires advanced setup; no simplified workflow is provided here.’).

---

- [ ] **601. Fix memory note punctuation and articles**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L63

Split into sentences, add missing article, and remove the exclamation point: ‘Please note that this applies to the plain mining process only. If your machine also runs a full node or other processes, then things change.’

---

- [ ] **602. Add article in network requirement**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L71

Change to ‘A plain miner needs the ability to open outgoing connections to the Internet.’

---

- [ ] **603. Add article in FAQ title**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L101-L103

Change ‘Is TON PoS or PoW network?’ to ‘Is TON a PoS or PoW network?’

---

- [ ] **604. Fix subject–verb agreement in PoW explanation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L105-L108

Change ‘the initial issue of 5 billion Toncoins were transferred’ to ‘the initial issue of 5 billion Toncoins was transferred’.

---

- [ ] **605. Replace ‘most actual’ with ‘most up-to-date’**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L112-L116

Change to ‘The most up‑to‑date information is available on ton.org/mining…’.

---

- [ ] **606. Replace ‘BN’ with ‘billion’**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L116

Change ‘4.9BN Toncoins’ to ‘4.9 billion Toncoins’.

---

- [ ] **607. Rename unprofessional anchor id**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L126

Rename ‘faq-general-pissed’ to a neutral id such as ‘faq-general-alternative’ and update any references.

---

- [ ] **608. Improve ‘How many miners’ answer grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L134-L137

Rephrase for clarity: ‘We cannot answer this. We only know the total hashrate of all miners on the network. However, there are graphs on ton.org/mining that estimate the number of machines of certain types needed to provide the approximate total hashrate.’

---

- [ ] **609. Correct mining reward description and agreement**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L142-L144

Change ‘TON are mined in blocks of 100’ to ‘Toncoin is mined…’ and remove the fixed ‘100’ claim or clarify that reward size depends on the specific PoW giver contract.

---

- [ ] **610. Make FAQ anchor ids unique**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L160,L164

Two items use id ‘faq-hw-machine’; rename one (e.g., to ‘faq-hw-income’) and update references.

---

- [ ] **611. Use standard plural/casing ‘ASICs’**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L170

Change ‘ASICS or FPGAs’ to ‘ASICs or FPGAs’.

---

- [ ] **612. Fix ‘4 x machines’ style**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L174

Use ‘four machines’, ‘4 machines’, or ‘4× machines’ (no spaces around ‘×’).

---

- [ ] **613. Clarify ARM CPUs answer**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L184

Rephrase to: ‘AWS Graviton2 instances can be very capable miners and offer a price/performance ratio comparable to AMD EPYC–based instances.’

---

- [ ] **614. Rephrase OS support and installation wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L188-L191

Use ‘BSD variants’ instead of ‘xBSD’ and clarify: ‘However, there is no convenient automated installation as there is under Linux with mytonctrl; you will need to install the software manually and create your own scripts.’

---

- [ ] **615. Rephrase full node question**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L196

Change the question to avoid the slash: ‘What do I need to operate a full node, and how can I do so?’

---

- [ ] **616. Standardize ‘mytonctrl’ capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#L202

Change the link text ‘Mytonctrl installation scripts’ to ‘mytonctrl installation scripts’ to match earlier usage.

---

- [ ] **617. Update MyTonCtrl link in Quick start to official repo**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#quick-start

Change the Step 3 link from ‘https://github.com/igroman787/mytonctrl#installation-ubuntu’ to ‘https://github.com/ton-blockchain/mytonctrl’ (or link directly to its scripts/install.sh as used elsewhere in the docs).

---

- [ ] **618. Fix broken anchors to Income estimates**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#quick-start, docs/v3/documentation/archive/mining.mdx#faq-hw

Update links pointing to ‘#income-estimates’ to ‘#hardware-estimates’ (or rename the section id to ‘income-estimates’) so internal links resolve.

---

- [ ] **619. Fix broken anchor to FPGA/ASIC FAQ**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#hardware

Change the link target from ‘#can-i-use-my-btceth-rig-to-mine-ton’ to ‘#faq-hw-asic’.

---

- [ ] **620. Remove hardcoded PoW givers count and reward size**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#basics

Replace statements like ‘Currently, there are 10 active PoW givers…’ and ‘Each giver distributes coins in blocks of 100 TON’ with neutral wording that reward amounts are contract‑defined; direct readers to ton.org/mining for current status.

---

- [ ] **621. Link to archived PoW givers documentation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#basics

Turn the reference to ‘PoW givers documentation (archived)’ into a link to ‘/v3/documentation/archive/pow-givers’.

---

- [ ] **622. Broaden Quick start OS versions**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#quick-start

Update Step 2 to reflect supported OS: ‘Install Ubuntu 20.04 or 22.04 (or Debian 11).’

---

- [ ] **623. Fix preposition in wallets sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#faq-general-whomined

Change ‘Coins have been mined to over 70,000 wallets’ to ‘Coins have been mined into over 70,000 wallets.’

---

- [ ] **624. Update MyTonCtrl links in FAQ to official repo**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/mining.mdx?plain=1#faq-software-node2, docs/v3/documentation/archive/mining.mdx#faq-software-build

Change links from the unofficial ‘igroman787/mytonctrl’ repo to ‘https://github.com/ton-blockchain/mytonctrl’ (and, if deep-linking to installer, use ‘scripts/install.sh’).

---

- [ ] **629. Remove or annotate specific payout amounts (and fix phrasing)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/pow-givers.mdx?plain=1#L17-L31,L198

Eliminate specific Toncoin amounts or mark them as historical with a link to the mining overview (docs/v3/documentation/archive/mining.mdx#basics); if any wording remains, rephrase to “deliver between 10 and 100 Toncoin every few minutes.”

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.