### PR TITLE
Split: update docs/v3/documentation/dapps/defi/nft.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/dapps/defi/nft.mdx
+++ b/docs/v3/documentation/dapps/defi/nft.mdx
@@ -2,15 +2,15 @@ import Feedback from '@site/src/components/Feedback';
 
 # NFT use cases
 
-NFTs, or non-fungible tokens, are a type of digital asset that is unique, and cannot be replaced by another identical asset. This article describes the approaches and already implemented use cases of NFTs in TON Blockchain.
+NFTs, or non‑fungible tokens, are unique digital assets that cannot be replaced with an identical asset. This article describes approaches and NFT use cases already implemented on the TON Blockchain.
 
-After reading this article, you will understand why are NFTs helpful and how you can use them in one of your projects.
+After reading this article, you will understand why NFTs are helpful and how to use them in your projects.
 
 ## Item ownership
 
 Non-fungible tokens are mostly known as cool pictures that you can buy and sell on NFT marketplaces like OpenSea or [getgems.io](https://getgems.io).
 
-NFT pictures and collections are funny and help people understand the concept of blockchain-based ownership. However, in the long-term, the NFT focus should shift beyond this to illustrate their wide variety of potential use cases.
+NFT pictures and collections are funny and help people understand the concept of blockchain-based ownership. However, in the long term, the NFT focus should shift beyond this to illustrate their wide variety of potential use cases.
 
 ## Support an artist
 
@@ -22,20 +22,20 @@ This is one of the most common reasons why marketplaces like getgems.io or OpenS
 
 ## Accounts as NFTs
 
-In November, the Telegram team launched [Fragment](https://fragment.com/) marketplace, where anyone can buy and sell Telegram usernames or Anonymous Numbers backed by an NFT on the TON Blockchain.
+In November 2022, the Telegram team launched the [Fragment](https://fragment.com/) marketplace, where anyone can buy and sell Telegram usernames or Anonymous Numbers backed by an NFT on the TON Blockchain.
 
-Moreover, in December the Telegram team released [No-SIM sign-up](https://telegram.org/blog/ultimate-privacy-topics-2-0#sign-up-without-a-sim-card). You can buy a **virtual phone number** as an NFT to sign up in the Telegram Messenger and ensure that your privacy is secured by the TON Blockchain.
+Moreover, in December 2022, the Telegram team released [No‑SIM sign‑up](https://telegram.org/blog/ultimate-privacy-topics-2-0#sign-up-without-a-sim-card); you can buy a virtual phone number as an NFT to sign up for Telegram without a SIM card, using a number represented as an NFT on the TON Blockchain.
 
 ## Web3 Domain as an NFT
 
-There is TON DNS service, which works fully onchain. It allows users to buy domains of format `mystore.ton` (the most convenient way to do that is via [DNS marketplace](https://dns.ton.org/)), and ensures unused domains are returned into circulation by requiring owner to pay a small, fixed fee to renew the domain.
+The TON DNS service works fully on‑chain; it allows users to buy domains in the format `mystore.ton` (the most convenient way is via the [DNS marketplace](https://dns.ton.org/)) and ensures unused domains are returned to circulation by requiring the owner to pay a small, fixed fee to renew the domain.
 
-NFT Telegram usernames from Fragment can also be used in TON DNS; `yourname.t.me` is a valid domain.
+NFT Telegram usernames from Fragment can also be used with TON DNS; note that `yourname.t.me` is a Telegram link, not a TON DNS domain.
 
 ### Use cases of TON domains
 
-1. You can set domain to resolve to your wallet address, so a person unfamiliar with crypto can transfer money not to `EQDyo...zuDf` but to easily readable `mystore.ton`.
-2. You can attach a [TON Site](/v3/guidelines/web3/ton-proxy-sites/how-to-run-ton-site) to the domain; then, it will be accessible in TON Web3 network under a convenient name.
+1. You can set a domain to resolve to your wallet address, so a person unfamiliar with crypto can transfer money not to `EQDyo...zuDf` but to an easily readable `mystore.ton`.
+2. You can attach a [TON Site](/v3/guidelines/web3/ton-proxy-sites/how-to-run-ton-site) to the domain; then, it will be accessible in the TON Web3 network under a convenient name.
 
 ## Ticket as an NFT
 
@@ -43,7 +43,7 @@ NFT tickets provide an excellent solution for verifying access to events, like c
 
 Owning an NFT ticket offers several unique advantages:
 
-First and foremost, NFT tickets cannot be forged or copied, eliminating the possibility of fraudulent sale of fake tickets. This ensures that buyers can trust the authenticity of the ticket and the legitimacy of the seller, giving them confidence in what they're paying for.
+First and foremost, NFT tickets are difficult to forge and enable on‑chain authenticity checks, reducing the risk of counterfeit sales. This ensures that buyers can trust the authenticity of the ticket and the legitimacy of the seller, giving them confidence in what they're paying for.
 
 Secondly, NFT tickets open up exciting opportunities for collecting. As the owner of an NFT ticket, you can store it in your digital wallet and have access to a whole collection of tickets from various events. In particular, TON has created a leaderboard for participating in their conferences on [society.ton.org](https://society.ton.org/contributors?tab=leaderboard). This creates a new form of aesthetic and financial satisfaction for music and art lovers.
 
@@ -55,15 +55,15 @@ Additionally, owning an NFT ticket can come with extra benefits and special priv
 
 Using NFTs as authorization tokens introduces a revolutionary approach to granting access rights and permissions.
 
-NFT tokens ensure elevated security and cannot be easily copied or forged. This eliminates the risk of unauthorized access or fake authentication, providing reliable authentication.
+NFTs ensure elevated security and cannot be easily copied or forged. This eliminates the risk of unauthorized access or fake authentication, providing reliable authentication.
 
 Furthermore, thanks to their transparency and traceability, the authenticity and ownership of an NFT authorization token can be easily verified. This enables quick and efficient verification, ensuring convenient access to various platforms, services, or restricted content.
 
 It is also worth mentioning that NFTs provide flexibility and adaptability in managing permissions. Since NFTs can be programmatically encoded with specific access rules or attributes, they can adapt to different authorization requirements. This flexibility allows for fine-grained control over access levels, granting or revoking permissions as needed, which can be particularly valuable in scenarios that require hierarchical access or temporary authorization restrictions.
 
-One of the services currently offering NFT authentication is [Playmuse](https://playmuse.org/), a media service built on the TON blockchain. This service aims to attract Web3 musicians as well as other creators.
+One of the services currently offering NFT authentication is [Playmuse](https://playmuse.org/), a media service built on the TON Blockchain. This service aims to attract Web3 musicians as well as other creators.
 
-Owners of NFTs from Playmuse gain access to the holders chat. Being a participant in this chat provides opportunity to influence the development direction of the service, vote on various initiatives, and receive early access to presales and NFT auctions featuring renowned creators.
+Owners of NFTs from Playmuse gain access to the holders' chat. Being a participant in this chat provides the opportunity to influence the development direction of the service, vote on various initiatives, and receive early access to presales and NFT auctions featuring renowned creators.
 
 Access to the chat is facilitated through a Telegram bot, which verifies the presence of a Playmuse NFT in the user's wallet.
 
@@ -71,6 +71,6 @@ It is important to note that this is just one example, and as the TON ecosystem 
 
 ## NFT as a virtual asset in games
 
-NFT integrated to a game allows players to own and trade in-game items in a way that is verifiable and secure, which adds an extra layer of value and excitement to the game.
+An NFT integrated into a game allows players to own and trade in-game items in a way that is verifiable and secure, which adds an extra layer of value and excitement to the game.
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-dapps-defi-nft.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/dapps/defi/nft.mdx`

Related issues (from issues.normalized.md):
- [ ] **784. Fix intro grammar and prepositions**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1#L5

Rewrite to: "NFTs, or non‑fungible tokens, are unique digital assets that cannot be replaced with an identical asset. This article describes approaches and NFT use cases already implemented on the TON Blockchain."

---

- [ ] **785. Correct word order in benefits sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1#L7

Change to: "After reading this article, you will understand why NFTs are helpful and how to use them in your projects."

---

- [ ] **786. Remove hyphen in “long term” (noun phrase)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1#L13

Use "in the long term" (no hyphen) when used as a noun phrase.

---

- [ ] **787. Add year and link for Fragment launch**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1#L25

Change to: "In November 2022, the Telegram team launched the [Fragment](https://fragment.com/) marketplace, ..."

---

- [ ] **788. Neutralize No‑SIM sign‑up claim; add date and link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1#L27

Change to: "Moreover, in December 2022, the Telegram team released [No‑SIM sign‑up](https://telegram.org/blog/ultimate-privacy-topics-2-0#sign-up-without-a-sim-card); you can buy a virtual phone number as an NFT to sign up for Telegram without a SIM card, using a number represented as an NFT on the TON Blockchain."

---

- [ ] **789. Improve TON DNS paragraph (on‑chain, articles, phrasing)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1#L31

Replace with: "The TON DNS service works fully on‑chain; it allows users to buy domains in the format `mystore.ton` (the most convenient way is via the [DNS marketplace](https://dns.ton.org/)) and ensures unused domains are returned to circulation by requiring the owner to pay a small, fixed fee to renew the domain."

---

- [ ] **790. Clarify that t.me usernames aren’t TON DNS domains**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1#L33

Change to: "NFT Telegram usernames from Fragment can also be used with TON DNS; note that `yourname.t.me` is a Telegram link, not a TON DNS domain."

---

- [ ] **791. Add missing articles in wallet address example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1#L37

Change to: "You can set a domain to resolve to your wallet address, so a person unfamiliar with crypto can transfer money not to `EQDyo...zuDf` but to an easily readable `mystore.ton`."

---

- [ ] **792. Add article before “TON Web3 network”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1#L38

Change "accessible in TON Web3 network" to "accessible in the TON Web3 network."

---

- [ ] **793. Soften absolute claim about counterfeit tickets**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1#L46

Rephrase to: "NFT tickets are difficult to forge and enable on‑chain authenticity checks, reducing the risk of counterfeit sales."

---

- [ ] **794. Replace “NFT tokens” with “NFTs”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1#L58

Change "NFT tokens ensure elevated security" to "NFTs ensure elevated security."

---

- [ ] **795. Capitalize “TON Blockchain” consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1#L64

Change "the TON blockchain" to "the TON Blockchain" to match page usage.

---

- [ ] **796. Fix possessive and article in “holders’ chat”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1#L66

Change to: "access to the holders' chat. Being a participant in this chat provides the opportunity ..."

---

- [ ] **797. Use “integrated into” for game phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1#L74

Change "NFT integrated to a game" to "NFT integrated into a game" (or "Integration of NFTs into a game").

---

- [ ] **4316. DeFi card description does not match its link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/dapps-overview.mdx?plain=1

DeFi card desc includes “Explore NFT use cases and Jettons. Implement subscriptions and micropayments.” but the link points to Coins, which only covers Toncoin and extra currencies — docs/v3/documentation/dapps/defi/coins.mdx. The mentioned topics are covered elsewhere: NFTs — docs/v3/documentation/dapps/defi/nft.mdx; Jettons — docs/v3/documentation/dapps/defi/tokens.mdx#jettons-fungible-tokens; Micropayments — docs/v3/documentation/dapps/defi/ton-payments.mdx; Subscriptions — docs/v3/documentation/dapps/defi/subscriptions.mdx. Minimal fix: either (a) trim the desc to only Toncoin and extra currencies to match the link, or (b) change the link to a broader DeFi entry (domain decision required if a DeFi index is intended but does not exist).

---

- [ ] **4503. Fix intro sentence grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1

Replace "After reading this article, you will understand why are NFTs helpful and how you can use them in one of your projects." with "After reading this article, you will understand why NFTs are helpful and how you can use them in your projects."

---

- [ ] **4504. Correct TON DNS article and on‑chain hyphenation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1

Replace "There is TON DNS service, which works fully onchain." with "The TON DNS service works fully on-chain."

---

- [ ] **4505. Remove unsupported claim about domain renewal**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1

Replace the clause about "ensures unused domains are returned into circulation by requiring owner to pay a small, fixed fee to renew the domain" with: "…buy the NFT domain on the DNS marketplace for your wallet and pay a rental fee for storing and processing data in the blockchain."

---

- [ ] **4506. Rephrase .t.me usage; avoid calling it a valid domain**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1

Replace "NFT Telegram usernames from Fragment can also be used in TON DNS; `yourname.t.me` is a valid domain." with "You can also use the NFT usernames bought on Fragment with TON DNS to bind them to your wallet and use your `username.t.me` NFT as a wallet address."

---

- [ ] **4507. Use standard terminology “TON Network”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1

Change "accessible in TON Web3 network" to "accessible on the TON Network."

---

- [ ] **4508. Add possessive apostrophe in holders’ chat**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1

Change "holders chat" to "holders' chat."

---

- [ ] **4509. Capitalize “TON Blockchain” consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1

In the Playmuse paragraph, change "TON blockchain" to "TON Blockchain" for consistency.

---

- [ ] **4510. Use “into” in game integration phrase**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1

Change "NFT integrated to a game allows…" to "NFT integrated into a game allows…"

---

- [ ] **4511. Specify the year for No‑SIM sign‑up**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1

Replace "in December" with "in 2022" (e.g., "Moreover, in 2022, the Telegram team released…") to clarify timing.

---

- [ ] **4512. Add definite article before Fragment marketplace**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1

Change "launched [Fragment] marketplace" to "launched the [Fragment] marketplace."

---

- [ ] **4513. Add article in “set a domain to resolve”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/nft.mdx?plain=1

Change "You can set domain to resolve…" to "You can set a domain to resolve to your wallet address…"

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.