### PR TITLE
Split: update docs/v3/documentation/data-formats/tlb/msg-tlb.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/data-formats/tlb/msg-tlb.mdx
+++ b/docs/v3/documentation/data-formats/tlb/msg-tlb.mdx
@@ -22,13 +22,15 @@ _ (Message Any) = MessageAny;
 ```
 
 - `Message X` refers to the standard message structure.
-- `MessageRelaxed X` is a variant that uses a `CommonMsgInfoRelaxed` body.
+- `MessageRelaxed X` uses `CommonMsgInfoRelaxed` for the `info` field.
 - `Message Any` is a union of both structures.
 
-The message structure is unified using X:Type, which in this context represents a cell.
+The message structure is unified using `X:Type`, which means X can be any type (not specifically a cell).
 According to TL-B rules, all data can be stored within a single cell—if it fits within 1023 bits—or distributed across references using the caret symbol `^`.
 
 A serialized `Message X` is placed into the action list using the FunC method `send_raw_message()`. The smart contract then executes this action, and the message is sent.
+
+See the `CommonMsgInfoRelaxed` definition in the [Func stdlib](/v3/documentation/smart-contracts/func/docs/stdlib).
 
 
 ### Definition of explicit serialization
@@ -53,10 +55,10 @@ body:(Either X ^X) = Message X;
 
 | Structure | Type                            | Required | Description                                                                                                                     |
 |-----------|---------------------------------|----------|---------------------------------------------------------------------------------------------------------------------------------|
-| message$_ | Constructor                     |          | Defined according to the constructor rule. The empty tag `$_` indicates that no bits are added initially.                       |
+| message$_ | Constructor                     | Required | Defined according to the constructor rule. The empty tag `$_` indicates that no bits are added initially.                       |
 | info      | [CommonMsgInfo](#commonmsginfo) | Required | Contains detailed message properties such as destination and value. It is always stored in the message's root cell.             |
 | init      | [StateInit](#stateinit-tl-b)    | Optional | The general structure is used in TON to initialize new contracts. It can be placed in either a cell reference or the root cell. |
-| body      | X                               | Required | Message payload. It can be placed in either a cell reference or the root cell.                                                  |                                                                                            |
+| body      | X                               | Required | Message payload. It can be placed in either a cell reference or the root cell.                                                  |
 
 
 ```tlb
@@ -73,7 +75,7 @@ Recall how `Maybe` and `Either` work—we can serialize different cases:
 
 <br></br>
 <ThemedImage
