### PR TITLE
Split: update docs/v3/documentation/dapps/defi/tokens.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/dapps/defi/tokens.mdx
+++ b/docs/v3/documentation/dapps/defi/tokens.mdx
@@ -8,42 +8,42 @@ import Button from '@site/src/components/button'
 
 > TON-powered tokens and NFTs are decentralized, avoiding single points of failure and bottlenecks.
 >
-> Each NFT in a given collection is a separate smart contract. The token balance for each user is stored in a separate user wallet.
+> Each NFT in a given collection is a separate smart contract. Each user's jetton balance is stored in a separate jetton wallet contract.
 >
 > Smart contracts interact directly with one another, distributing the load across the entire network.
 >
 > As the number of users and transactions grows, the network maintains an even load, enabling seamless scalability.
 
-## TON Course: jettons & NFTs
+## TON Course: Jettons & NFTs
 
 :::tip
 Before starting the course, make sure you have a good understanding of the basics of blockchain technology. If you have gaps in your knowledge, we recommend taking the [Blockchain Basics with TON](https://stepik.org/course/201294/promo) ([RU version](https://stepik.org/course/202221/), [CHN version](https://stepik.org/course/200976/)) course.
-Module 4 covers the basic knowledge of NFT & Jettons.
+In the Blockchain Basics with TON course, Module 4 covers the basics of NFTs and jettons.
 :::
 
 The [TON Blockchain Course](https://stepik.org/course/176754/) is a comprehensive guide to TON Blockchain development.
 
-Module 7 completely covers **NFT & Jettons** development.
+The course includes comprehensive modules on NFT and jetton development.
 
 <Button href="https://stepik.org/course/176754/promo" colorType={'primary'} sizeType={'sm'}>
-  Check TON Blockchain Course
+  Explore the TON Blockchain Course
 </Button>
 
 <Button href="https://stepik.org/course/201638/promo" colorType={'secondary'} sizeType={'sm'}>
-  CHN
+  Chinese
 </Button>
 
 <Button href="https://stepik.org/course/201855/promo" colorType={'secondary'} sizeType={'sm'}>
-  RU
+  Russian
 </Button>
 
 ## Tutorials
 
-- [Web3 Game Tutorial](/v3/guidelines/dapps/tutorials/web3-game-example) - Learn how to build a Web3 game with TON Blockchain.
-- [Mint your first Jetton](/v3/guidelines/dapps/tutorials/mint-your-first-token/) — Learn how to deploy and customize your first Jetton
-- [\[YouTube\] TON Keeper founders Oleg Andreev and Oleg Illarionov on TON jettons](https://www.youtube.com/watch?v=oEO29KmOpv4)
+- [Web3 Game Tutorial](/v3/guidelines/dapps/tutorials/web3-game-example) — Learn how to build a Web3 game with TON Blockchain.
+- [Mint your first Jetton](/v3/guidelines/dapps/tutorials/mint-your-first-token/) — Learn how to deploy and customize your first Jetton.
+- [\[YouTube\] TON Keeper founders Oleg Andreev and Oleg Illarionov on TON jettons](https://www.youtube.com/watch?v=oEO29KmOpv4).
 
-### TON speed run
+### TON Speed Run
 
 - [🚩 Challenge 1: Simple NFT Deploy](https://github.com/romanovichim/TONQuest1)
 - [🚩 Challenge 2: Chatbot Contract](https://github.com/romanovichim/TONQuest2)
@@ -52,34 +52,33 @@ Module 7 completely covers **NFT & Jettons** development.
 - [🚩 Challenge 5: Create UI to interact with the contract in 5 minutes](https://github.com/romanovichim/TONQuest5)
 - [🚩 Challenge 6: Analyzing NFT sales on the Getgems marketplace](https://github.com/romanovichim/TONQuest6)
 
-## Jettons (fungible tokens)
+## Jettons (Fungible Tokens)
 
 ### Guides
 
 - [TON Jetton processing](/v3/guidelines/dapps/asset-processing/jettons)
-- [TON Metadata Parsing](/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing)
 
 ### Standards
 
 - [Jettons standard](https://github.com/ton-blockchain/TEPs/blob/master/text/0074-jettons-standard.md)
 
-### Smart contracts
+### Smart Contracts
 
 - [Smart contracts implementation (FunC)](https://github.com/ton-blockchain/token-contract/)
 
-### Jetton deployer
+### Jetton Deployer
 
-Jettons are custom fungible tokens on TON Blockchain. You can create your own token on TON Blockchain using the Jetton Deployer example below:
+Jettons are custom fungible tokens on the TON blockchain. You can create your own token on the TON blockchain using the Jetton Deployer example below:
 
 - **[TON Minter](https://minter.ton.org/)** — open-source Jetton Deployer dApp
 - [Jetton Deployer — contracts](https://github.com/ton-defi-org/jetton-deployer-contracts) (FunC, TL-B)
-- [Jetton Deployer — WebClient](https://github.com/ton-defi-org/jetton-deployer-webclient) (React, TypeScript)
+- [Jetton Deployer — Web Client](https://github.com/ton-defi-org/jetton-deployer-webclient) (React, TypeScript)
 
-### Tools to work with jettons
+### Tools to Work with Jettons
 
-- [NFT Jetton Sale Contract](https://github.com/dvlkv/nft-jetton-sale-smc) - NFT Sale contract with jetton support
-- [Scaleton](http://scaleton.io)—see your custom token balance
-- [@tegro/ton3-client](https://github.com/TegroTON/ton3-client#jettons-example)—SDK to query information about Jettons
+- [NFT Jetton Sale Contract](https://github.com/dvlkv/nft-jetton-sale-smc) — NFT sale contract with jetton support
+- Scaleton (https://scaleton.io) — see your custom token balance
+- [@tegro/ton3-client](https://github.com/TegroTON/ton3-client#jettons-example) — SDK to query information about jettons
 
 ## NFT
 
@@ -87,14 +86,18 @@ Jettons are custom fungible tokens on TON Blockchain. You can create your own to
 
 - [NFT standard](https://github.com/ton-blockchain/TEPs/blob/master/text/0062-nft-standard.md)
 - [SBT (Soulbound NFT) standard](https://github.com/ton-blockchain/TEPs/blob/master/text/0085-sbt-standard.md)
-- [NFTRoyalty standard extension](https://github.com/ton-blockchain/TEPs/blob/master/text/0066-nft-royalty-standard.md)
+- [NFT Royalty standard extension](https://github.com/ton-blockchain/TEPs/blob/master/text/0066-nft-royalty-standard.md)
 
-### Smart contracts
+### Guides
+
+- [Metadata parsing](/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing)
+
+### Smart Contracts
 
 - [Smart contracts implementation (FunC)](https://github.com/ton-blockchain/token-contract/)
-- [Getgems NFT, sale, auctions smart contracts (FunC)](https://github.com/getgems-io/nft-contracts)
+- [Getgems NFT sale and auction smart contracts (FunC)](https://github.com/getgems-io/nft-contracts)
 
-### NFT minters
+### NFT Minters
 
 - [NFT Deployer](https://github.com/tondiamonds/ton-nft-deployer) by TON Diamonds (TypeScript, no comments)
 - [NFT Minter example](https://github.com/ton-foundation/token-contract/tree/main/nft/web-example) (JavaScript, with comments)
@@ -102,7 +105,7 @@ Jettons are custom fungible tokens on TON Blockchain. You can create your own to
 - [NFT Deployer](https://github.com/anomaly-guard/nft-deployer) (Python, with comments)
 - [NFT Minter using Golang](https://github.com/xssnick/tonutils-go#nft) (Golang library, with comments and full examples)
 
-### Tools to work with NFTs
+### Tools to Work with NFTs
 
 - [LiberMall/tnt](https://github.com/LiberMall/tnt)—TNT is an all-in-one command-line tool to query, edit, and mint new Non-Fungible Tokens on The Open Network.
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-dapps-defi-tokens.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/dapps/defi/tokens.mdx`

Related issues (from issues.normalized.md):
- [ ] **813. Clarify jetton wallet terminology in intro**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/tokens.mdx?plain=1#L9-L15

The intro incorrectly says “user wallet”; replace with “Each user’s jetton balance is stored in a separate jetton wallet contract.”

---

- [ ] **814. Disambiguate “Module 4” by naming the course**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/tokens.mdx?plain=1#L20-L22

Clarify the ambiguous “Module 4” by naming the course explicitly, e.g., “In the Blockchain Basics with TON course, Module 4 covers the basics of NFTs and jettons.”

---

- [ ] **815. Generalize unverified “Module 7” claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/tokens.mdx?plain=1#L26

Replace the unverified “Module 7 completely covers NFT & Jettons development” with a generalized statement like “The course includes comprehensive modules on NFT and jetton development.”

---

- [ ] **816. Use full language names on buttons**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/tokens.mdx?plain=1#L32-L38

Change language buttons from “CHN” and “RU” to “Chinese” and “Russian” to match site-wide usage.

---

- [ ] **817. Make tutorials list punctuation consistent**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/tokens.mdx?plain=1#L41-L44

Make the three tutorial bullets end consistently by adding trailing periods to those that lack them.

---

- [ ] **818. Match link text to target title for “Metadata parsing”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/tokens.mdx?plain=1#L60

Change link text “TON Metadata Parsing” to “Metadata parsing” to match the target page title and scope.

---

- [ ] **819. Move metadata parsing guide to NFT section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/tokens.mdx?plain=1#L60

Move the “Metadata parsing” guide link from the Jettons section to the NFT section to reflect its subject.

---

- [ ] **820. Use HTTPS and proper dash spacing for Scaleton link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/tokens.mdx?plain=1#L81

Update the Scaleton entry to “Scaleton (https://scaleton.io) — see your custom token balance” to use HTTPS and proper spacing.

---

- [ ] **821. Lowercase “jettons” in prose**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/tokens.mdx?plain=1#L82

Lowercase “Jettons” to “jettons” in prose (e.g., “SDK to query information about jettons”).

---

- [ ] **822. Insert space in “NFT Royalty”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/tokens.mdx?plain=1#L88-L92

Insert a space in “NFTRoyalty” so it reads “NFT Royalty standard extension.”

---

- [ ] **823. Normalize capitalization in headings and labels**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/tokens.mdx?plain=1

Use Title Case for headings and capitalize “Jettons” in titles/labels (e.g., “TON Speed Run”, “TON Course: Jettons & NFTs”, “Tools to Work with Jettons”) for consistency.

---

- [ ] **824. Standardize dash style and spacing across bullets**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/tokens.mdx?plain=1

Replace hyphen-minus and cramped punctuation with spaced em dashes across list items and labels (e.g., “NFT Jetton Sale Contract — NFT sale contract with Jetton support”; “@tegro/ton3-client — SDK to query information about jettons”).

---

- [ ] **825. Use “the TON blockchain” phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/tokens.mdx?plain=1

Change “on TON Blockchain” to “on the TON blockchain” in the Jetton deployer section.

---

- [ ] **826. Improve course CTA button label**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/tokens.mdx?plain=1

Replace the awkward button text “Check TON Blockchain Course” with “Explore the TON Blockchain Course” for a clearer CTA.

---

- [ ] **827. Fix Getgems smart contracts bullet grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/tokens.mdx?plain=1

Rewrite “Getgems NFT, sale, auctions smart contracts” to “Getgems NFT sale and auction smart contracts (FunC)”.

---

- [ ] **828. Add space in “Web Client” label**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/tokens.mdx?plain=1

Change “Jetton Deployer — WebClient (React, TypeScript)” to “Jetton Deployer — Web Client (React, TypeScript)”.

---

- [ ] **3060. Capitalize "Jetton" in title and headings**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx?plain=1

Capitalize Jetton in the page title and section headings for consistency with cross-doc references; e.g., change "Mint your first jetton" → "Mint your first Jetton" and "Deploy a jetton" → "Deploy a Jetton" (see docs/v3/documentation/dapps/defi/tokens.mdx#tutorials and docs/v3/guidelines/dapps/asset-processing/jettons.mdx#jetton-processing).

---

- [ ] **4314. Ambiguous “native token” and generic “tokens” in Assets card**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/dapps-overview.mdx?plain=1

Digital assets card desc reads: “Explore Toncoin, tokens, and the native token.” This is confusing: - Coins page uses “Native token: Toncoin” — docs/v3/documentation/dapps/defi/coins.mdx#native-token-toncoin. - Assets overview describes “Native token” as a special asset type not in use — docs/v3/documentation/dapps/assets/overview.mdx#digital-asset-types-on-ton. - “tokens” should be “Jettons” per token docs — docs/v3/documentation/dapps/defi/tokens.mdx#jettons-fungible-tokens. Minimal fix: Change the desc to “Explore Toncoin, jettons, and NFTs.” If keeping “native token,” a domain decision is required to reconcile terminology between Coins and Assets pages.

---

- [ ] **4316. DeFi card description does not match its link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/dapps-overview.mdx?plain=1

DeFi card desc includes “Explore NFT use cases and Jettons. Implement subscriptions and micropayments.” but the link points to Coins, which only covers Toncoin and extra currencies — docs/v3/documentation/dapps/defi/coins.mdx. The mentioned topics are covered elsewhere: NFTs — docs/v3/documentation/dapps/defi/nft.mdx; Jettons — docs/v3/documentation/dapps/defi/tokens.mdx#jettons-fungible-tokens; Micropayments — docs/v3/documentation/dapps/defi/ton-payments.mdx; Subscriptions — docs/v3/documentation/dapps/defi/subscriptions.mdx. Minimal fix: either (a) trim the desc to only Toncoin and extra currencies to match the link, or (b) change the link to a broader DeFi entry (domain decision required if a DeFi index is intended but does not exist).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.