### PR TITLE
Split: update docs/v3/documentation/dapps/assets/overview.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/dapps/assets/overview.mdx
+++ b/docs/v3/documentation/dapps/assets/overview.mdx
@@ -1,66 +1,61 @@
 import Feedback from '@site/src/components/Feedback';
 
-import Button from '@site/src/components/button'
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # Asset processing overview
 
-Here you can find a **short overview** on [how TON transfers work](/v3/documentation/dapps/assets/overview#overview-on-messages-and-transactions), what [asset types](/v3/documentation/dapps/assets/overview#digital-asset-types-on-ton) can you find in TON (and what about will you read [next](/v3/documentation/dapps/assets/overview#read-next)) and how to [interact with ton](/v3/documentation/dapps/assets/overview#interaction-with-ton-blockchain) using your programming language, it's recommended to understand all information, discovered below, before going to the next pages.
+This page provides a short overview of how TON transfers work, the digital asset types on TON, and how to interact with the TON Blockchain using your programming language. Read and understand the information below before proceeding to the next pages.
 
-## Overview on messages and transactions
+## Overview of messages and transactions
 
-Embodying a fully asynchronous approach, TON Blockchain involves a few concepts which are uncommon to traditional blockchains. Particularly, each interaction of any actor with the blockchain consists of a graph of asynchronously transferred [messages](/v3/documentation/smart-contracts/message-management/messages-and-transactions) between smart contracts and/or the external world. Each transaction consists of one incoming message and up to 255 outgoing messages.
+Embodying a fully asynchronous approach, the TON Blockchain involves a few concepts that are uncommon to traditional blockchains. In particular, each interaction of any actor with the blockchain consists of a graph of asynchronously transferred [messages](/v3/documentation/smart-contracts/message-management/messages-and-transactions) between smart contracts and/or the external world. Each transaction consists of one incoming message and up to 255 outgoing messages.
 
-There are 3 types of messages, that are fully described [here](/v3/documentation/smart-contracts/message-management/sending-messages#types-of-messages). To put it briefly:
+There are three types of messages, which are fully described [here](/v3/documentation/smart-contracts/message-management/sending-messages#types-of-messages):
 
-- [external message](/v3/documentation/smart-contracts/message-management/external-messages):
-  - `external in message` (sometimes called just `external message`) is message that is sent from _outside_ of the blockchain to a smart contract _inside_ the blockchain.
-  - `external out message` (usually called `logs message`) is sent from a _blockchain entity_ to the _outer world_.
-- [internal message](/v3/documentation/smart-contracts/message-management/internal-messages) is sent from one _blockchain entity_ to _another_, can carry some amount of digital assets and arbitrary portion of data.
+- [External message](/v3/documentation/smart-contracts/message-management/external-messages): from outside the blockchain to a smart contract inside the blockchain.
+- [Internal message](/v3/documentation/smart-contracts/message-management/internal-messages): between blockchain entities; can carry some amount of digital assets and an arbitrary portion of data.
+- Log message: from a blockchain entity to the outside world.
 
-The common path of any interaction starts with an external message sent to a `wallet` smart contract, which authenticates the message sender using public-key cryptography, takes charge of fee payment, and sends internal blockchain messages. That messages queue form directional acyclic graph, or a tree.
+The common path of any interaction starts with an external message sent to a wallet smart contract, which authenticates the message sender using public-key cryptography, takes charge of fee payment, and sends internal blockchain messages. These message queues form a directed acyclic graph (DAG).
 
 For example:
 
-![](/img/docs/asset-processing/alicemsgDAG.svg)
+![Message flow DAG from Alice to wallet A v4 to wallet B v4](/img/docs/asset-processing/alicemsgDAG.svg)
 
-- `Alice` use e.g [Tonkeeper](https://tonkeeper.com/) to send an `external message` to her wallet.
-- `external message` is the input message for `wallet A v4` contract with empty source (a message from nowhere, such as [Tonkeeper](https://tonkeeper.com/)).
-- `outgoing message` is the output message for `wallet A v4` contract and input message for `wallet B v4` contract with `wallet A v4` source and `wallet B v4` destination.
+- Alice uses, e.g., [Tonkeeper](https://tonkeeper.com/) to send an external message to her wallet.
+- The external message is the input to wallet A v4 with an empty source (external message).
+- The outgoing message is the output of wallet A v4 and the input to wallet B v4, with wallet A v4 as the source and wallet B v4 as the destination.
 
-As a result there are 2 transactions with their set of input and output messages.
+As a result, there are two transactions, each with its set of input and output messages.
 
-Each action, when contract take message as input (triggered by it), process it and generate or not generate outgoing messages as output, called `transaction`. Read more about transactions [here](/v3/documentation/smart-contracts/message-management/messages-and-transactions#what-is-a-transaction).
+A transaction occurs when a contract takes a message as input, processes it, and optionally generates outgoing messages. Read more about transactions [here](/v3/documentation/smart-contracts/message-management/messages-and-transactions#what-is-a-transaction).
 
-That `transactions` can span a **prolonged period** of time. Technically, transactions with queues of messages are aggregated into blocks processed by validators. The asynchronous nature of the TON Blockchain **does not allow to predict the hash and lt (logical time) of a transaction** at the stage of sending a message.
+Transactions can span a prolonged period of time. Technically, transactions and their message queues are aggregated into blocks processed by validators. Because of asynchrony, you cannot know a transaction’s hash or logical time (LT) at the moment you send a message.
 
-The `transaction` accepted to the block is final and cannot be modified.
+A transaction accepted into a block is final and cannot be modified.
 
 :::info Transaction Confirmation
 TON transactions are irreversible after just one confirmation. For the best user experience, it is suggested to avoid waiting on additional blocks once transactions are finalized on the TON Blockchain. Read more in the [Catchain.pdf](https://docs.ton.org/catchain.pdf#page=3).
 :::
 
-Smart contracts pay several types of [fees](/v3/documentation/smart-contracts/transaction-fees/fees) for transactions (usually from the balance of an incoming message, behavior depends on [message mode](/v3/documentation/smart-contracts/message-management/sending-messages#message-modes)). Amount of fees depends on workchain configs with maximal fees on `masterchain` and substantially lower fees on `basechain`.
+Smart contracts pay several types of [fees](/v3/documentation/smart-contracts/transaction-fees/fees) for transactions (usually from the balance of an incoming message; behavior depends on [message mode](/v3/documentation/smart-contracts/message-management/sending-messages#message-modes)). The amount of fees depends on network configuration, with higher fees on the masterchain and substantially lower fees on the basechain.
 
 ## Digital asset types on TON
 
 TON has three types of digital assets.
 
 - Toncoin, the main token of the network. It is used for all basic operations on the blockchain, for example, paying gas fees or staking for validation.
-- Contract assets, such as tokens and NFTs, which are analogous to the ERC-20/ERC-721 standards and are managed by arbitrary contracts and thus can require custom rules for processing. You can find more info on it's processing in [process NFTs](/v3/guidelines/dapps/asset-processing/nft-processing/nfts) and [process Jettons](/v3/guidelines/dapps/asset-processing/jettons) articles.
-- Native token, which is special kind of assets that can be attached to any message on the network. But these asset is currently not in use since the functionality for issuing new native tokens is closed.
+- Contract assets, such as jettons and NFTs, are analogous to the ERC‑20/ERC‑721 standards and are managed by arbitrary contracts, which can require custom processing rules. You can find more info on their processing in the [NFT processing](/v3/guidelines/dapps/asset-processing/nft-processing/nfts) and [Jetton processing](/v3/guidelines/dapps/asset-processing/jettons) articles.
+- TON supports up to 2^32 extra currencies; accounts and messages support them, but no extra currency has been created on the TON Blockchain yet—the minter system contract for their creation has not been deployed. See [Extra currencies](/v3/documentation/dapps/defi/coins) for more details.
 
-## Interaction with TON Blockchain
+## Interaction with the TON Blockchain
 
-Basic operations on TON Blockchain can be carried out via TonLib. It is a shared library which can be compiled along with a TON node and expose APIs for interaction with the blockchain via so-called lite servers (servers for lite clients). TonLib follows a trustless approach by checking proofs for all incoming data; thus, there is no necessity for a trusted data provider. Methods available to TonLib are listed [in the TL scheme](https://github.com/ton-blockchain/ton/blob/master/tl/generate/scheme/tonlib_api.tl#L234). They can be used either as a shared library via [wrappers](/v3/guidelines/dapps/asset-processing/payments-processing/#sdks).
+Basic operations on the TON Blockchain can be carried out via TonLib. TonLib is a shared library that can be compiled along with a TON node and exposes APIs for interacting with the blockchain via lite servers (servers for lite clients). TonLib follows a trustless approach by checking proofs for all incoming data; thus, there is no need for a trusted data provider. Methods available in TonLib are listed in the [TL scheme](https://github.com/ton-blockchain/ton/blob/master/tl/generate/scheme/tonlib_api.tl). You can use TonLib directly as a shared library or via language wrappers (see [SDKs](/v3/guidelines/dapps/asset-processing/payments-processing/#sdks)).
 
 ## Read next
 
 After reading this article you can check:
 
-1. [Payments processing](/v3/guidelines/dapps/asset-processing/payments-processing) to get how to work with `TON coins`
-2. [Jetton processing](/v3/guidelines/dapps/asset-processing/jettons) to get how to work with `jettons` (sometime called `tokens`)
-3. [NFT processing](/v3/guidelines/dapps/asset-processing/nft-processing/nfts) to get how to work with `NFT` (that is the special type of `jetton`)
+1. [Payments processing](/v3/guidelines/dapps/asset-processing/payments-processing) — learn how to work with Toncoin.
+2. [Jetton processing](/v3/guidelines/dapps/asset-processing/jettons) — learn how to work with jettons (sometimes called “tokens”).
+3. [NFT processing](/v3/guidelines/dapps/asset-processing/nft-processing/nfts) — learn how to work with NFTs.
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-dapps-assets-overview.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/dapps/assets/overview.mdx`

Related issues (from issues.normalized.md):
- [x] **735. Remove unused MDX imports**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/overview.mdx?plain=1#L3-L5

Delete unused imports Button, Tabs, and TabItem to reduce noise and build overhead.

---

- [x] **736. Fix intro paragraph grammar and capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/overview.mdx?plain=1#L9

Rewrite the opening as clear sentences, use “overview of” (not “overview on”), and capitalize “TON”; e.g., “This page provides a short overview of how TON transfers work, the digital asset types on TON, and how to interact with the TON Blockchain using your programming language. Read and understand the information below before proceeding to the next pages.”

---

- [x] **737. Use “Overview of messages and transactions” heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/overview.mdx?plain=1#L11

Change the section title to “Overview of messages and transactions” for idiomatic English.

---

- [x] **738. Correct message types lead-in and terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/overview.mdx?plain=1#L15-L20

Replace the lead-in with “There are three types of messages, which are fully described here:” and define the canonical types as External (from outside to a contract), Internal (between contracts), and Log (from a blockchain entity to the outside world); fix missing articles and hyphenation, change “logs message” to “log message,” and remove the non-canonical “external out” term; use these terms consistently across the page.

---

- [x] **739. Improve DAG sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/overview.mdx?plain=1#L22

Change to: “These message queues form a directed acyclic graph (DAG).”

---

- [x] **740. Clean up example bullets (grammar and clarity)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/overview.mdx?plain=1#L28-L30

Reword the bullets for agreement and clarity, e.g.: “Alice uses, e.g., Tonkeeper to send an external message to her wallet.” / “The external message is the input to wallet A v4 with an empty source (external message).” / “The outgoing message is the output of wallet A v4 and the input to wallet B v4, with wallet A v4 as the source and wallet B v4 as the destination.”

---

- [x] **741. Spell out “two” and add comma after lead-in**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/overview.mdx?plain=1#L32

Use: “As a result, there are two transactions, each with its set of input and output messages.”

---

- [x] **742. Rewrite transaction definition**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/overview.mdx?plain=1#L34

Use: “A transaction occurs when a contract takes a message as input, processes it, and optionally generates outgoing messages.” Keep the existing “read more” link aligned with the canonical definition.

---

- [x] **743. Clarify asynchrony and LT term**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/overview.mdx?plain=1#L36

Use: “Transactions can span a prolonged period of time. Technically, transactions and their message queues are aggregated into blocks processed by validators. Because of asynchrony, you cannot know a transaction’s hash or logical time (LT) at the moment you send a message.” Ensure “LT” capitalization is consistent; optionally cross-reference where users retrieve a transaction ID later.

---

- [x] **744. Use “accepted into a block” phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/overview.mdx?plain=1#L38

Change to: “A transaction accepted into a block is final and cannot be modified.”

---

- [x] **745. Tighten fees paragraph**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/overview.mdx?plain=1#L44

Use: “Smart contracts pay several types of fees for transactions (usually from the balance of an incoming message; behavior depends on the message mode). The amount of fees depends on network configuration, with higher fees on the masterchain and substantially lower fees on the basechain.”

---

- [x] **746. Use canonical asset terms and link texts**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/overview.mdx?plain=1#L51

Change to: “Contract assets, such as jettons and NFTs, are analogous to the ERC‑20/ERC‑721 standards and are managed by arbitrary contracts, which can require custom processing rules. You can find more info on their processing in the NFT processing and Jetton processing articles.” Ensure consistent capitalization of “Jetton.”

---

- [x] **747. Update native token status to match “Extra currencies”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/overview.mdx?plain=1#L52

Rephrase to align with core docs: “TON supports up to 2^32 extra currencies; accounts and messages support them, but no extra currency has been created on the TON Blockchain yet—the minter system contract for their creation has not been deployed.” Link to the “Extra currencies” documentation for context.

---

- [x] **748. Use “the TON Blockchain” consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/overview.mdx?plain=1#L54-L56

Add the definite article where missing (e.g., “Interaction with the TON Blockchain,” “Basic operations on the TON Blockchain …”) to match style used elsewhere.

---

- [x] **749. Fix TonLib paragraph (grammar, structure, and links)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/overview.mdx?plain=1#L56

Rewrite as: “TonLib is a shared library that can be compiled along with a TON node and exposes APIs for interacting with the blockchain via lite servers (servers for lite clients). TonLib follows a trustless approach by checking proofs for all incoming data; thus, there is no need for a trusted data provider. Methods available in TonLib are listed in the TL scheme. You can use TonLib directly as a shared library or via language wrappers (see SDKs).” Also update the TL scheme link to the file URL without a brittle line anchor.

---

- [x] **750. Fix “Read next” list wording and facts**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/overview.mdx?plain=1#L62-L64

Use: “Payments processing — learn how to work with Toncoin.” / “Jetton processing — learn how to work with jettons (sometimes called ‘tokens’).” / “NFT processing — learn how to work with NFTs.” Remove the incorrect claim that NFTs are a special type of jetton.

---

- [x] **751. Remove code formatting for common nouns**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/overview.mdx?plain=1

Remove backticks around general terms like “transaction” and “wallet” in narrative text; reserve code formatting for identifiers or code.

---

- [ ] **752. Add citations for “up to 255 outgoing messages”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/overview.mdx?plain=1#overview-on-messages-and-transactions

If the text states “up to 255 outgoing messages,” keep the claim and add citations to the action list limit (fees low-level) and wallet v5 docs to support it.

---

- [x] **753. Add descriptive alt text to the diagram**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/assets/overview.mdx?plain=1#overview-on-messages-and-transactions

Provide meaningful alt text for the image (e.g., “Message flow DAG from Alice to wallet A v4 to wallet B v4”) to improve accessibility.

---

- [ ] **1994. Clarify 'non-system contract' and fix link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/message-modes-cookbook.mdx?plain=1#L16

Replace “non-system contract … one incoming message and up to 255 outgoing” with a neutral, sourced statement and link to the canonical explanation: “Transactions process one incoming message and up to 255 outgoing messages” (link: docs/v3/documentation/dapps/assets/overview.mdx#overview-on-messages-and-transactions).

---

- [ ] **4314. Ambiguous “native token” and generic “tokens” in Assets card**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/dapps-overview.mdx?plain=1

Digital assets card desc reads: “Explore Toncoin, tokens, and the native token.” This is confusing: - Coins page uses “Native token: Toncoin” — docs/v3/documentation/dapps/defi/coins.mdx#native-token-toncoin. - Assets overview describes “Native token” as a special asset type not in use — docs/v3/documentation/dapps/assets/overview.mdx#digital-asset-types-on-ton. - “tokens” should be “Jettons” per token docs — docs/v3/documentation/dapps/defi/tokens.mdx#jettons-fungible-tokens. Minimal fix: Change the desc to “Explore Toncoin, jettons, and NFTs.” If keeping “native token,” a domain decision is required to reconcile terminology between Coins and Assets pages.

---

- [ ] **4315. Misleading USD₮ mention in Assets card**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/dapps-overview.mdx?plain=1

The Assets card says “Learn how USD₮ works on TON.” but links to the Assets overview, which does not cover USD₮ — docs/v3/documentation/dapps/assets/overview.mdx. USD₮ details are on a separate page — docs/v3/documentation/dapps/assets/usdt.mdx. Minimal fix: remove the USD₮ sentence from the card desc, or change the link to the USD₮ page if that is the intended destination.

---

- [ ] **4317. Generic H1 reduces navigability**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/dapps-overview.mdx?plain=1

The page H1 is “Overview”, which is ambiguous in breadcrumbs and search. Other pages use specific titles (e.g., “Asset processing overview” — docs/v3/documentation/dapps/assets/overview.mdx). Minimal fix: change H1 to “DApps Overview” for clarity and consistency with its path and with the “DApps” card on docs/v3/documentation/ton-documentation.mdx.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.