-alt=""
+alt="Message X serialized inline in one cell"
 sources={{
 light: '/img/docs/data-formats/tl-b-docs-9.png?raw=true',
 dark: '/img/docs/data-formats/tl-b-docs-9-dark.png?raw=true',
@@ -86,7 +88,7 @@ dark: '/img/docs/data-formats/tl-b-docs-9-dark.png?raw=true',
 
 <br></br>
 <ThemedImage
-alt=""
+alt="Message X serialized using references"
 sources={{
 light: '/img/docs/data-formats/tl-b-docs-8.png?raw=true',
 dark: '/img/docs/data-formats/tl-b-docs-8-dark.png?raw=true',
@@ -142,9 +144,9 @@ int_msg_info$0 ihr_disabled:Bool bounce:Bool bounced:Bool
 | src            | [MsgAddressInt](#msgaddressint-tl-b)      | Required | The sender's smart contract address.                                                                                            |
 | dest           | [MsgAddressInt](#msgaddressint-tl-b)      | Required | The recipient's smart contract address.                                                                                         |
 | value          | [CurrencyCollection](#currencycollection) | Required | Describes the currency details, including the total funds transferred with the message.                                         |
-| ihr_fee        | [VarUInteger 16](#varuinteger-n)          | Required | Fee for delivering the message using hypercube routing.                                                                         |
-| fwd_fee        | [VarUInteger 16](#varuinteger-n)          | Required | Validators set the fee for forwarding the message.                                                                              |
-| created_lt     | uint64                                    | Required | Logic time of the message, used by validators to order actions in smart contracts.                                              |
+| ihr_fee        | Grams                                     | Required | Fee for delivering the message using hypercube routing.                                                                         |
+| fwd_fee        | Grams                                     | Required | Validators set the fee for forwarding the message.                                                                              |
+| created_lt     | uint64                                    | Required | Logical time of the message, used by validators to order actions in smart contracts.                                            |
 | created_at     | uint32                                    | Required | UNIX timestamp indicating when the message was created.                                                                         |
 
 
@@ -167,7 +169,7 @@ ext_in_msg_info$10 src:MsgAddressExt dest:MsgAddressInt
 | ext_in_msg_info$10 | Constructor                          | Required | The `$10` tag indicates that the `CommonMsgInfo` begins with `10` bits in serialization, denoting an external incoming message. |
 | src                | [MsgAddressExt](#msgaddressext-tl-b) | Required | The external sender’s address.                                                                                                  |
 | dest               | [MsgAddressInt](#msgaddressint-tl-b) | Required | The destination smart contract address.                                                                                         |
-| import_fee         | [VarUInteger 16](#varuinteger-n)     | Required | The fee for executing and delivering the message.                                                                               |
+| import_fee         | Grams                                | Required | The fee for executing and delivering the message.                                                                               |
 
 
 
@@ -187,7 +189,7 @@ ext_out_msg_info$11 src:MsgAddressInt dest:MsgAddressExt
 | ext_out_msg_info$11 | Constructor                          | Required | The `$11` tag indicates that the `CommonMsgInfo` begins with `11` bits in serialization, denoting an external outgoing message. |
 | src                 | [MsgAddressInt](#msgaddressint-tl-b) | Required | The sender’s smart contract address.                                                                                            |
 | dest                | [MsgAddressExt](#msgaddressext-tl-b) | Required | The external destination address for the message.                                                                               |
-| created_lt          | uint64                               | Required | Logic times of the message, assigned by the validator. Used for ordering actions in the smart contract.                         |
+| created_lt          | uint64                               | Required | Logical time of the message, assigned by the validator. Used for ordering actions in the smart contract.                        |
 | created_at          | uint32                               | Required | UNIX timestamp representing when the message was created.                                                                       |
 
 
@@ -234,7 +236,7 @@ addr_none$00 = MsgAddressExt;
 
 | Structure    | Type        | Required | Description                                                                                                                                   |
 |--------------|-------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------|
-| addr_none$00 | Constructor | Required | The `$00` tag in serialization indicates that `MsgAddressExt` starts with `00` bits. This signifies that the entire external address is `00`. |
+| addr_none$00 | Constructor | Required | The `$00` tag in serialization indicates a null external address (`MsgAddressExt`; no external sender).                                       |
 
 
 ### addr_extern$01
@@ -248,7 +250,7 @@ addr_extern$01 len:(## 9) external_address:(bits len)
 | Structure        | Type        | Required | Description                                                                                                            |
 |------------------|-------------|----------|------------------------------------------------------------------------------------------------------------------------|
 | addr_extern$01   | Constructor | Required | The `$01` tag in serialization indicates that `MsgAddressExt` starts with `01` bits and describes an external address. |
-| len              | ## 9        | Required | Represents an unsigned N-bit number, similar to `uintN`.                                                               |
+| len              | ## 8        | Required | Represents an unsigned N-bit number, similar to `uintN`.                                                               |
 | external_address | (bits len)  | Required | A bitstring address, where the length of the address equals the previously defined `len`.                              |
 
 
@@ -294,11 +296,11 @@ workchain_id:int32 address:(bits addr_len) = MsgAddressInt;
 | addr_var$11  | Constructor | Required  | The `$11` tag indicates that in the serialization of `MsgAddressInt`, the address starts with `11` bits, representing an internal contract address. |
 | anycast      | Anycast*    | Optional  | Additional address data is not currently used in regular internal messages.               |
 | addr_len     | ## 9        | Required  | Same as `uintN` – represents an unsigned N-bit number.                                                                       |
-| workchain_id | int32       | Required  | The WorkChain is where the smart contract for the destination address is located. Currently, this is always set to zero.                           |
-| address      | (bits256)   | Required  | The payload address (this could be the account ID).                                                                                   |
+| workchain_id | int32       | Required  | Workchain where the smart contract resides; typically 0 (basechain), may differ (e.g., -1 for masterchain).                           |
+| address      | (bits addr_len)   | Required  | The payload address (this could be the account ID).                                                                                   |
 
 
-## Basic used types
+## Basic types
 
 
 ### CurrencyCollection
@@ -314,7 +316,7 @@ currencies$_ grams:Grams other:ExtraCurrencyCollection
 | Structure    | Type                    | Required | Description                                                                                                  |
 |--------------|-------------------------|----------|--------------------------------------------------------------------------------------------------------------|
 | currencies$_ | Constructor             | Required | The `$_` empty tag indicates that no bits are added at the beginning during the serialization of `CurrencyCollection`.|
-| grams        | (VarUInteger 16)        | Required | Represents the message value, expressed in nanoTons.                                                                                |
+| grams        | (VarUInteger 16)        | Required | Represents the message value, expressed in nanograms.                                                                               |
 | other        | ExtraCurrencyCollection | Optional | ExtraCurrencyCollection is a dictionary intended for additional, typically empty currencies.         |
 
 - ExtraCurrencyCollection is a complex type usually written as an empty dictionary in messages.
@@ -332,7 +334,7 @@ var_int$_ {n:#} len:(#< n) value:(int (len * 8))
 
 | Structure  | Type             | Required | Description                                                                                                                 |
 |------------|------------------|----------|-----------------------------------------------------------------------------------------------------------------------------|
-| var_uint$_ | Constructor      | Required | The `var_uint$_` is an empty tag, indicating that no bits are added at the beginning of `CurrencyCollection` serialization. |
+| var_uint$_ | Constructor      | Required | The `var_uint$_` is an empty tag, indicating that no bits are added at the beginning of `VarUInteger` serialization. |
 | len        | uintN            | Required | Specifies the bit-length used to encode the next value.                                                                     |
 | value      | (uint (len * 8)) | Optional | An optional unsigned integer encoded in `(len * 8)` bits.                                                                   |
 
@@ -365,6 +367,8 @@ var_int$_ {n:#} len:(#< n) value:(int (len * 8))
 
 Validators always overwrite message parts, which can be skipped and filled with zero bits. The message's sender is also skipped and serialized as `addr_none$00`.
 
+This short-form example uses `CommonMsgInfoRelaxed`, where `src:MsgAddress` allows `addr_none$00`.
+
 ```func
   cell msg = begin_cell()
         .store_uint(0x18, 6)
@@ -376,4 +380,3 @@ Validators always overwrite message parts, which can be skipped and filled with 
 ```
 
 <Feedback />
-

--- a/docs/v3/documentation/data-formats/tlb/msg-tlb.mdx
+++ b/docs/v3/documentation/data-formats/tlb/msg-tlb.mdx
@@ -30,9 +30,6 @@ According to TL-B rules, all data can be stored within a single cell—if it fit
 
 A serialized `Message X` is placed into the action list using the FunC method `send_raw_message()`. The smart contract then executes this action, and the message is sent.
 
-See the `CommonMsgInfoRelaxed` definition in the [Func stdlib](/v3/documentation/smart-contracts/func/docs/stdlib).
-
-
 ### Definition of explicit serialization
 
 To construct valid binary data according to a TL-B structure, serialization must be performed as defined recursively for each type. To serialize a `Message X`, you must also know how to serialize nested structures like `StateInit`, `CommonMsgInfo`, etc.

--- a/docs/v3/documentation/data-formats/tlb/msg-tlb.mdx
+++ b/docs/v3/documentation/data-formats/tlb/msg-tlb.mdx
@@ -25,7 +25,7 @@ _ (Message Any) = MessageAny;
 - `MessageRelaxed X` uses `CommonMsgInfoRelaxed` for the `info` field.
 - `Message Any` is a union of both structures.
 
-The message structure is unified using `X:Type`, which means X can be any type (not specifically a cell).
+The message structure is unified using X:Type, which in this context represents a cell.
 According to TL-B rules, all data can be stored within a single cell—if it fits within 1023 bits—or distributed across references using the caret symbol `^`.
 
 A serialized `Message X` is placed into the action list using the FunC method `send_raw_message()`. The smart contract then executes this action, and the message is sent.
@@ -144,8 +144,8 @@ int_msg_info$0 ihr_disabled:Bool bounce:Bool bounced:Bool
 | src            | [MsgAddressInt](#msgaddressint-tl-b)      | Required | The sender's smart contract address.                                                                                            |
 | dest           | [MsgAddressInt](#msgaddressint-tl-b)      | Required | The recipient's smart contract address.                                                                                         |
 | value          | [CurrencyCollection](#currencycollection) | Required | Describes the currency details, including the total funds transferred with the message.                                         |
-| ihr_fee        | Grams                                     | Required | Fee for delivering the message using hypercube routing.                                                                         |
-| fwd_fee        | Grams                                     | Required | Validators set the fee for forwarding the message.                                                                              |
+| ihr_fee        | [VarUInteger 16](#varuinteger-n)                                     | Required | Fee for delivering the message using hypercube routing.                                                                         |
+| fwd_fee        | [VarUInteger 16](#varuinteger-n)                                     | Required | Validators set the fee for forwarding the message.                                                                              |
 | created_lt     | uint64                                    | Required | Logical time of the message, used by validators to order actions in smart contracts.                                            |
 | created_at     | uint32                                    | Required | UNIX timestamp indicating when the message was created.                                                                         |
 
@@ -169,7 +169,7 @@ ext_in_msg_info$10 src:MsgAddressExt dest:MsgAddressInt
 | ext_in_msg_info$10 | Constructor                          | Required | The `$10` tag indicates that the `CommonMsgInfo` begins with `10` bits in serialization, denoting an external incoming message. |
 | src                | [MsgAddressExt](#msgaddressext-tl-b) | Required | The external sender’s address.                                                                                                  |
 | dest               | [MsgAddressInt](#msgaddressint-tl-b) | Required | The destination smart contract address.                                                                                         |
-| import_fee         | Grams                                | Required | The fee for executing and delivering the message.                                                                               |
+| import_fee         | [VarUInteger 16](#varuinteger-n)                                | Required | The fee for executing and delivering the message.                                                                               |
 
 
 
@@ -236,7 +236,7 @@ addr_none$00 = MsgAddressExt;
 
 | Structure    | Type        | Required | Description                                                                                                                                   |
 |--------------|-------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------|
-| addr_none$00 | Constructor | Required | The `$00` tag in serialization indicates a null external address (`MsgAddressExt`; no external sender).                                       |
+| addr_none$00 | Constructor | Required | The `$00` tag in serialization indicates that `MsgAddressExt` starts with `00` bits. This signifies that the entire external address is `00`.                                       |
 
 
 ### addr_extern$01
@@ -250,7 +250,7 @@ addr_extern$01 len:(## 9) external_address:(bits len)
 | Structure        | Type        | Required | Description                                                                                                            |
 |------------------|-------------|----------|------------------------------------------------------------------------------------------------------------------------|
 | addr_extern$01   | Constructor | Required | The `$01` tag in serialization indicates that `MsgAddressExt` starts with `01` bits and describes an external address. |
-| len              | ## 8        | Required | Represents an unsigned N-bit number, similar to `uintN`.                                                               |
+| len              | ## 9        | Required | Represents an unsigned N-bit number, similar to `uintN`.                                                               |
 | external_address | (bits len)  | Required | A bitstring address, where the length of the address equals the previously defined `len`.                              |
 
 
@@ -296,8 +296,8 @@ workchain_id:int32 address:(bits addr_len) = MsgAddressInt;
 | addr_var$11  | Constructor | Required  | The `$11` tag indicates that in the serialization of `MsgAddressInt`, the address starts with `11` bits, representing an internal contract address. |
 | anycast      | Anycast*    | Optional  | Additional address data is not currently used in regular internal messages.               |
 | addr_len     | ## 9        | Required  | Same as `uintN` – represents an unsigned N-bit number.                                                                       |
-| workchain_id | int32       | Required  | Workchain where the smart contract resides; typically 0 (basechain), may differ (e.g., -1 for masterchain).                           |
-| address      | (bits addr_len)   | Required  | The payload address (this could be the account ID).                                                                                   |
+| workchain_id | int32       | Required  | The WorkChain is where the smart contract for the destination address is located. Currently, this is always set to zero.                           |
+| address      | (bits256)   | Required  | The payload address (this could be the account ID).                                                                                   |
 
 
 ## Basic types
@@ -316,7 +316,7 @@ currencies$_ grams:Grams other:ExtraCurrencyCollection
 | Structure    | Type                    | Required | Description                                                                                                  |
 |--------------|-------------------------|----------|--------------------------------------------------------------------------------------------------------------|
 | currencies$_ | Constructor             | Required | The `$_` empty tag indicates that no bits are added at the beginning during the serialization of `CurrencyCollection`.|
-| grams        | (VarUInteger 16)        | Required | Represents the message value, expressed in nanograms.                                                                               |
+| grams        | (VarUInteger 16)        | Required | Represents the message value, expressed in nanotons.                                                                               |
 | other        | ExtraCurrencyCollection | Optional | ExtraCurrencyCollection is a dictionary intended for additional, typically empty currencies.         |
 
 - ExtraCurrencyCollection is a complex type usually written as an empty dictionary in messages.
@@ -334,7 +334,7 @@ var_int$_ {n:#} len:(#< n) value:(int (len * 8))
 
 | Structure  | Type             | Required | Description                                                                                                                 |
 |------------|------------------|----------|-----------------------------------------------------------------------------------------------------------------------------|
-| var_uint$_ | Constructor      | Required | The `var_uint$_` is an empty tag, indicating that no bits are added at the beginning of `VarUInteger` serialization. |
+| var_uint$_ | Constructor      | Required | The `var_uint$_` is an empty tag, indicating that no bits are added at the beginning of `CurrencyCollection` serialization. |
 | len        | uintN            | Required | Specifies the bit-length used to encode the next value.                                                                     |
 | value      | (uint (len * 8)) | Optional | An optional unsigned integer encoded in `(len * 8)` bits.                                                                   |
 
@@ -366,8 +366,6 @@ var_int$_ {n:#} len:(#< n) value:(int (len * 8))
 ### Regular func message in short form
 
 Validators always overwrite message parts, which can be skipped and filled with zero bits. The message's sender is also skipped and serialized as `addr_none$00`.
-
-This short-form example uses `CommonMsgInfoRelaxed`, where `src:MsgAddress` allows `addr_none$00`.
 
 ```func
   cell msg = begin_cell()


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-data-formats-tlb-msg-tlb.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/data-formats/tlb/msg-tlb.mdx`

Related issues (from issues.normalized.md):
- [ ] **1018. Add reference for CommonMsgInfoRelaxed**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/msg-tlb.mdx?plain=1#L17-L19

Link CommonMsgInfoRelaxed used in the TL‑B snippet to its definition or include a brief subsection summarizing it.

---

- [ ] **1019. Fix MessageRelaxed description (uses relaxed info)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/msg-tlb.mdx?plain=1#L25

Change the sentence to: “MessageRelaxed X uses CommonMsgInfoRelaxed for the info field.”

---

- [ ] **1020. Correct X:Type wording and code formatting**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/msg-tlb.mdx?plain=1#L28

Rephrase to: “`X:Type` means X can be any type (not specifically a cell).” and wrap X:Type in code formatting.

---

- [ ] **1021. Remove extra pipe in message$_ table**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/msg-tlb.mdx?plain=1#L59

In the message$_ table, delete the trailing “|” at the end of the body row so the table has exactly four columns.

---

- [ ] **1022. Mark message$_ constructor as Required**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/msg-tlb.mdx?plain=1

Set the “Required” column for the message$_ constructor row to “Required” for consistency with other constructor tables.

---

- [ ] **1023. Use Grams for ihr_fee and fwd_fee**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/msg-tlb.mdx?plain=1#L145-L146

Change the Type for ihr_fee and fwd_fee from “[VarUInteger 16]” to “Grams” to match the TL‑B scheme.

---

- [ ] **1024. Use “Logical time” (singular) for created_lt**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/msg-tlb.mdx?plain=1#L147,L190

Change the created_lt descriptions to “Logical time of the message …” in both int_msg_info$0 and ext_out_msg_info$11.

---

- [ ] **1025. Use Grams for import_fee**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/msg-tlb.mdx?plain=1#L170

Change the Type for import_fee from “[VarUInteger 16]” to “Grams” to match the TL‑B scheme.

---

- [ ] **1026. Clarify addr_none$00 tag semantics**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/msg-tlb.mdx?plain=1#L237

Rephrase to clarify that the “$00” tag indicates the null external address (MsgAddressExt; no external sender), not that the entire address equals “00”.

---

- [ ] **1027. Update workchain_id description (not always zero)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/msg-tlb.mdx?plain=1#L297

Replace “always set to zero” with a neutral phrasing such as: “Workchain where the smart contract resides; typically 0 (basechain), may differ (e.g., −1 for masterchain).”

---

- [ ] **1028. Fix addr_var.address type to (bits addr_len)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/msg-tlb.mdx?plain=1#L299

Change the Type of address from “(bits256)” to “(bits addr_len)” to match the TL‑B definition.

---

- [ ] **1029. Rename section to “Basic types”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/msg-tlb.mdx?plain=1#L301

Change the section title from “Basic used types” to “Basic types” for clearer, idiomatic English.

---

- [ ] **1030. Use “nanograms” for grams unit**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/msg-tlb.mdx?plain=1#L317

Replace “expressed in nanoTons” with “expressed in nanograms” to match the TL‑B definition and terminology used elsewhere.

---

- [ ] **1031. Fix VarUInteger table description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/msg-tlb.mdx?plain=1#L335

Change the var_uint$_ description to reference the correct type: “no bits are added at the beginning of VarUInteger serialization.”

---

- [ ] **1032. Clarify short-form example uses CommonMsgInfoRelaxed**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/msg-tlb.mdx?plain=1#L366

Explicitly state the short-form example uses CommonMsgInfoRelaxed (where src:MsgAddress allows addr_none$00), or adjust the example for internal messages that use MsgAddressInt and cannot serialize addr_none$00.

---

- [ ] **1033. Align addr_extern$01 length field (## 8 vs ## 9)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/msg-tlb.mdx?plain=1

Resolve the cross-doc inconsistency by confirming the intended width and aligning both locations; if stdlib is authoritative, update this page to len:(## 8) for addr_extern$01 and adjust any related tables.

---

- [ ] **1034. Add descriptive alt text to informative images**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/data-formats/tlb/msg-tlb.mdx?plain=1

Replace empty alt attributes in ThemedImage components with short descriptions (e.g., “Message X serialized inline in one cell” and “Message X serialized using references”) for accessibility.

---

- [ ] **2003. Fix broken bounce flag link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/message-modes-cookbook.mdx?plain=1#L163

Replace the non-existent anchor /v3/guidelines/smart-contracts/howto/wallet#internal-message-creation with the canonical reference to the bounce flag in the message header: docs/v3/documentation/data-formats/tlb/msg-tlb.mdx#commonmsginfo.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.