### PR TITLE
Split: update docs/v3/documentation/archive/precompiled-binaries.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/archive/precompiled-binaries.mdx
+++ b/docs/v3/documentation/archive/precompiled-binaries.mdx
@@ -22,7 +22,7 @@ If you don't use Blueprint SDK for smart contracts development, you can use prec
 
 ### Prerequisites
 
-For the local development of TON smart contracts _without Javascript_, you need to prepare binaries of `func`, `fift`, and `lite client` on your device.
+For the local development of TON smart contracts _without JavaScript_, you need to prepare binaries of `func`, `fift`, and `lite-client` on your device.
 
 You can download and set them up below, or read this article from TON Society:
 
@@ -30,17 +30,17 @@ You can download and set them up below, or read this article from TON Society:
 
 ### 1. Download
 
-Download the binaries from the table below.  Make sure to select the correct version for your operating system and to install any additional dependencies:
+Download the binaries from the table below. Make sure to select the correct version for your operating system and to install any additional dependencies:
 
 | OS             | TON binaries                                                                                    | fift                                                                                         | func                                                                                         | lite-client                                                                                         | Additional dependencies                                                      |
 | -------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| MacOS x86-64   | [download](https://github.com/ton-blockchain/ton/releases/latest/download/ton-mac-x86-64.zip)   | [download](https://github.com/ton-blockchain/ton/releases/latest/download/fift-mac-x86-64)   | [download](https://github.com/ton-blockchain/ton/releases/latest/download/func-mac-x86-64)   | [download](https://github.com/ton-blockchain/ton/releases/latest/download/lite-client-mac-x86-64)   |                                                                              |
-| MacOS arm64    | [download](https://github.com/ton-blockchain/ton/releases/latest/download/ton-mac-arm64.zip)    |                                                                                              |                                                                                              |                                                                                                     | `brew install openssl ninja libmicrohttpd pkg-config`                        |
-| Windows x86-64 | [download](https://github.com/ton-blockchain/ton/releases/latest/download/ton-win-x86-64.zip)   | [download](https://github.com/ton-blockchain/ton/releases/latest/download/fift.exe)          | [download](https://github.com/ton-blockchain/ton/releases/latest/download/func.exe)          | [download](https://github.com/ton-blockchain/ton/releases/latest/download/lite-client.exe)          | Install [OpenSSL 1.1.1](/ton-binaries/windows/Win64OpenSSL_Light-1_1_1q.msi) |
-| Linux  x86_64  | [download](https://github.com/ton-blockchain/ton/releases/latest/download/ton-linux-x86_64.zip) | [download](https://github.com/ton-blockchain/ton/releases/latest/download/fift-linux-x86_64) | [download](https://github.com/ton-blockchain/ton/releases/latest/download/func-linux-x86_64) | [download](https://github.com/ton-blockchain/ton/releases/latest/download/lite-client-linux-x86_64) |                                                                              |
-| Linux  arm64   | [download](https://github.com/ton-blockchain/ton/releases/latest/download/ton-linux-arm64.zip)  |                                                                                              |                                                                                              |                                                                                                     | `sudo apt install libatomic1 libssl-dev`                                     |
+| macOS x86_64   | [download](https://github.com/ton-blockchain/ton/releases/latest/download/ton-mac-x86-64.zip)   | [download](https://github.com/ton-blockchain/ton/releases/latest/download/fift-mac-x86-64)   | [download](https://github.com/ton-blockchain/ton/releases/latest/download/func-mac-x86-64)   | [download](https://github.com/ton-blockchain/ton/releases/latest/download/lite-client-mac-x86-64)   |                                                                              |
+| macOS arm64    | [download](https://github.com/ton-blockchain/ton/releases/latest/download/ton-mac-arm64.zip)    |                                                                                              |                                                                                              |                                                                                                     | `brew install openssl ninja libmicrohttpd pkg-config`                        |
+| Windows x86_64 | [download](https://github.com/ton-blockchain/ton/releases/latest/download/ton-win-x86-64.zip)   | [download](https://github.com/ton-blockchain/ton/releases/latest/download/fift.exe)          | [download](https://github.com/ton-blockchain/ton/releases/latest/download/func.exe)          | [download](https://github.com/ton-blockchain/ton/releases/latest/download/lite-client.exe)          | Install [OpenSSL 1.1.1](/ton-binaries/windows/Win64OpenSSL_Light-1_1_1q.msi) |
+| Linux x86_64   | [download](https://github.com/ton-blockchain/ton/releases/latest/download/ton-linux-x86_64.zip) | [download](https://github.com/ton-blockchain/ton/releases/latest/download/fift-linux-x86_64) | [download](https://github.com/ton-blockchain/ton/releases/latest/download/func-linux-x86_64) | [download](https://github.com/ton-blockchain/ton/releases/latest/download/lite-client-linux-x86_64) |                                                                              |
+| Linux arm64    | [download](https://github.com/ton-blockchain/ton/releases/latest/download/ton-linux-arm64.zip)  |                                                                                              |                                                                                              |                                                                                                     | `sudo apt install libatomic1 libssl-dev`                                     |
 
-### 2. Setup your binaries
+### 2. Set up your binaries
 
 export const Highlight = ({children, color}) => (
 <span
@@ -56,33 +56,33 @@ padding: '0.2rem',
 
 <Tabs groupId="operating-systems">
   <TabItem value="win" label="Windows">
-    1. After downloading, you need to `create` a new folder. For example: **`C:/Users/%USERNAME%/ton/bin`** and move the installed files there.
+    1. After downloading, you need to `create` a new folder. For example: **`C:\\Users\\%USERNAME%\\ton\\bin`** and move the installed files there.
 
-    2. To open the Windows environment variables, press the <Highlight color="#1877F2">Win + R</Highlight> buttons on the keyboard, type `sysdm.cpl`, and press Enter.
+    2. To open the Windows environment variables, press the <Highlight color="#1877F2">Win + R</Highlight> keys on the keyboard, type `sysdm.cpl`, and press Enter.
 
     3. On the "_Advanced_" tab, click the <Highlight color="#1877F2">"Environment Variables..."</Highlight> button.
 
     4. In the _"User variables"_ section, select the "_Path_" variable and click <Highlight color="#1877F2">"Edit"</Highlight> (this is usually required).
 
-    5. To add a new value `(path)` to the system variable in the next window, click the  button <Highlight color="#1877F2">"New"</Highlight>.
+    5. To add a new PATH entry to the system variable in the next window, click the button <Highlight color="#1877F2">"New"</Highlight>.
        In the new field, you need to specify the path to the folder where the previously installed files are stored:
 
     ```
     C:\Users\%USERNAME%\ton\bin\
     ```
 
-    6. To check whether everything was installed correctly, run in terminal (_cmd.exe_):
+    6. To check whether everything was installed correctly, run in terminal (_PowerShell_):
 
-    ```bash
-    fift -V -and func -V -and lite-client -V
+    ```powershell
+    fift -V; func -V; lite-client -V
     ```
 
     7. If you plan to use fift, you need `FIFTPATH` environment variable with the necessary imports:
 
-       1. Download [fiftlib.zip](/ton-binaries/windows/fiftlib.zip)
-       2. Open the zip in some directory on your machine (like **`C:/Users/%USERNAME%/ton/lib/fiftlib`**)
+       1. Download [fiftlib.zip](/ton-binaries/fiftlib.zip)
+       2. Open the zip in some directory on your machine (like **`C:\\Users\\%USERNAME%\\ton\\lib\\fiftlib`**)
        3. Create a new (click button <Highlight color="#1877F2">"New"</Highlight>) environment variable `FIFTPATH` in "_User variables_" section.
-       4. In the "_Variable value_" field, specify the path to the files: **`/%USERNAME%/ton/lib/fiftlib`** and click <Highlight color="#1877F2">OK</Highlight>. Done.
+       4. In the "_Variable value_" field, specify the path to the files: **`C:\\Users\\%USERNAME%\\ton\\lib\\fiftlib`** and click <Highlight color="#1877F2">OK</Highlight>. Done.
 
 :::caution important
 Instead of the `%USERNAME%` keyword, you must insert your own `username`.
@@ -90,7 +90,7 @@ Instead of the `%USERNAME%` keyword, you must insert your own `username`.
 
   </TabItem>
 
-  <TabItem value="mac" label="Linux / MacOS">
+  <TabItem value="mac" label="Linux / macOS">
     1. After downloading, make sure the downloaded binaries are executable by changing their permissions.
 
     ```bash
@@ -99,12 +99,12 @@ Instead of the `%USERNAME%` keyword, you must insert your own `username`.
     chmod +x lite-client
     ```
 
-    2. It's also useful to add these binaries to your path (or copy them to `/usr/local/bin`) so you can access them from anywhere.
+    2. It's also useful to add these binaries to your path (or copy them to `/usr/local/bin`) so you can access them from anywhere. This may require `sudo`.
 
     ```bash
-    cp ./func /usr/local/bin/func
-    cp ./fift /usr/local/bin/fift
-    cp ./lite-client /usr/local/bin/lite-client
+    sudo cp ./func /usr/local/bin/func
+    sudo cp ./fift /usr/local/bin/fift
+    sudo cp ./lite-client /usr/local/bin/lite-client
     ```
 
     3. To check that everything was installed correctly, run in terminal.
@@ -113,16 +113,16 @@ Instead of the `%USERNAME%` keyword, you must insert your own `username`.
     fift -V && func -V && lite-client -V
     ```
 
-    4. If you plan to `use fift`, also download [fiftlib.zip](/ton-binaries/windows/fiftlib.zip), open the zip in some directory on your device (like `/usr/local/lib/fiftlib`), and set the environment variable `FIFTPATH` to point to this directory.
+    4. If you plan to use fift, also download [fiftlib.zip](/ton-binaries/fiftlib.zip), open the zip in some directory on your device (like `/usr/local/lib/fiftlib`), and set the environment variable `FIFTPATH` to point to this directory.
 
-    ```
+    ```bash
     unzip fiftlib.zip
     mkdir -p /usr/local/lib/fiftlib
     cp fiftlib/* /usr/local/lib/fiftlib
     ```
 
-:::info Hey, you're almost finished :)
-Remember to set the [environment variable](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux-unix) `FIFTPATH` to point to this directory.
+:::info
+Remember to set the `FIFTPATH` environment variable to point to this directory (for example: `export FIFTPATH=/usr/local/lib/fiftlib`). Consider adding it to your shell profile to persist across sessions.
 :::
 
   </TabItem>
@@ -130,7 +130,7 @@ Remember to set the [environment variable](https://stackoverflow.com/questions/1
 
 ## Build from source
 
-If you don't want to rely on pre-compiled binaries and prefer to compile the binaries yourself, you can follow the [official instructions](/v3/guidelines/smart-contracts/howto/compile/compilation-instructions).
+If you don't want to rely on precompiled binaries and prefer to compile the binaries yourself, you can follow the [official instructions](/v3/guidelines/smart-contracts/howto/compile/compilation-instructions).
 
 The ready-to-use gist instructions are provided below:
 
@@ -146,8 +146,8 @@ mkdir ~/ton/build && cd ~/ton/build && cmake .. -DCMAKE_BUILD_TYPE=Release && ma
 
 ## Other sources for binaries
 
-The core team provides automatic builds for several operating systems as [GitHub Actions](https://github.com/ton-blockchain/ton/releases/latest).
+The core team provides automatic builds for several operating systems as [Release assets](https://github.com/ton-blockchain/ton/releases/latest).
 
-Click on the link above, choose the workflow on the left relevant to your operating system, click on a recent green passing build, and download `ton-binaries` under "Artifacts".
+Open the link above, choose the latest release, and download `ton-binaries` under "Assets".
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-archive-precompiled-binaries.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/archive/precompiled-binaries.mdx`

Related issues (from issues.normalized.md):
- [ ] **643. Remove duplicate “Precompiled binaries” subheading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/precompiled-binaries.mdx?plain=1#L19

An H2 titled “Precompiled binaries” appears directly under an H1 with the same title; remove or rename the H2 (e.g., “Overview” or “Manual installation”) to avoid redundancy and duplicate anchors.

---

- [ ] **644. Use binary name “lite-client” in Prerequisites**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/precompiled-binaries.mdx?plain=1#L25

Replace the literal “`lite client`” with “`lite-client`” to match the actual executable and later usage.

---

- [ ] **645. Capitalize JavaScript correctly**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/precompiled-binaries.mdx?plain=1#L25

Change “without Javascript” to “without JavaScript”.

---

- [ ] **646. Standardize macOS and table labels**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/precompiled-binaries.mdx?plain=1#L37-L38,L93

Use “macOS” (not “MacOS”) in the table and tab label; harmonize architecture notation (e.g., “x86_64”, “arm64” consistently) and remove double spaces in labels (e.g., “Linux x86_64” → “Linux x86_64”).

---

- [ ] **647. Clarify arm64 rows: links and dependencies**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/precompiled-binaries.mdx?plain=1#L37-L41

For “macOS arm64” and “Linux arm64”, either provide per‑tool links (fift/func/lite-client) or add a note that the archive includes all tools; list Homebrew/dependencies consistently for both macOS architectures or move dependency guidance to per‑OS notes.

---

- [ ] **648. Use “Set up your binaries” heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/precompiled-binaries.mdx?plain=1#L43

Change the section title from “Setup your binaries” to “Set up your binaries”.

---

- [ ] **649. Use backslashes in Windows path examples**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/precompiled-binaries.mdx?plain=1#L59

Standardize the Windows example path to backslashes: change “C:/Users/%USERNAME%/ton/bin” to “C:\Users\%USERNAME%\ton\bin”.

---

- [ ] **650. Fix Windows verification command and code block language**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/precompiled-binaries.mdx?plain=1#L74-L78

The command is described for cmd.exe but uses PowerShell’s “-and” and is tagged “bash”; for cmd.exe use “fift -V && func -V && lite-client -V” with language “bat”, or for PowerShell use “fift -V; func -V; lite-client -V” with language “powershell”.

---

- [ ] **651. Fix Windows FIFTPATH example path**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/precompiled-binaries.mdx?plain=1#L85

Replace the UNIX-like “/%USERNAME%/ton/lib/fiftlib” with a valid Windows path, e.g., “C:\Users\%USERNAME%\ton\lib\fiftlib”.

---

- [ ] **652. Use sudo when copying to /usr/local/bin**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/precompiled-binaries.mdx?plain=1#L104-L108

Copying into “/usr/local/bin” typically requires elevated privileges; prefix the cp commands with sudo or instruct adding the binaries directory to PATH instead.

---

- [ ] **653. Provide FIFTPATH export example for Linux/macOS**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/precompiled-binaries.mdx?plain=1#L116-L126

After installing fiftlib, add a concrete example such as “export FIFTPATH=/usr/local/lib/fiftlib” and suggest adding it to a shell profile for persistence.

---

- [ ] **654. Replace casual callout with neutral instruction**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/precompiled-binaries.mdx?plain=1#L124-L126

Rephrase “Hey, you're almost finished :)” to a neutral tone, e.g., “Remember to set the FIFTPATH environment variable to this directory.”

---

- [ ] **655. Align “Other sources” text with Releases link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/precompiled-binaries.mdx?plain=1#L147-L151

The text describes downloading artifacts from GitHub Actions but links to Releases; either change the link to the Actions page or revise the text to explain downloading assets from the Releases page (TON auto builds).

---

- [ ] **656. Tidy wording in Windows steps**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/precompiled-binaries.mdx?plain=1

Change “press the Win + R buttons” to “press the Win + R keys”, remove the extra space in “click the button”, and rephrase “add a new value (path)” to “add a new PATH entry”.

---

- [ ] **657. Remove code formatting in “use fift” phrase**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/precompiled-binaries.mdx?plain=1

Avoid code formatting on the prose phrase “use fift”; use plain text (“If you plan to use fift”) and format tool names consistently elsewhere as needed.

---

- [ ] **658. Avoid Windows-only path for fiftlib download**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/precompiled-binaries.mdx?plain=1

Both sections link to “/ton-binaries/windows/fiftlib.zip”; update to a platform‑agnostic path (e.g., “/ton-binaries/fiftlib.zip”) or add a note that the archive is cross‑platform.

---

- [ ] **659. Add bash language tag to unzip/copy snippet**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/precompiled-binaries.mdx?plain=1

Add a “bash” language tag to the unzip/mkdir/cp snippet for proper syntax highlighting.

---

- [ ] **660. Use “precompiled” consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/precompiled-binaries.mdx?plain=1

Standardize on “precompiled” (no hyphen) throughout the page to match the title.

---

- [ ] **661. Remove double space after period**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/precompiled-binaries.mdx?plain=1

Fix “Download the binaries from the table below. Make sure...” to use a single space after the period.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.