### PR TITLE
Split: update docs/v3/documentation/dapps/defi/ton-payments.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/dapps/defi/ton-payments.mdx
+++ b/docs/v3/documentation/dapps/defi/ton-payments.mdx
@@ -2,12 +2,11 @@ import Feedback from '@site/src/components/Feedback';
 
 # TON Payments
 
-TON Payments is the platform for micropayment channels.
+TON Payments is the platform for payment channels.
 
-It allows instant payments without the need to commit all transactions to the blockchain, pay the associated transaction fees (e.g., for the gas consumed), and wait five seconds until the block
-containing the transactions in question is confirmed.
+It allows instant payments without the need to commit all transactions to the blockchain, pay the associated transaction fees (e.g., for the gas consumed), and wait for block confirmation.
 
-Because the overall expense of such instant payments is so minimal, they can be used for micropayments in games, APIs, and off-chain apps. [See examples](/v3/documentation/dapps/defi/ton-payments#examples).
+Because the overall expense of such instant payments is so minimal, they can be used for micropayments in games, APIs, and off-chain apps. [See examples](#examples).
 
 - [Payments on TON](https://blog.ton.org/ton-payments)
 
@@ -21,19 +20,19 @@ Because the overall expense of such instant payments is so minimal, they can be 
 
 To use payment channels, you don’t need deep knowledge of cryptography.
 
-You can use prepared SDKs:
+You can use the following SDKs:
 
-- [toncenter/tonweb](https://github.com/toncenter/tonweb)  JavaScript SDK
-- [toncenter/payment-channels-example](https://github.com/toncenter/payment-channels-example)—how to use a payments channel with tonweb.
+- [toncenter/tonweb](https://github.com/toncenter/tonweb) — JavaScript SDK
+- [toncenter/payment-channels-example](https://github.com/toncenter/payment-channels-example) — how to use a payment channel with TonWeb.
 
 ### Examples
 
-Find examples of using payment channels in the [Hack-a-TON #1](https://ton.org/hack-a-ton-1) winners:
+Find examples among the [Hack-a-TON #1](https://ton.org/hack-a-ton-1) winners:
 
-- [grejwood/Hack-a-TON](https://github.com/Grejwood/Hack-a-TON)—OnlyTONs payments project ([website](https://main.d3puvu1kvbh8ti.amplifyapp.com/), [video](https://www.youtube.com/watch?v=38JpX1vRNTk))
-- [nns2009/Hack-a-TON-1_Tonario](https://github.com/nns2009/Hack-a-TON-1_Tonario)—OnlyGrams payments project ([website](https://onlygrams.io/), [video](https://www.youtube.com/watch?v=gm5-FPWn1XM))
-- [sevenzing/hack-a-ton](https://github.com/sevenzing/hack-a-ton)—Pay-per-Request API usage in TON ([video](https://www.youtube.com/watch?v=7lAnbyJdpOA&feature=youtu.be))
-- [illright/diamonds](https://github.com/illright/diamonds)—Pay-per-Minute learning platform ([website](https://diamonds-ton.vercel.app/), [video](https://www.youtube.com/watch?v=g9wmdOjAv1s))
+- [Grejwood/Hack-a-TON](https://github.com/Grejwood/Hack-a-TON) — OnlyTONs payments project ([website](https://main.d3puvu1kvbh8ti.amplifyapp.com/), [video](https://www.youtube.com/watch?v=38JpX1vRNTk))
+- [nns2009/Hack-a-TON-1_Tonario](https://github.com/nns2009/Hack-a-TON-1_Tonario) — OnlyGrams payments project ([video](https://www.youtube.com/watch?v=gm5-FPWn1XM))
+- [sevenzing/hack-a-ton](https://github.com/sevenzing/hack-a-ton) — Pay-per-request API usage on TON ([video](https://www.youtube.com/watch?v=7lAnbyJdpOA&feature=youtu.be))
+- [illright/diamonds](https://github.com/illright/diamonds) — Pay-per-minute learning platform ([website](https://diamonds-ton.vercel.app/), [video](https://www.youtube.com/watch?v=g9wmdOjAv1s))
 
 ## See also
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-dapps-defi-ton-payments.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/dapps/defi/ton-payments.mdx`

Related issues (from issues.normalized.md):
- [x] **829. Remove hardcoded block confirmation time**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/ton-payments.mdx?plain=1#L7-L8

Replace “wait five seconds until the block … is confirmed.” with “wait for block confirmation.”

---

- [x] **830. Rephrase “prepared SDKs”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/ton-payments.mdx?plain=1#L24

Change “You can use prepared SDKs:” to “You can use the following SDKs:”.

---

- [x] **831. Standardize SDK bullets and TonWeb naming**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/ton-payments.mdx?plain=1#L26-L27

Make both SDK bullets consistent: use an em dash with spaces (“ — ”), remove extra/double spaces, change “payments channel” to “payment channel,” and capitalize TonWeb in descriptive text (keep repository link text as-is).

---

- [x] **832. Streamline examples lead-in**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/ton-payments.mdx?plain=1#L31

Change “Find examples of using payment channels in the [Hack-a-TON #1] winners:” to “Find examples among the [Hack-a-TON #1] winners:”.

---

- [x] **833. Fix repo owner casing in example link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/ton-payments.mdx?plain=1#L33

Change the visible link text from “grejwood/Hack-a-TON” to “Grejwood/Hack-a-TON” (URL remains the same).

---

- [x] **834. Remove or replace broken OnlyGrams website link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/ton-payments.mdx?plain=1#L34

The “website” link (https://onlygrams.io/) fails TLS; replace it with a working URL or an archived snapshot, or remove the website link and keep the video.

---

- [x] **835. Use “on TON” instead of “in TON”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/ton-payments.mdx?plain=1#L35

Change “Pay-per-Request API usage in TON” to “Pay-per-Request API usage on TON”.

---

- [x] **836. Normalize “Pay-per-*” capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/ton-payments.mdx?plain=1

Use “Pay-per-request” and “Pay-per-minute” for consistent hyphen-case capitalization.

---

- [x] **837. Use local anchor for “See examples”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/ton-payments.mdx?plain=1

Change “[See examples](/v3/documentation/dapps/defi/ton-payments#examples)” to “[See examples](#examples)” to reduce link fragility.

---

- [x] **838. Add spaces around em dashes in example bullets**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/ton-payments.mdx?plain=1

Add spaces around the em dash between each example link and its description (e.g., “) — ”).

---

- [x] **839. Prefer “payment channels” over “micropayment channels”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/defi/ton-payments.mdx?plain=1

Change “TON Payments is the platform for micropayment channels.” to “TON Payments is the platform for payment channels.”

---

- [x] **4316. DeFi card description does not match its link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/dapps-overview.mdx?plain=1

DeFi card desc includes “Explore NFT use cases and Jettons. Implement subscriptions and micropayments.” but the link points to Coins, which only covers Toncoin and extra currencies — docs/v3/documentation/dapps/defi/coins.mdx. The mentioned topics are covered elsewhere: NFTs — docs/v3/documentation/dapps/defi/nft.mdx; Jettons — docs/v3/documentation/dapps/defi/tokens.mdx#jettons-fungible-tokens; Micropayments — docs/v3/documentation/dapps/defi/ton-payments.mdx; Subscriptions — docs/v3/documentation/dapps/defi/subscriptions.mdx. Minimal fix: either (a) trim the desc to only Toncoin and extra currencies to match the link, or (b) change the link to a broader DeFi entry (domain decision required if a DeFi index is intended but does not exist).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.