### PR TITLE
Split: update docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/data-formats/cells/serialization.mdx
+++ b/docs/v3/documentation/data-formats/cells/serialization.mdx
@@ -8,7 +8,7 @@ import Feedback from '@site/src/components/Feedback';
 
 - If the cell is a leaf node: `weight = 1`
 - For ordinary (non-leaf) cells: `weight = sum of children’s weights + 1`
-- If the cell is [special (exotic)](./cell-boc.mdx#special-exotic-cells): `weight = 0`
+- If the cell is [special (exotic)](/v3/documentation/data-formats/cells/overview#exotic-cells): `weight = 0`
 
 This concept is used to construct a weight-balanced tree structure when serializing cells. The following algorithm outlines how weights are assigned to each cell and how the tree is reordered accordingly.
 
@@ -24,7 +24,7 @@ The method also:
 
 Reindexing is performed in depth-first order, likely due to specific dependencies or optimizations. As stated in the whitepaper, this indexing order is preferred.
 
-To follow the original node’s bag of cells ([BoC](./cell-boc.mdx)) serialization format, the following steps should be applied:
+To follow the original node’s bag of cells ([BoC](/v3/documentation/data-formats/cells/overview)) serialization format, the following steps should be applied:
 
 - First, if the cell's weights have not been set, this is typically handled during cell import; the weight for each cell is set to `1 + sum_child_weight`, where `sum_child_weight` represents the total weight of its child nodes. The additional 1 ensures that leaf nodes receive a weight of 1.
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-data-formats-tlb-canonical-cell-serialization.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx`

Related issues (from issues.normalized.md):
- [x] **930. Use lowercase `weight` and fix article**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx?plain=1#L7-L13

Change the backticked property name to lowercase (`weight`) and replace “in the cell tree” with “in a cell tree” for general phrasing; keep this usage consistent throughout.

---

- [x] **931. Remove extra space before colon after “special”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx?plain=1#L11

Fix “If the cell is _special_ :” to “If the cell is _special_:”.

---

- [x] **932. Standardize “special (exotic)” terminology and link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx?plain=1#L11-L12,L38,L54-L57

Replace “special” with “special (exotic)” and link the first occurrence to docs/v3/documentation/data-formats/tlb/cell-boc.mdx#special-exotic-cells; keep the term consistent across the page.

---

- [x] **933. Improve heading “Weight reorder algorithm”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx?plain=1#L15

Change the heading to “Weight reordering algorithm” (or “Weight-based reordering algorithm”) for grammatical correctness.

---

- [x] **934. Omit parentheses in reorder_cells link text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx?plain=1#L17

Change the link text “[reorder_cells()]” to “[reorder_cells]” while keeping the same target.

---

- [x] **935. Clarify traversal order; remove unsupported BFS claim and speculation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx?plain=1#L18-L25

Do not assert breadth‑first traversal or “cache linearity” rationale without a citation; either add a precise spec/whitepaper reference or rephrase to describe the implementation-specific phased passes (children visited before parents, special nodes prioritized) without claiming BFS.

---

- [x] **936. Rephrase “Recalculates hash sizes”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx?plain=1#L21

Replace “Recalculates hash sizes” with “Recomputes hash counts (representation and higher hashes)” or “Updates hash counters” to avoid implying hash output size changes.

---

- [x] **937. Fix comma and wording in roots reindexing sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx?plain=1#L22

Remove the superfluous comma and reword to “Reindexes the bag of cells (roots) and their trees” (or “roots and their corresponding trees”).

---

- [x] **938. Clarify “empty references”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx?plain=1#L23

Define “empty references” (e.g., absent/missing references in a cell) or replace with clearer wording consistent with the BoC schema.

---

- [x] **939. Add citation or remove uncited whitepaper claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx?plain=1#L25

Provide an explicit link to the relevant whitepaper section for the stated indexing preference, or remove the sentence.

---

- [x] **940. Link BoC on first mention and clarify “original node’s”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx?plain=1#L27

Rephrase to “reference implementation’s BoC serialization format” (or similar) and link “BoC” to docs/v3/documentation/data-formats/tlb/cell-boc.mdx (and/or the glossary), avoiding the ambiguous “original node’s”.

---

- [x] **941. Specify integer division and identifier formatting in formulas**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx?plain=1#L31-L34

Use backticks for identifiers and state explicitly that divisions are integer (floor) divisions where applicable (e.g., “(maximum_possible_weight - 1 + ref_index) / num_references”).

---

- [x] **942. Cite algorithmic constraints or mark as implementation-specific**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx?plain=1#L32-L34,L37-L41

Add citations for the detailed constraints and counters (e.g., per-reference limits and hash-count rules) or note that they follow the reference implementation; include precise source links.

---

- [x] **943. Replace vague rounding note with concrete example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx?plain=1#L32

Explain the bias using a worked example, e.g., with maximum_possible_weight = 64 and num_references = 5, limits are floor((63 + j)/5) for j = 0..4 → 12, 12, 13, 13, 13; later references get the extra 1.

---

- [x] **944. Clarify clamping step and integer division**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx?plain=1#L33-L34

Describe that for each invalid reference the per-reference limit is weight_left / invalid_ref_count (integer division), and only weights exceeding the limit are reduced to the limit.

---

- [x] **945. Align hash counter terminology and define**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx?plain=1#L38-L41

Use consistent terms for hash counts, aligning with “representation” and “higher” hashes and/or mapping to code identifiers `int_hashes` and `top_hashes`; briefly define “hash count” or link to the Cell hash section.

---

- [x] **946. Add “the” in “Recursively reindex the tree”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx?plain=1#L43

Change “Recursively reindex tree:” to “Recursively reindex the tree:”; keep “reindex” (no hyphen).

---

- [x] **947. Clarify visit-state phrasing in reindexing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx?plain=1#L43-L46

Replace “has not been revisited or visited” wording with a clear single-state description, e.g., “If a node has not been visited, recursively process its references; visit special (exotic) nodes (and their children) first so their children get the lowest indices.”

---

- [x] **948. Use “indices” consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx?plain=1#L44-L48

Replace “indexes” with “indices” throughout this range and say “the highest indices” for root nodes.

---

- [x] **949. Cite and align “maximum_possible_weight = 64”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx?plain=1#L50

Note the source of this constant (e.g., `max_cell_whs` in the reference code) and/or add a citation; align naming or parenthetically map “maximum_possible_weight” to the source identifier.

---

- [x] **950. Fix grammar: “weighs/has weight 0”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx?plain=1#L54

Change “A special cell weights 0.” to “A special (exotic) cell has weight 0.” (or “weighs 0”).

---

- [x] **951. Render comparison operator as code**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx?plain=1#L55

Change “weight \<= 255” to “weight <= 255” in code formatting, e.g., “ensure that the weight fits within 8 bits (`weight <= 255`)”.

---

- [x] **952. Correct scope of hash counters**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx?plain=1#L56-L57

Clarify that `int_hashes` sums the hash counts of all cells with final weight 0 (not only roots), while `top_hashes` sums the hash counts of root cells with weight > 0.

---

- [x] **1317. Clarify serialization note in Prerequisites**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/configs/blockchain-configs.mdx?plain=1#prerequisites

Replace the vague “binary encoding … at the end of the TON Blockchain parameter” note with: “Configuration values are TL‑B‑typed cells serialized into Bags of Cells (BoC); see canonical serialization and Bag of Cells,” linking to docs/v3/documentation/data-formats/tlb/canonical-cell-serialization.mdx and docs/v3/documentation/data-formats/tlb/cell-boc.mdx.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.