### PR TITLE
Split: update docs/v3/documentation/network/protocols/adnl/overview.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/network/protocols/adnl/overview.mdx
+++ b/docs/v3/documentation/network/protocols/adnl/overview.mdx
@@ -6,37 +6,31 @@ Please see the [**implementation**](https://github.com/ton-blockchain/ton/tree/m
 
 ## Overview
 
-The Abstract Datagram Network Layer (ADNL) is a fundamental component of the TON.
+The Abstract Datagram Network Layer (ADNL) is a fundamental component of TON.
 
-ADNL is an overlay, peer-to-peer, unreliable (small-size) datagram protocol that operates over **UDP** in **IPv4**, with plans to support **IPv6** in the future. Additionally, it has an optional **TCP fallback** for instances when UDP is unavailable.
+ADNL is a peer-to-peer, unreliable datagram protocol in the TON networking stack. ADNL operates over UDP and TCP.
 
 ## ADNL address
 
-Each participant in the network possesses a 256-bit ADNL Address.
+Each participant in the network possesses a 256-bit ADNL address.
 
-The ADNL Protocol enables the sending and receiving of datagrams using only ADNL Addresses, concealing the underlying IP Addresses and Ports.
+The ADNL protocol enables the sending and receiving of datagrams using only ADNL addresses, concealing the underlying IP addresses and ports.
 
-An ADNL Address effectively functions as a 256-bit ECC public key, which can be generated arbitrarily, allowing for the creation of multiple network identities as needed by the node.
-
-However, the corresponding private key must be known to receive and decrypt messages intended for a specific address.
-
-In practice, the ADNL Address is not the public key itself; rather, it is a 256-bit SHA256 hash of a serialized TL object. Depending on its constructor, this TL object can represent various types of public keys and addresses.
+An ADNL address is a 256‑bit identifier derived as SHA‑256(type_id || public_key), where `type_id` is a little‑endian uint32 indicating the key type — that is, the SHA‑256 of the TL‑serialized key object. The corresponding private key must be known to receive and decrypt messages intended for a specific address.
 
 ## Encryption and security
 
-Typically, each datagram sent is signed by the sender and encrypted so that only the intended recipient can decrypt the message and verify its integrity using the signature.
+ADNL packets can be signed and encrypted; when signatures are present, recipients verify integrity and authenticity.
 
 ## Neighbor tables
 
-A TON ADNL node will typically maintain a **neighbor table** that contains information about other known nodes, including their abstract addresses, public keys, IP addresses, and UDP ports. Over time, this table expands with information gathered from these known nodes, which may come from responses to specific queries or by removing outdated records.
+A TON ADNL node will typically maintain a **neighbor table** that contains information about other known nodes, including their abstract addresses, public keys, IP addresses, and UDP ports. Over time, this table is updated: new entries are discovered from responses to specific queries, and outdated records are removed.
 
-ADNL facilitates the establishment of point-to-point channels and tunnels (chains of proxies).
-
-A TCP-like stream protocol can be constructed on top of ADNL.
+Higher-level protocols such as [RLDP](/v3/documentation/network/protocols/rldp) operate over ADNL.
 
 ## What's next?
 
 - To learn more about ADNL, refer to the [Low-level ADNL documentation](/v3/documentation/network/protocols/adnl/low-level-adnl).
-- See Chapter 3.1 of the [TON Whitepaper](https://docs.ton.org/ton.pdf).
+- See the [TON Whitepaper](https://ton.org/whitepaper.pdf).
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-network-protocols-adnl-overview.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/network/protocols/adnl/overview.mdx`

Related issues (from issues.normalized.md):
- [ ] **1418. Simplify transport description and remove emphasis**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/adnl/overview.mdx?plain=1

Replace the transport sentence with “ADNL operates over UDP and TCP.” and remove speculative IPv6/fallback wording and unnecessary bold emphasis.

---

- [ ] **1419. Normalize capitalization for 'address', 'protocol', and IP terms**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/adnl/overview.mdx?plain=1

Use “ADNL address” and “ADNL protocol” (sentence case) and “IP addresses and ports” consistently; align the heading and body to “ADNL address.”

---

- [ ] **1420. Correct ADNL address definition (derived hash, not public key)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/adnl/overview.mdx?plain=1

Remove the claim that an ADNL address “functions as a public key” and state: “An ADNL address is a 256‑bit identifier derived as SHA‑256(type_id || public_key), where type_id is a little‑endian uint32 indicating the key type,” i.e., the SHA‑256 of the TL‑serialized key object.

---

- [ ] **1421. Standardize hash algorithm naming to 'SHA‑256'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/adnl/overview.mdx?plain=1

Replace all instances of “SHA256” with “SHA‑256” for consistency with the rest of the docs.

---

- [ ] **1422. Fix neighbor table update sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/adnl/overview.mdx?plain=1

Rephrase to: “Over time, this table is updated: new entries are discovered from responses to specific queries, and outdated records are removed.”

---

- [ ] **1423. Avoid 'overlay' wording for ADNL**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/adnl/overview.mdx?plain=1

Rephrase the introduction to avoid calling ADNL an “overlay” protocol; use “ADNL is a peer‑to‑peer, unreliable datagram protocol in the TON networking stack.”

---

- [ ] **1424. Qualify packet signing as optional**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/adnl/overview.mdx?plain=1

Change “each datagram is signed and encrypted” to “ADNL packets can be signed and encrypted; when signatures are present, recipients verify integrity and authenticity.”

---

- [ ] **1425. Replace vague 'tunnels'/'TCP‑like stream' with RLDP reference**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/adnl/overview.mdx?plain=1

Remove or rephrase mentions of “tunnels (chains of proxies)” and a “TCP‑like stream protocol”; instead, state that higher‑level protocols such as RLDP operate over ADNL and link to docs/v3/documentation/network/protocols/rldp.mdx.

---

- [ ] **1426. Use canonical whitepaper URL**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/adnl/overview.mdx?plain=1

Replace the “https://docs.ton.org/ton.pdf” link and “Chapter 3.1” wording with a single link to the canonical whitepaper: https://ton.org/whitepaper.pdf.

---

- [ ] **4385. Fix typo: ANDL → ADNL**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx?plain=1

Replace every occurrence of “ANDL” with the correct term “ADNL” in step titles and descriptions (e.g., “Generate a persistent ADNL address”) to match canonical usage (see docs/v3/documentation/network/protocols/adnl/overview.mdx).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.