### PR TITLE
Split: update docs/v3/documentation/network/protocols/dht/ton-dht.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/network/protocols/dht/ton-dht.mdx
+++ b/docs/v3/documentation/network/protocols/dht/ton-dht.mdx
@@ -11,9 +11,9 @@ Please see the implementations:
 
 The Kademlia-like Distributed Hash Table (DHT) plays a crucial role in the networking aspect of the TON project, enabling the discovery of other nodes within the network.
 
-The keys used in the TON DHT are 256-bit integers, often derived from a SHA256 of a TL-serialized object.
+The keys used in the TON DHT are 256-bit integers, often derived from the SHA‑256 hash of a TL‑serialized object.
 
-The values associated with these 256-bit keys are essentially arbitrary byte strings of limited length. The meaning of these byte strings is determined by the pre-image of the corresponding key; this is typically known by both the node performing the key lookup and the node storing the key.
+The values associated with these 256-bit keys are essentially arbitrary byte strings of limited length. The meaning of these byte strings is determined by the preimage of the corresponding key; this is typically known by both the node performing the key lookup and the node storing the key.
 
 In its simplest form, the key represents an ADNL address of a node, while the value could be its IP address and port.
 
@@ -21,34 +21,32 @@ The key-value mappings of the TON DHT are maintained on the DHT nodes.
 
 ## DHT nodes
 
-Each DHT node has a 256-bit DHT address. Unlike an ADNL address, a DHT address should not change too frequently; otherwise, other nodes will be unable to locate the keys they are searching for.
+Each DHT node has a 256-bit DHT address. Unlike an ADNL address, a DHT address is typically kept stable so that other nodes can locate stored keys.
 
-The value of key `K` is expected to be stored on the `S` Kademlia-nearest nodes to `K`.
+The value for key `K` is expected to be stored on the `S` nodes nearest to `K` by Kademlia distance.
 
-Kademlia distance is calculated by performing a 256-bit `XOR` operation between the key `X` and the 256-bit DHT node address. This distance does not relate to geographic location.
+Kademlia distance is calculated by performing a 256-bit `XOR` operation between the key `K` and the node’s identifier (key ID). This distance is unrelated to geographic location.
 
-`S` is a small parameter, for instance, `S = 7`, which helps improve the reliability of the DHT. If the key were stored only on a single node (the nearest one to `K`) the value of that key would be lost if that node were to go offline.
+`S` is a small parameter that helps improve the reliability of the DHT. If the key were stored only on a single node (the nearest one to `K`), the value of that key would be lost if that node were to go offline.
 
 ## Kademlia routing table
 
-A node participating in a DHT typically maintains a Kademlia routing table.
+A node participating in a DHT typically maintains a Kademlia routing table that groups known nodes into buckets by exponentially increasing Kademlia distance from the node’s own identifier. Each bucket holds a limited number of the “best” nodes, along with some additional candidate nodes.
 
-This table consists of 256 buckets, numbered from 0 to 255. The `i`-th bucket contains information about known nodes that lie within a Kademlia distance from `2^i` to `2^(i+1) − 1` from the node’s address `a`. Each bucket holds a fixed number of the “best” nodes, along with some additional candidate nodes.
-
-The information stored in these buckets includes the DHT addresses, IP addresses, UDP ports, and availability details, such as the time and delay of the last ping.
+The information stored in these buckets includes the DHT addresses, IP addresses, UDP ports, and availability details, such as the timestamp and latency of the last ping.
 
 When a Kademlia node discovers another Kademlia node through a query, it places that node into the appropriate bucket as a candidate. If some of the “best” nodes in that bucket become unresponsive (for example, if they do not reply to ping queries for an extended period), they can be replaced by some of these candidates. This process ensures that the Kademlia routing table remains populated.
 
 ## Key-value pairs
 
-Key-value pairs can be added and updated in the TON DHT. The rules for these updates can vary. In some cases, they allow for the old value to be replaced with a new one as long as the new value is signed by the owner or creator. This signature must be retained as part of the value so that it can be verified later by any other nodes that receive this key's value.
+Key-value pairs can be added and updated in the TON DHT. The rules for these updates can vary. In some cases, they allow the old value to be replaced with a new one if the update satisfies the key’s update rule (for example, a valid signature for `dht.updateRule.signature` by the owner of the associated private key). The signature must be retained alongside the value so it can be verified by other nodes.
 
-In other cases, the old value impacts the new value in some way. For example, the old value may contain a sequence number, and it can only be overwritten if the new sequence number is larger. This helps prevent replay attacks.
+In other cases, the old value impacts the new value in some way. For example, the value may include metadata such as a version that influences update acceptance. This helps prevent replay attacks.
 
-The TON DHT is not only used to store the IP addresses of ADNL nodes; it also serves other purposes. It can store a list of addresses of nodes that are holding a specific torrent in TON Storage, a list of addresses of nodes included in an overlay subnetwork, ADNL addresses of TON services, and ADNL addresses of accounts on the TON Blockchain, among others.
+The TON DHT is not only used to store the IP addresses of ADNL nodes; it also serves other purposes. It can store a list of addresses of nodes that are holding a specific torrent in TON Storage, a list of addresses of nodes included in an overlay subnetwork, ADNL addresses of TON services, and ADNL addresses published by services on the TON Blockchain, among others.
 
 :::info
