### PR TITLE
Split: update docs/v3/documentation/data-formats/tl.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/data-formats/tl.mdx
+++ b/docs/v3/documentation/data-formats/tl.mdx
@@ -1,31 +1,31 @@
 import Feedback from '@site/src/components/Feedback';
 
-# TL
+# TL language
 TL (Type Language) is a language used to describe data structures.
 
 [TL schemas](https://github.com/ton-blockchain/ton/tree/master/tl/generate/scheme) are used to structure data when communicating. 
 
 TL operates on 32-bit blocks, meaning the data size in TL must always be a multiple of 4 bytes. If the object's size is not a multiple of 4, zero padding must be added to make it align with a 4-byte boundary.
 
-Numbers are always encoded in Little Endian order.
+In TL, numbers are encoded in little-endian order.
 
 For more details on TL, refer to the [Telegram documentation](https://core.telegram.org/mtproto/TL).
 
 
-## Encoding bytes array
-To encode a byte array, we first determine its size. If the array is less than 254 bytes, the size is encoded using a single byte. If the array size exceeds 254 bytes, the first byte is set to `0xFE` to indicate an oversized array, followed by a 3-byte size field.
+## Encoding a byte array
+To encode a byte array, we first determine its size. If the array is less than 254 bytes, the size is encoded using a single byte. If the array size is ≥ 254 bytes, the first byte is `0xFE`, followed by a 3‑byte little-endian length.
 
 For example, to encode the array `[0xAA, 0xBB]` with size 2, we use 1 byte for the size, followed by the data itself, resulting in `[0x02, 0xAA, 0xBB]`. However, the total size is 3 bytes, which is not a multiple of 4. Therefore, we add 1 byte of padding to align it to 4 bytes, resulting in `[0x02, 0xAA, 0xBB, 0x00]`.
 
-If we need to encode an array with a size of, for example, 396 bytes, we use 3 bytes for the size encoding and 1 byte for the oversize indicator. The encoding would be: `[0xFE, 0x8C, 0x01, 0x00, array bytes]`. The total size becomes `396+4 = 400` bytes, a multiple of 4, so no additional alignment is needed.
+If we need to encode an array with a size of, for example, 396 bytes, we use 3 bytes for the size encoding and 1 byte for the 0xFE long-form length marker. The encoding would be: `[0xFE, 0x8C, 0x01, 0x00, array bytes]`. The total size becomes `396 + 4 = 400` bytes, a multiple of 4, so no additional alignment is needed.
 
 ## Non-obvious serialization rules
 
-A 4-byte prefix is often added before the schema itself—its ID. The schema ID is a CRC32 hash derived from the schema text using an IEEE table, with symbols like `;` and `()` removed beforehand. The serialization of a schema with an ID prefix is called **boxed**, which enables the parser to determine which schema is being used when multiple options exist.
+A 4-byte prefix is often added before the constructor itself—its ID. The constructor ID is a CRC32 (IEEE) of the normalized constructor declaration text. The serialization of a constructor with an ID prefix is called **boxed**, which enables the parser to determine which constructor is being used when multiple options exist.
 
-If a schema is part of another schema, the decision to serialize it with or without a prefix depends on the specified field type. The schema is serialized without a prefix if the type is explicitly defined. If the type is not explicitly defined (which applies to many types), the schema should be serialized with the ID prefix (boxed). For example:
+If a constructor is part of another constructor, the decision to serialize it with or without a prefix depends on the specified field type. The constructor is serialized without a prefix if the type is explicitly defined. If the type is not explicitly defined (which applies to many types), the constructor should be serialized with the ID prefix (boxed). For example:
 
-```tlb
+```tl
 pub.unenc data:bytes = PublicKey;
 pub.ed25519 key:int256 = PublicKey;
 pub.aes key:int256 = PublicKey;
@@ -34,13 +34,13 @@ pub.overlay name:bytes = PublicKey;
 
 Consider the following scenario: if `PublicKey` is specified within the schema like this:
 
-```
+```tl
 adnl.node id:PublicKey addr_list:adnl.addressList = adnl.Node;
 ```
 
 Since the type is not explicitly defined, it needs to be serialized with an ID prefix (boxed). However, if the schema is specified as follows:
 
-```
+```tl
 adnl.node id:pub.ed25519 addr_list:adnl.addressList = adnl.Node;
 ```
 
@@ -50,4 +50,3 @@ The type is explicitly specified, so the prefix is not needed.
 
 [Link to the original article](https://github.com/xssnick/ton-deep-doc/blob/master/TL.md) - _[Oleg Baranov](https://github.com/xssnick)_.
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-data-formats-tl.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/data-formats/tl.mdx`

Related issues (from issues.normalized.md):
- [ ] **891. Disambiguate H1 title**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tl.mdx?plain=1#L3-L4

Change the H1 from "TL" to "TL language" to avoid confusion with TL‑B.

---

- [ ] **892. Clarify endianness scope and style**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tl.mdx?plain=1#L10

Change to "In TL, numbers are encoded in little-endian order." for correct scope and house style.

---

- [ ] **893. Fix section heading grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tl.mdx?plain=1#L15

Replace "Encoding bytes array" with "Encoding a byte array" for grammatical correctness.

---

- [ ] **894. Clarify byte array length threshold**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tl.mdx?plain=1#L16

State explicitly: "If the array size is ≥ 254 bytes, the first byte is 0xFE, followed by a 3‑byte little-endian length."

---

- [ ] **895. Standardize 0xFE wording and example spacing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tl.mdx?plain=1#L16-L20

Replace "oversize indicator"/"oversized" with "0xFE long-form length marker" consistently, and format the example as "396 + 4 = 400".

---

- [ ] **896. Use correct term "constructor ID"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tl.mdx?plain=1#L24-L26

Replace "schema ID" (and "schema" in this context) with "constructor ID" (and "constructor") to match TL terminology.

---

- [ ] **897. Remove or soften unverified CRC32 normalization details**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tl.mdx?plain=1#L24

Rephrase to "CRC32 (IEEE) of the normalized constructor declaration text" and remove the specific list of stripped symbols unless cited to the TL spec.

---

- [ ] **898. Relabel TL schema code fence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tl.mdx?plain=1#L28-L33

Change the code fence language from ```tlb to ```tl because the examples are TL schemas, not TL‑B.

---

- [ ] **899. Add language to unlabeled TL code fences**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tl.mdx?plain=1#L37-L45

Add the ```tl language identifier to the later TL schema code blocks for consistent highlighting.

---

- [ ] **1368. Fix TL bytes-encoding link wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/adnl/adnl-tcp.mdx?plain=1#L90

Change “parsing encoding bytes in TL” to “encoding byte arrays in TL” and link to docs/v3/documentation/data-formats/tl.mdx#encoding-bytes-array.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.