### PR TITLE
Split: update docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-status.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-status.mdx
+++ b/docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-status.mdx
@@ -4,23 +4,23 @@ import Feedback from '@site/src/components/Feedback';
 
 This document serves as a comprehensive guide to help you understand the output of **MyTonCtrl**'s `status` command.
 
-![status](/img/docs/mytonctrl/status.png)
+![MyTonCtrl status screen](/img/docs/mytonctrl/status.png)
 
 ## TON network status
 
 ### Network name
 
-Possible values are: `mainnet`, `testnet`, and `unknown`. However, the value `unknown` should never be displayed.
+Possible values are: `mainnet`, `testnet`, and `unknown`. However, the value `unknown` should not appear under normal conditions.
 
 ### Number of validators
 
 There are two key values: one represented in green and the other in yellow. The green value indicates the number of online validators, while the yellow value represents the total number of validators.
 
-Both values must be integers greater than 0. You can obtain the green value using the command `getconfig 34` with MyTonCtrl. For more information, please check the [relevant section here](/v3/documentation/network/configs/blockchain-configs#param-32-34-and-36) regarding parameters 32, 34, and 36.
+Both values are integers; the total validator count is ≥ 1. `getconfig 34` returns validator set counts (yellow/total). The green value is dynamic (not from blockchain configs); see the [params 32/34/36](/v3/documentation/network/configs/blockchain-configs#param-32-34-and-36) and the MyTonCtrl `vl` command for active validators.
 
-### Number of shardchains
+### Number of ShardChains
 
-This value must be an integer greater than 0 and is displayed in green.
+This value is an integer and is displayed in green.
 
 ### Number of offers
 
@@ -58,39 +58,39 @@ This section shows the current balance of the wallet.
 
 ### Load average
 
-The `load average` format is `[int]: int, int, int`. The first integer represents the number of CPUs, while the subsequent integers indicate the system load average for the last 1, 5, and 15 minutes.
+Format: `[CPUs]: <1m>, <5m>, <15m>`. The first value is the CPU count (integer); the subsequent values are the system load averages over 1, 5, and 15 minutes (may be fractional).
 
 ### Network load average
 
-This section also displays three integers, following the same logic as the `load average`: it presents the system load average for the last 1, 5, and 15 minutes.
+Shows network load averages for the last 1, 5, and 15 minutes; values may be fractional.
 
 ### Memory load
 
 **Absolute and Relative Memory Usage:** This refers to the usage of RAM and swap memory in two pairs of integers.
 
-### Disk load average
+### Disk usage
 
-This is similar to the `memory load`. However, it relates to the usage of all disk space instead.
+Shows total disk space usage (absolute and relative).
 
-### Mytoncore status
+### mytoncore status
 
-The status indicator should be green, showing how long Mytoncore has been operational.
+The indicator should be green and show how long mytoncore has been operational.
 
-### Local validator status
+### Local validator uptime
 
-This indicator should also be green, displaying the uptime of the local validator.
+This indicator should be green, displaying the uptime of the local validator.
 
 ### Local validator out of sync
 
-This integer value should be less than 20, indicating that it is functioning properly (it will appear green).
+Displays the number of blocks the local validator is out of sync.
 
 ### Local validator last state serialization
 
-This entry displays the number of MasterChain blocks that are currently out of service.
+Displays the number of MasterChain blocks since the last state serialization.
 
-### Local Validator database size
+### Local validator database size
 
-The absolute load size should be less than 1000 GB, and the relative load should be under 80%.
+Shows absolute database size and relative usage.
 
 ### Version of MyTonCtrl
 
@@ -104,31 +104,31 @@ This shows the hash of the commit and the name of the branch.
 
 ### Configurator address
 
-The address of the configurator. Refer to [this parameter-0](/v3/documentation/network/configs/blockchain-configs#param-0) for more information.
+The address of the configurator. Refer to [Param 0](/v3/documentation/network/configs/blockchain-configs#param-0) for more information.
 
 ### Elector address
 
-The address of the elector. Refer to [this parameter-1](/v3/documentation/network/configs/blockchain-configs#param-1) for additional details.
+The address of the elector. Refer to [Param 1](/v3/documentation/network/configs/blockchain-configs#param-1) for additional details.
 
 ### Validation period
 
-The duration of the validation period in seconds. Check [this parameter-15](/v3/documentation/network/configs/blockchain-configs#param-15).
+The duration of the validation period in seconds. Check [Param 15](/v3/documentation/network/configs/blockchain-configs#param-15).
 
 ### Duration of elections
 
-This refers to the duration of elections in seconds. To know more, refer to [this parameter-15](/v3/documentation/network/configs/blockchain-configs#param-15).
+This refers to the duration of elections in seconds. To know more, refer to [Param 15](/v3/documentation/network/configs/blockchain-configs#param-15).
 
 ### Hold period
 
-The hold period in seconds, with details available at [this parameter-15](/v3/documentation/network/configs/blockchain-configs#param-15).
+The hold period in seconds, with details available at [Param 15](/v3/documentation/network/configs/blockchain-configs#param-15).
 
 ### Minimum stake
 
-The minimum stake required in TONs. Check [this parameter-17](/v3/documentation/network/configs/blockchain-configs#param-17).
+The minimum stake required in Toncoins. Check [Param 17](/v3/documentation/network/configs/blockchain-configs#param-17).
 
 ### Maximum stake
 
-The maximum stake allowed in TONs. Check [this parameter-17](/v3/documentation/network/configs/blockchain-configs#param-17).
+The maximum stake allowed in Toncoins. Check [Param 17](/v3/documentation/network/configs/blockchain-configs#param-17).
 
 ## TON timestamps
 
@@ -136,13 +136,13 @@ The maximum stake allowed in TONs. Check [this parameter-17](/v3/documentation/n
 
 This indicates the launch time of the current network, whether it is the Mainnet or Testnet.
 
-### Start of the validation cycle
+### Start of the validation period
 
-The timestamp indicates the beginning of the validation cycle. If it represents a future event, it will be displayed in green.
+The timestamp indicates the beginning of the validation period. If it represents a future event, it will be displayed in green.
 
-### End of the validation cycle
+### End of the validation period
 
-This is the timestamp for the end of the validation cycle; it will also appear green if it indicates a future date.
+This is the timestamp for the end of the validation period; it will also appear green if it indicates a future date.
 
 ### Start of elections
 
@@ -150,11 +150,10 @@ The timestamp for when elections begin. This will be green if it represents a fu
 
 ### End of elections
 
-The timestamp indicating the end of elections is displayed in green if it predicts a future date.
+The timestamp indicating the end of elections is displayed in green if it indicates a future date.
 
-### Beginning of the next elections
+### Start of the next elections
 
 The timestamp for the start of the next elections will appear green if it signifies a future event.
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-infra-nodes-mytonctrl-mytonctrl-status.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-status.mdx`

Related issues (from issues.normalized.md):
- [ ] **1225. Fix incorrect source for online validators count**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-status.mdx?plain=1#L16-L20

Replace the claim that the green value (online validators) comes from getconfig 34 with: getconfig 34 returns validator set counts (yellow/total); the green value is dynamic (not from blockchain configs); keep links to params 32/34/36 and refer to the mytonctrl "vl" command for active validators.

---

- [ ] **1226. Capitalize ShardChains; remove unsupported 'must be > 0'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-status.mdx?plain=1#L21-L23

Change “Number of shardchains” to “Number of ShardChains” and replace “must be greater than 0” with a neutral statement that it is an integer (no unsourced requirement).

---

- [ ] **1227. Correct load average format; allow fractions**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-status.mdx?plain=1#L59-L63

State the format as “[CPUs]: <1m>, <5m>, <15m>”, where the first value is the CPU count (an integer) and the subsequent values are the system load averages over 1, 5, and 15 minutes (fractional).

---

- [ ] **1228. Clarify network load average; remove 'system'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-status.mdx?plain=1#L63-L65

Replace “presents the system load average” with “shows network load averages for the last 1, 5, and 15 minutes,” noting the values may be fractional.

---

- [ ] **1229. Rename 'Disk load average' to 'Disk usage'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-status.mdx?plain=1#L71-L73

Change the heading to “Disk usage” and clarify that it shows total disk space usage (absolute and relative).

---

- [ ] **1230. Standardize mytoncore casing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-status.mdx?plain=1#L75-L77

Use lowercase “mytoncore” for the service/command and phrase the line as “mytoncore status,” stating that the indicator should be green and show how long mytoncore has been operational.

---

- [ ] **1231. Clarify 'out of service' phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-status.mdx?plain=1#L87-L89

Replace the unclear “out of service” text with “Displays the number of MasterChain blocks since the last state serialization.”

---

- [ ] **1232. Fix 'Local validator database size' heading and wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-status.mdx?plain=1#L91-L93

Change the heading to “Local validator database size” and reword to describe absolute database size and relative usage, removing unsupported thresholds and “load” terminology.

---

- [ ] **1233. Fix parameter link text ("Param 0/1/15/17")**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-status.mdx?plain=1#L105-L131

Replace “this parameter-0/1/15/17” with “Param 0,” “Param 1,” “Param 15,” and “Param 17,” keeping the same anchors.

---

- [ ] **1234. Use 'Toncoins' for currency**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-status.mdx?plain=1#L125-L131

Replace “in TONs” with “in Toncoins” for the minimum/maximum stake descriptions.

---

- [ ] **1235. Use 'validation period' terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-status.mdx?plain=1#L139-L145

Replace “validation cycle” with “validation period” in headings and descriptions for consistency with config terminology.

---

- [ ] **1236. Improve 'End of elections' phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-status.mdx?plain=1#L151-L153

Change to “is displayed in green if it indicates a future date.”

---

- [ ] **1237. Align 'Start of the next elections' phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-status.mdx?plain=1#L155-L157

Replace “Beginning of the next elections” with “Start of the next elections.”

---

- [ ] **1238. Relax validator count requirement**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-status.mdx?plain=1

Soften the statement that both validator counts must be greater than 0 to: “Both values are integers; the total validator count is ≥ 1,” without asserting an online count minimum.

---

- [ ] **1239. Avoid duplicate 'Local validator status' heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-status.mdx?plain=1

Rename the later subheading “Local validator status” to “Local validator uptime” to avoid duplication and better match the content.

---

- [ ] **1240. Remove unsupported out-of-sync threshold**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-status.mdx?plain=1

Remove the normative “Local validator out of sync < 20 (green)” threshold unless a canonical source is cited.

---

- [ ] **1241. Improve status image alt text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-status.mdx?plain=1

Replace the generic alt text “status” with “MyTonCtrl status screen” for accessibility.

---

- [ ] **1242. Soften 'unknown should never be displayed'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-status.mdx?plain=1

Change “unknown should never be displayed” to “unknown should not appear under normal conditions,” unless a canonical source is cited.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.