### PR TITLE
Split: update docs/v3/documentation/archive/tg-bot-integration-py.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/archive/tg-bot-integration-py.mdx
+++ b/docs/v3/documentation/archive/tg-bot-integration-py.mdx
@@ -5,10 +5,10 @@ import Button from '@site/src/components/button'
 # TON Connect for Telegram Bots - Python
 
 :::warning deprecated
-This guide explains an outdated method of integrating TON Connect with Telegram bots. For a more secure and modern approach, consider using [Telegram Mini Apps](/v3/guidelines/dapps/tma/overview for a more modern and secure integration.
+This guide explains an outdated method of integrating TON Connect with Telegram bots. For a more secure and modern approach, consider using [Telegram Mini Apps](/v3/guidelines/dapps/tma/overview) for a more modern and secure integration.
 :::
 
-In this tutorial, we’ll create a sample telegram bot that supports TON Connect 2.0 authentication using Python TON Connect SDK [pytonconnect](https://github.com/XaBbl4/pytonconnect).
+In this tutorial, we’ll create a sample Telegram bot that supports TON Connect 2.0 authentication using Python TON Connect SDK [pytonconnect](https://github.com/XaBbl4/pytonconnect).
 We will analyze connecting a wallet, sending a transaction, getting data about the connected wallet, and disconnecting a wallet.
 
  
@@ -30,9 +30,9 @@ Check out GitHub
 
 ### Install libraries
 
-To make bot we are going to use `aiogram` 3.0 Python library.
+To build the bot, we use the aiogram 3.0 Python library.
 To start integrating TON Connect into your Telegram bot, you need to install the `pytonconnect` package.
-And to use TON primitives and parse user address we need `pytoniq-core`.
+To use TON primitives and parse the user address, install `pytoniq-core`.
 You can use pip for this purpose:
 
 ```bash
@@ -41,7 +41,7 @@ pip install pytonconnect
 ```
 
 ### Set up config
-Specify in `.env` file [bot token](https://t.me/BotFather) and link to the TON Connect [manifest file](https://github.com/ton-connect/sdk/tree/main/packages/sdk#add-the-tonconnect-manifest). After load them in `config.py`:
+Specify in `.env` file the [bot token](https://t.me/BotFather) and a link to the TON Connect [manifest file](/v3/guidelines/ton-connect/creating-manifest) (for example, `https://<YOUR_APP_URL>/tonconnect-manifest.json`). Then load them into `config.py`:
 
 ```dotenv
 # .env
@@ -62,7 +62,7 @@ TOKEN = env['TOKEN']
 MANIFEST_URL = env['MANIFEST_URL']
 ```
 
-## Create simple bot
+## Create a simple bot
 
 Create `main.py` file which will contain the main bot code:
 
@@ -106,7 +106,7 @@ if __name__ == "__main__":
 
 ### TON Connect Storage
 
-Let's create simple storage for TON Connect
+Let's create a simple storage class for TON Connect.
 
 ```python
 # tc_storage.py
@@ -138,7 +138,7 @@ class TcStorage(IStorage):
 
 ### Connection handler
 
-Firstly, we need function which returns different instances for each user:
+First, we need a function that returns a different instance for each user:
 
 ```python
 # connector.py
@@ -153,7 +153,9 @@ def get_connector(chat_id: int):
     return TonConnect(config.MANIFEST_URL, storage=TcStorage(chat_id))
 
 ```
-Secondary, let's add connection handler in `command_start_handler()`:
+Secondly, add a connection handler in `command_start_handler()`:
+
+Note: Some imports used in the snippets below appear in the full `main.py` listing at the end.
 
 ```python
 # main.py
@@ -179,7 +181,7 @@ async def command_start_handler(message: Message):
 ```
 
 Now, for a user who has not yet connected a wallet, the bot sends a message with buttons for all available wallets.
-So we need to write function to handle `connect:{wallet["name"]}` callbacks:
+So we need to write a function to handle `connect:{wallet["name"]}` callbacks:
 
 ```python
 # main.py
@@ -237,11 +239,11 @@ async def main_callback_handler(call: CallbackQuery):
             await connect_wallet(message, data[1])
 ```
 
-Bot gives user 3 minutes to connect a wallet, after which it reports a timeout error. 
+The bot gives the user 3 minutes to connect a wallet, after which it reports a timeout.
 
-## Implement Transaction requesting
+## Request a transaction
 
-Let's take one of examples from the [Sending messages](/v3/guidelines/ton-connect/cookbook/ton-transfer) article:
+Let's take one of the examples from the [Sending messages](/v3/guidelines/ton-connect/cookbook/ton-transfer) article:
 
 ```python
 # messages.py
@@ -300,7 +302,7 @@ async def send_transaction(message: Message):
     )
 ```
 
-But we also should handle possible errors, so we wrap the `send_transaction` method into `try - except` statement:
+We should also handle possible errors, so wrap the `send_transaction` method in a try–except statement:
 
 ```python
 @dp.message(Command('transaction'))
@@ -321,7 +323,7 @@ async def send_transaction(message: Message):
 
 ## Add disconnect handler
 
-This function implementation is simple enough:
+The implementation of this function is simple:
 
 ```python
 async def disconnect_wallet(message: Message):
@@ -505,10 +507,10 @@ if __name__ == "__main__":
 
 ### Add permanent storage - Redis
 
-Currently, our TON Connect Storage uses dict which causes to lost sessions after bot restart. 
+Currently, our TON Connect Storage uses a dict, which causes sessions to be lost after a bot restart.
 Let's add permanent database storage with Redis:
 
-After you launched Redis database install python library to interact with it:
+After launching a Redis server, install the Python client library:
 
 ```bash
 pip install redis
@@ -541,15 +543,15 @@ class TcStorage(IStorage):
         await client.delete(self._get_key(key))
 ```
 
-### Add QR Code
+### Add QR code
 
-Install python `qrcode` package to generate them:
+Install the Python `qrcode` package:
 
 ```bash
 pip install qrcode
 ```
 
-Change `connect_wallet()` function so it generates qrcode and sends it as a photo to the user:
+Change the `connect_wallet()` function so it generates a QR code and sends it as a photo to the user:
 
 ```python
 from io import BytesIO
@@ -572,13 +574,12 @@ async def connect_wallet(message: Message, wallet_name: str):
 
 ## Summary
 
-What is next?
-- You can add better errors handling in the bot.
-- You can add start text and something like `/connect_wallet` command.
+What's next?
+- You can add better error handling in the bot.
+- You can add start text and something like a /connect_wallet command.
 
 ## See Also
 - [Full bot code](https://github.com/yungwine/ton-connect-bot)
 - [Sending messages](/v3/guidelines/ton-connect/cookbook/ton-transfer)
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-archive-tg-bot-integration-py.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/archive/tg-bot-integration-py.mdx`

Related issues (from issues.normalized.md):
- [ ] **662. Fix broken link in deprecated notice**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/tg-bot-integration-py.mdx?plain=1

The deprecation block’s Telegram Mini Apps link is missing a closing parenthesis; replace the whole block with: ":::warning deprecated\nThis guide explains an outdated method of integrating TON Connect with Telegram bots. For a more secure and modern approach, consider using [Telegram Mini Apps](/v3/guidelines/dapps/tma/overview) for a more modern and secure integration.\n:::".

---

- [ ] **663. Capitalize “Telegram” consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/tg-bot-integration-py.mdx?plain=1

Use “Telegram” as a proper noun throughout (e.g., “sample Telegram bot”).

---

- [ ] **664. Improve install section phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/tg-bot-integration-py.mdx?plain=1

Reword to: “To build the bot, we use the aiogram 3.0 Python library” and “To use TON primitives and parse the user address, install pytoniq-core.”

---

- [ ] **665. Combine dependency installation into one pip command**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/tg-bot-integration-py.mdx?plain=1

Use a single command for clarity and completeness: “pip install aiogram pytoniq-core python-dotenv pytonconnect”.

---

- [ ] **666. Fix config section sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/tg-bot-integration-py.mdx?plain=1

Change “After load them in config.py:” to “Then load them into config.py:”.

---

- [ ] **667. Add missing article in heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/tg-bot-integration-py.mdx?plain=1

Rename “Create simple bot” to “Create a simple bot”.

---

- [ ] **668. Clarify storage section lead-in**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/tg-bot-integration-py.mdx?plain=1

Change “Let's create simple storage for TON Connect” to “Let's create a simple storage class for TON Connect.”

---

- [ ] **669. Remove unused import in storage snippet**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/tg-bot-integration-py.mdx?plain=1

Drop “DefaultStorage” from “from pytonconnect.storage import IStorage, DefaultStorage” since it isn’t used.

---

- [ ] **670. Fix sequencing and article usage**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/tg-bot-integration-py.mdx?plain=1

Update to “First, we need a function that returns a different instance for each user,” “Secondly,” “add a connection handler,” and similar spots like “write a function to handle…”.

---

- [ ] **671. Add missing imports to code snippets**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/tg-bot-integration-py.mdx?plain=1

Ensure snippets import what they use (e.g., “from aiogram.utils.keyboard import InlineKeyboardBuilder”, “from pytonconnect import TonConnect”, “from pytoniq_core import Address”, “import time”, “from messages import get_comment_message”, “import pytonconnect.exceptions”) or note that these imports appear in the full main.py listing.

---

- [ ] **672. Fix wallet selection prompt**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/tg-bot-integration-py.mdx?plain=1

Change “Choose wallet to connect” to “Choose a wallet to connect”.

---

- [ ] **673. Standardize wallets API usage**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/tg-bot-integration-py.mdx?plain=1

Use “connector.get_wallets()” consistently instead of mixing it with “TonConnect.get_wallets()”.

---

- [ ] **674. Clarify timeout sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/tg-bot-integration-py.mdx?plain=1

Change to “The bot gives the user 3 minutes to connect a wallet, after which it reports a timeout.”

---

- [ ] **675. Rename transaction section heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/tg-bot-integration-py.mdx?plain=1

Replace “Implement Transaction requesting” with “Request a transaction”.

---

- [ ] **676. Correct “one of examples” grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/tg-bot-integration-py.mdx?plain=1

Change “Let's take one of examples” to “Let's take one of the examples”.

---

- [ ] **677. Fix base64 comment accuracy**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/tg-bot-integration-py.mdx?plain=1

In get_comment_message, change the comment on the “.decode()” line to “convert bytes to a string” (the encoding happens in urlsafe_b64encode).

---

- [ ] **678. Polish error-handling wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/tg-bot-integration-py.mdx?plain=1

Change to “We should also handle possible errors,” use “try–except,” and “wrap … in a try–except statement.”

---

- [ ] **679. Simplify disconnect section phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/tg-bot-integration-py.mdx?plain=1

Change “This function implementation is simple enough:” to “The implementation of this function is simple:”.

---

- [ ] **680. Normalize project tree formatting**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/tg-bot-integration-py.mdx?plain=1

Present the file tree in a consistent style (e.g., show “.env” as “├── .env” under the project root with tree connectors).

---

- [ ] **681. Fix Redis storage grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/tg-bot-integration-py.mdx?plain=1

Use “uses a dict, which causes sessions to be lost after a bot restart” and “After launching a Redis server, install the Python client library”.

---

- [ ] **682. Use sentence case for QR code section and text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/tg-bot-integration-py.mdx?plain=1

Rename the heading to “Add QR code,” change “Install python qrcode package” to “Install the Python qrcode package,” and “generates qrcode” to “generates a QR code”.

---

- [ ] **683. Improve summary phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/tg-bot-integration-py.mdx?plain=1

Change to “What’s next?”, “better error handling,” and “something like a /connect_wallet command.”

---

- [ ] **684. Point manifest reference to internal guide**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/tg-bot-integration-py.mdx?plain=1

Replace the external GitHub manifest link with “/v3/guidelines/ton-connect/creating-manifest” and use a neutral example URL like “https://<YOUR_APP_URL>/tonconnect-manifest.json”.

---

- [ ] **685. Make in-memory removal non-throwing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/archive/tg-bot-integration-py.mdx?plain=1

Change TcStorage.remove_item to use “storage.pop(self._get_key(key), None)” to avoid KeyError when the key is absent.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.