-Learn more about TON DHT in [DHT](/v3/documentation/network/protocols/dht/dht-deep-dive) documentation, or in Chapter 3.2. of the [TON Whitepaper](https://docs.ton.org/ton.pdf).
+Learn more about TON DHT in the [DHT](/v3/documentation/network/protocols/dht/dht-deep-dive) documentation or in Chapter 3.2 of the [TON Whitepaper](https://docs.ton.org/ton.pdf).
 :::
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-network-protocols-dht-ton-dht.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/network/protocols/dht/ton-dht.mdx`

Related issues (from issues.normalized.md):
- [ ] **1444. Use "SHA‑256 hash" wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/dht/ton-dht.mdx?plain=1#L14

Replace “derived from a SHA256 of a TL-serialized object” with “often derived from the SHA‑256 hash of a TL‑serialized object” to clarify phrasing and standardize the algorithm name.

---

- [ ] **1445. Use “preimage” (no hyphen)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/dht/ton-dht.mdx?plain=1#L16

Replace “pre-image” with “preimage of the corresponding key”.

---

- [ ] **1446. Fix storage rule grammar and phrasing; remove “S = 7”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/dht/ton-dht.mdx?plain=1#L26

Rewrite as “The value for key K is expected to be stored on the S nodes nearest to K by Kademlia distance,” and drop the unsourced example “S = 7”.

---

- [ ] **1447. Use K consistently and clarify geography note**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/dht/ton-dht.mdx?plain=1#L28

Change “key X” to “key K” and rephrase “This distance does not relate to geographic location” to “This distance is unrelated to geographic location.”

---

- [ ] **1448. Replace “DHT node address” with “node identifier (key ID)”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/dht/ton-dht.mdx?plain=1#L28

Replace “256-bit DHT node address” with “node’s identifier (key ID)” and compute distance “between the key K and the node’s key ID.”

---

- [ ] **1449. Use ASCII hyphen-minus in range**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/dht/ton-dht.mdx?plain=1#L36

Replace the Unicode minus in “2^(i+1) − 1” with ASCII: “2^(i+1)-1”, and remove extra spaces.

---

- [ ] **1450. Use precise ping terms**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/dht/ton-dht.mdx?plain=1#L38

Replace “time and delay of the last ping” with “timestamp and latency of the last ping” (or “time and round-trip latency of the last ping”).

---

- [ ] **1451. Standardize curly apostrophe in “key’s value”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/dht/ton-dht.mdx?plain=1#L44

Use a curly apostrophe for consistency: change “key's value” to “key’s value”.

---

- [ ] **1452. Avoid implying accounts have ADNL addresses**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/dht/ton-dht.mdx?plain=1#L48

Replace “ADNL addresses of accounts on the TON Blockchain” with “ADNL addresses published by services on the TON Blockchain.”

---

- [ ] **1453. Fix info box grammar and punctuation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/dht/ton-dht.mdx?plain=1#L51

Change to: “Learn more about TON DHT in the [DHT](/v3/documentation/network/protocols/dht/dht-deep-dive) documentation or in Chapter 3.2 of the [TON Whitepaper](https://docs.ton.org/ton.pdf).” (add “the”, remove the comma before “or”, and remove the trailing period after “3.2”.)

---

- [ ] **1454. Generalize bucket description; remove undefined “a”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/dht/ton-dht.mdx?plain=1

Rephrase the bucket definition to avoid exact counts/ranges and the undefined symbol “a”, e.g., “group known nodes into buckets by exponentially increasing Kademlia distance from the node’s own identifier.”

---

- [ ] **1455. Soften “fixed number” capacity claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/dht/ton-dht.mdx?plain=1

Change “a fixed number of the ‘best’ nodes” to “a limited number of the ‘best’ nodes.”

---

- [ ] **1456. Clarify signature placement relative to value**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/dht/ton-dht.mdx?plain=1

Change “This signature must be retained as part of the value” to “The signature must be retained alongside the value so it can be verified by other nodes.”

---

- [ ] **1457. Soften DHT node identity stability claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/dht/ton-dht.mdx?plain=1

Replace “should not change too frequently” with “is typically kept stable so that other nodes can locate stored keys.”

---

- [ ] **1458. Refer to explicit update rules**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/dht/ton-dht.mdx?plain=1

Replace “signed by the owner or creator” with “the update satisfies the key’s update rule (for example, a valid signature for dht.updateRule.signature)” and prefer “owner of the associated private key.”

---

- [ ] **1459. Avoid unsupported “sequence number” overwrite rule**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/dht/ton-dht.mdx?plain=1

Generalize to “may include metadata such as a version that influences update acceptance,” unless a citation is provided for strict monotonic sequence numbers.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.