### PR TITLE
Split: update docs/v3/documentation/data-formats/tlb/exotic-cells.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/data-formats/tlb/exotic-cells.mdx
+++ b/docs/v3/documentation/data-formats/tlb/exotic-cells.mdx
@@ -2,11 +2,11 @@ import Feedback from '@site/src/components/Feedback';
 
 # Exotic cells
 
-Each cell has a type encoded by an integer ranging from -1 to 255. A cell with a type of -1 is considered an `ordinary` cell, while all other cells are classified as `exotic` or `special`.
+Cells are either ordinary or special (exotic).
 The type of an exotic cell is stored in the first eight bits of its data. It is considered invalid if an exotic cell contains fewer than eight data bits.
 Currently, there are 4 exotic cell types:
 
-```json
+```text
 {
   Prunned Branch: 1,
   Library Reference: 2,
@@ -26,7 +26,7 @@ The structure of a pruned branch cell is as follows:
 - Next, `h * 32` bytes represent hashes of the deleted subtrees.
 - Then, `h * 2` bytes represent the depths of the deleted subtrees.
 
-The level `l` of a pruned branch is is the index of the most significant bit in `mask` (starting from zero) plus one. The level is also called its De Bruijn index, as it determines the outer Merkle proof or Merkle update during the construction process in which the branch was pruned.
+The level `l` of a pruned branch is is the index of the most significant bit in `mask` (starting from zero) plus one.
 
 Higher-level hashes `Hash[0]..Hash[l-1]` of a pruned branch are stored within its data and can be obtained as follows:
 
@@ -69,7 +69,7 @@ Following that, 4 bytes represent the depth of the deleted old and new subtrees.
 
 Let's assume there is a cell `c`:
 
-```json
+```text
 24[000078] -> {
 	32[0000000F] -> {
 		1[80] -> {
@@ -93,7 +93,7 @@ To achieve this, we request the prover to generate a Merkle proof, replacing all
 
 The first descendant of `c` from which there is no way to reach `a` is `ref1`:
 
-```json
+```text
 32[0000000F] -> {
 	1[80] -> {
 		32[0000000E]
@@ -110,7 +110,7 @@ The next cell is `512[0000000...00000000064]`.
 
 The prover creates a pruned branch to replace this cell as well:
 
-```json
+```text
 24[000078] -> {
 	288[0101EC7C1379618703592804D3A33F7E120CEBE946FA78A6775F6EE2E28D80DDB7DC0002],
 	16[000B] -> {
@@ -124,7 +124,7 @@ The prover creates a pruned branch to replace this cell as well:
 
 The resulting Merkle proof that the prover sends to the verifier (us, in this example) looks like this:
 
-```json
+```text
 280[0344EFD0FDFFFA8F152339A0191DE1E1C5901FDCFE13798AF443640AF99616B9770003] -> {
 	24[000078] -> {
 		288[0101EC7C1379618703592804D3A33F7E120CEBE946FA78A6775F6EE2E28D80DDB7DC0002],
@@ -146,6 +146,6 @@ Such proofs significantly reduce computational load and minimize the amount of d
 
 ## See also
 
-- [Advanced proofs verifying examples](/v3/documentation/data-formats/tlb/proofs)
+- [Proofs verifying (low-level)](/v3/documentation/data-formats/tlb/proofs)
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-data-formats-tlb-exotic-cells.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/data-formats/tlb/exotic-cells.mdx`

Related issues (from issues.normalized.md):
- [ ] **987. Retag types map and fix 'Prunned Branch'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/exotic-cells.mdx?plain=1#L9-L16

The exotic types mapping block is labeled as JSON but uses non-JSON syntax and misspells “Prunned Branch”; retag the block as text and correct the label to “Pruned branch” (matching section casing).

---

- [ ] **988. Remove duplicate “is”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/exotic-cells.mdx?plain=1#L29

Replace “is is” with “is”.

---

- [ ] **989. Clarify i-th/k-th phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/exotic-cells.mdx?plain=1#L33-L34

Change “`i`th” to “i-th” and “If `k`th bit of `mask` is 0 then …” to “If the k-th bit of `mask` is 0, then …”.

---

- [ ] **990. Lowercase “representation hash”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/exotic-cells.mdx?plain=1#L44

In mid-sentence link text, change “Representation hash” to “representation hash” for consistency with the target section title.

---

- [ ] **991. Use Hash_{i+1}(ref) notation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/exotic-cells.mdx?plain=1#L56

Replace “Hash_i+1(ref)” with “Hash_{i+1}(ref)” to avoid ambiguity.

---

- [ ] **992. Replace Unicode minus with ASCII hyphen**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/exotic-cells.mdx?plain=1#L62

In “max(Lvl(ref1) − 1, Lvl(ref2) − 1, 0)”, replace “−” with “-”: “max(Lvl(ref1) - 1, Lvl(ref2) - 1, 0)”.

---

- [ ] **993. Correct Merkle update hash names**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/exotic-cells.mdx?plain=1#L65

Change “`Hash_1(ref1)` and `Hash_2(ref2)`” to “`Hash_1(ref1)` and `Hash_1(ref2)`” (old and new hashes, respectively).

---

- [ ] **994. Retag non-JSON examples as text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/exotic-cells.mdx?plain=1#L72-L89, #L96-L105, #L113-L123, #L127-L139

These examples use custom cell notation, not JSON; change the code fence language from JSON to text to avoid misleading highlighting.

---

- [ ] **995. Reword type range and “-1 ordinary” claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/exotic-cells.mdx?plain=1#exotic-cells

Remove the uncorroborated “type in the range -1..255” and “-1 denotes an ordinary cell” sentence, and instead state that cells are ordinary or special (exotic), with exotic cells encoding an 8-bit type in the first data byte.

---

- [ ] **996. Standardize “special (exotic)” phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/exotic-cells.mdx?plain=1#exotic-cells

Replace “exotic or special” with the consistent phrasing “special (exotic)”.

---

- [ ] **997. Remove undefined “De Bruijn index” clause**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/exotic-cells.mdx?plain=1#pruned-branch

Delete the “also called its De Bruijn index” clause to avoid introducing an undefined term.

---

- [ ] **998. Align See also link text with target title**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/exotic-cells.mdx?plain=1#see-also

Change the link text to “Proofs verifying (low-level)” to match the target page title.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.