### PR TITLE
Split: update docs/v3/documentation/dapps/oracles/pyth.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/dapps/oracles/pyth.mdx
+++ b/docs/v3/documentation/dapps/oracles/pyth.mdx
@@ -34,7 +34,7 @@ The following code snippet demonstrates how to fetch price updates, interact wit
 - TON Mainnet: [EQBU6k8HH6yX4Jf3d18swWbnYr31D3PJI7PgjXT-flsKHqql](https://docs.pyth.network/price-feeds/contract-addresses/ton)
 - TON Testnet: [EQB4ZnrI5qsP_IUJgVJNwEGKLzZWsQOFhiaqDbD7pTt_f9oU](https://docs.pyth.network/price-feeds/contract-addresses/ton)
 
-The following example uses testnet contract. For mainnet usage, change the `PYTH_CONTRACT_ADDRESS_TESTNET` to `PYTH_CONTRACT_ADDRESS_MAINNET` accordingly. 
+The following example uses the testnet contract. For mainnet usage, change the `PYTH_CONTRACT_ADDRESS_TESTNET` to `PYTH_CONTRACT_ADDRESS_MAINNET` accordingly. 
 
 <details>
 ```ts
@@ -119,4 +119,3 @@ You may find these additional resources helpful for developing your TON applicat
 - [Pyth TON example](https://github.com/pyth-network/pyth-examples/tree/main/price_feeds/ton/sdk_js_usage)
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-dapps-oracles-pyth.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/dapps/oracles/pyth.mdx`

Related issues (from issues.normalized.md):
- [ ] **856. Fix shell block language and multiline install commands**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/oracles/pyth.mdx?plain=1

Change code fences for install commands from ts to bash (or sh) and keep each command on a single line (or add backslashes if split), e.g., npm install @pythnetwork/pyth-ton-js @pythnetwork/hermes-client @ton/core @ton/ton @ton/crypto and yarn add @pythnetwork/pyth-ton-js @pythnetwork/hermes-client @ton/core @ton/ton @ton/crypto.

---

- [ ] **857. Align terminology to “Pyth TON contract”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/oracles/pyth.mdx?plain=1

Replace “Pyth receiver contract” with “Pyth TON contract” throughout for consistency with the code (PythContract) and the resources section.

---

- [ ] **858. Import MAINNET constant in example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/oracles/pyth.mdx?plain=1

Include PYTH_CONTRACT_ADDRESS_MAINNET in the import alongside PYTH_CONTRACT_ADDRESS_TESTNET and note to choose the address matching the target network.

---

- [ ] **859. Add summary to details block**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/oracles/pyth.mdx?plain=1

Add a <summary> (e.g., “Show TypeScript example”) to the <details> block so the toggle label is descriptive.

---

- [ ] **860. Remove unused toNano import**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/oracles/pyth.mdx?plain=1

Delete the unused toNano import from @ton/core in the example (or use it), to avoid confusion and keep the snippet minimal.

---

- [ ] **861. Clarify API key guidance and source**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/oracles/pyth.mdx?plain=1

Update the apiKey example comment to indicate where to obtain a TON Center API key (e.g., “Get your API key via @tonapibot or https://t.me/toncenter”), and keep “Optional” only if the key is indeed optional.

---

- [ ] **862. Fix grammar: “the testnet contract”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/dapps/oracles/pyth.mdx?plain=1

Change “The following example uses testnet contract.” to “The following example uses the testnet contract.” for correct grammar.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.