### PR TITLE
Split: update docs/v3/documentation/dapps/assets/nft-2.0.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/dapps/assets/nft-2.0.mdx
+++ b/docs/v3/documentation/dapps/assets/nft-2.0.mdx
@@ -65,7 +65,7 @@ This status does not involve any on-chain transactions or changes to the contrac
 The examples illustrate a standard NFT and the same item when it is marked as **royalty violated**.
 
 
-```jsonc
+```json
 // Standard NFT metadata
 {
   "name": "Magic Mushroom #57",
@@ -81,7 +81,7 @@ The examples illustrate a standard NFT and the same item when it is marked as **
 ```
 
 
-```jsonc
+```json
 // Royalty violated NFT metadata
 {
   "name": "Magic Mushroom #58",
@@ -138,7 +138,7 @@ For example, if `numerator = 11` and `denominator = 1000`, the royalty share is 
 
 #### Marketplace responsibilities
 
-- Marketplaces that comply with the NFT 2.0 specification are expected to send `mulDivFloor(price, numerator, denominator)` to the destination address after an NFT sale or any other successful commercial operation.
+- Marketplaces that comply with the NFT 2.0 specification are expected to send `muldiv(price, numerator, denominator)` to the destination address after an NFT sale or any other successful commercial operation.
 - Marketplaces **SHOULD NOT** send royalty payments when the calculated amount is zero.
 - Marketplaces **MAY** deduct gas and message fees required to send the royalty from the royalty amount.
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-dapps-assets-nft-2.0.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/dapps/assets/nft-2.0.mdx`

Related issues (from issues.normalized.md):
- [ ] **716. Remove unused import**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/nft-2.0.mdx?plain=1#L8

The imported Button component is not used; remove the line `import Button from '@site/src/components/button';`.

---

- [ ] **717. Improve TEP-66 paragraph wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/nft-2.0.mdx?plain=1#L18

Replace the sentence starting “So it means enforcing royalties...” with: “This would mean enforcing royalties at the cost of restricting legitimate, non-commercial transfers — such as gifting or migrating assets between personal wallets.”

---

- [ ] **718. Normalize spacing after period**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/nft-2.0.mdx?plain=1#L24

Replace the double space after “on-chain.” with a single space.

---

- [ ] **719. Add missing article**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/nft-2.0.mdx?plain=1#L50

Change “specific field in the off-chain metadata” to “a specific field in the off-chain metadata”.

---

- [ ] **720. Use American spelling “signaling”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/nft-2.0.mdx?plain=1#L63

Change “signalling” to “signaling” to match US English.

---

- [ ] **721. Mark JSON examples as JSON with comments**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/nft-2.0.mdx?plain=1#L69-L82, L85-L103

Change the fenced code language from `json` to `jsonc` to reflect the use of `//` comments in the examples.

---

- [ ] **722. Use consistent flag field name `royalty_violation`**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/nft-2.0.mdx?plain=1#L113

Replace `royalty_violated` with `royalty_violation` (e.g., “`royalty_violation = true`”) for consistency with the rest of the page and examples.

---

- [ ] **723. Fix section heading grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/nft-2.0.mdx?plain=1#L140

Change “Marketplaces responsibilities” to “Marketplace responsibilities”.

---

- [ ] **724. Align royalty amount function and rounding**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/nft-2.0.mdx?plain=1#L142-L144, L160-L166

Use `mulDivFloor(price, numerator, denominator)` in the bullet list to match the code example and keep floor rounding semantics consistent.

---

- [ ] **725. Use hyphens in “TEP-66-compatible”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/nft-2.0.mdx?plain=1#L187

Replace “TEP–66–compatible” (en dashes) with “TEP-66-compatible” (hyphens) for consistency.

---

- [ ] **726. Remove wording repetition**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/nft-2.0.mdx?plain=1#L198

Change “restrict user interactions with restricted NFT items” to “restrict user interactions with these NFT items”.

---

- [ ] **727. Acknowledge TEP-64 in standards sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/nft-2.0.mdx?plain=1

Update the sentence about NFT standards to: “On TON, NFTs follow TEP-62 and TEP-64; royalties are defined by TEP-66.”

---

- [ ] **728. Clarify off-chain vs on-chain propagation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/nft-2.0.mdx?plain=1

Remove the claim that indexers “propagate critical flags … back on-chain” and state that indexers expose critical flags via their APIs, since metadata updates do not modify the smart contract.

---

- [ ] **729. Standardize “Mint Platform API” naming**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/nft-2.0.mdx?plain=1

Use the term and casing “Mint Platform API” consistently throughout the page.

---

- [ ] **730. Add trailing slash to internal link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/nft-2.0.mdx?plain=1

In “See also,” change the link to “/v3/guidelines/dapps/asset-processing/nft-processing/nfts/” with a trailing slash.

---

- [ ] **731. Define or link the term “pack”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/nft-2.0.mdx?plain=1

On first use of “pack,” add a brief definition or link to a page that defines “pack” to avoid ambiguity.

---

- [ ] **732. Add alt text to images**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/nft-2.0.mdx?plain=1

Replace empty image alt text with concise descriptions (e.g., “NFT 2.0 workflow”, “Royalty violation process”) to improve accessibility.

---

- [ ] **733. Clarify policy on flagged-item transfers**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/nft-2.0.mdx?plain=1

Explicitly state whether non-commercial transfers of items with `royalty_violation: true` are allowed and align the restrictions section with that policy.

---

- [ ] **734. Soften uncited royalty parameter constraint**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/nft-2.0.mdx?plain=1

Change “The numerator must be less than the denominator” to “Typically, the numerator is less than the denominator.”

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.