### PR TITLE
Split: update docs/v3/documentation/network/protocols/overlay.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/network/protocols/overlay.mdx
+++ b/docs/v3/documentation/network/protocols/overlay.mdx
@@ -10,7 +10,7 @@ Please see the implementation:
 
 The architecture of the TON is designed to support multiple chains that can operate simultaneously and independently, whether they are private or public. Nodes have the flexibility to choose which shards and chains they store and process.
 
-Despite this variability, the communication protocol remains consistent due to its universal nature. Protocols such as DHT (Distributed Hash Table), RLDP (Reliable Layered Datagram Protocol), and overlays facilitate this functionality.
+Despite this variability, the communication protocol remains consistent due to its universal nature. Protocols such as DHT (Distributed Hash Table), RLDP (Reliable Large Datagram Protocol), and overlays facilitate this functionality.
 
 We are already familiar with the first two protocols; in this section, we will focus on overlays.
 
@@ -22,9 +22,7 @@ For public overlays, you can discover nodes using the DHT protocol.
 
 In contrast to ADNL, TON overlay networks typically do not allow the sending of datagrams to arbitrary nodes. Instead, they establish "semi-permanent links" between specific nodes, known as "neighbors," within the overlay network. Messages are usually forwarded along these links, meaning communication happens from one node to one of its neighbors.
 
-Each overlay subnetwork is assigned a 256-bit network identifier, which is usually equivalent to a SHA256 that describes the overlay network as a TL-serialized object.
-
-Overlay subnetworks can either be public or private.
+Each overlay subnetwork is assigned a 256-bit network identifier: overlay is the 256‑bit SHA256 hash of the TL‑serialized tonNode.shardPublicOverlayId (result type tonNode.ShardPublicOverlayId), i.e., the DHT key ID.
 
 These subnetworks operate using a special [gossip](https://en.wikipedia.org/wiki/Gossip_protocol) protocol.
 
@@ -34,7 +32,7 @@ We have already analyzed an example of finding overlay nodes in an article about
 
 In this section, we will focus on how to interact with these nodes.
 
-When querying the DHT, we will retrieve the addresses of the overlay nodes. From these addresses, we can discover the addresses of additional nodes within the overlay by using the [overlay.getRandomPeers](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/tl/generate/scheme/ton_api.tl#L237) query.
+When querying the DHT, we will retrieve the addresses of the overlay nodes. From these nodes, we can discover additional peers (nodes) in the overlay by using the [overlay.getRandomPeers](https://github.com/ton-blockchain/ton/blob/ee42357f5954f777d7ebd937b2683096da3699bf/tl/generate/scheme/ton_api.tl#L244) query.
 
 After connecting to a sufficient number of nodes, we will be able to receive information about all blocks and other chain events from them. Additionally, we can send our transactions to these nodes for processing.
 
@@ -51,11 +49,11 @@ overlay.nodes nodes:(vector overlay.node) = overlay.Nodes;
 overlay.getRandomPeers peers:overlay.nodes = overlay.Nodes;
 ```
 
-The `peers` array should include the peers we are aware of so that we do not receive messages from them again. Since we currently do not know any peers, `peers.nodes` will initially be an empty array.
+The `peers` array typically includes the peers we are already aware of so that we do not receive messages from them again. Since we currently do not know any peers, `peers.nodes` will initially be an empty array.
 
-If we want to retrieve information, participate in the overlay, and receive broadcasts, we need to include information about our own node in the `peers` array during the request. Once the peers are aware of our presence, they will begin to send us broadcasts using ADNL or RLDP.
+If we want to retrieve information, participate in the overlay, and receive broadcasts, we may include information about our own node in the `peers` array during the request. Once the peers are aware of our presence, they will begin to send broadcasts over ADNL (using RLDP for large payloads).
 
-Additionally, each request made within the overlay must be prefixed with the TL schema:
+Additionally, requests within the overlay are prefixed by the TL schema:
 
 ```tlb
 overlay.query overlay:int256 = True;
@@ -65,13 +63,13 @@ The `overlay` should be the overlay's ID, specifically the ID of the `tonNode.Sh
 
 To combine two serialized schemas, we should concatenate two serialized byte arrays: `overlay.query` will come first, followed by `overlay.getRandomPeers`.
 
-We then wrap the resulting array in the `adnl.message.query` schema and send it via ADNL. In response, we expect `overlay.nodes`, which will be a list of overlay nodes that we can connect to. If necessary, we can repeat the request to any new nodes until we acquire enough connections.
+We then wrap the resulting array in the `adnl.message.query` schema and send it via ADNL. In response, we expect `overlay.Nodes`, which will be a list of overlay nodes that we can connect to. If necessary, we can repeat the request to any new nodes until we acquire enough connections.
 
 ### Functional requests
 
-Once the connection is established, we can access the overlay nodes using `tonNode.*` via the [requests](https://github.com/ton-blockchain/ton/blob/ad736c6bc3c06ad54dc6e40d62acbaf5dae41584/tl/generate/scheme/ton_api.tl#L413).
+Once the connection is established, we can access the overlay nodes using `tonNode.*` via the [requests](https://github.com/ton-blockchain/ton/blob/ee42357f5954f777d7ebd937b2683096da3699bf/tl/generate/scheme/ton_api.tl#L420).
 
-We utilize the RLDP protocol for these types of requests. It's crucial to remember that every query in the overlay must begin with the `overlay.query` prefix.
+We utilize RLDP for these types of requests. Queries in the overlay are prefixed by the `overlay.query` prefix.
 
 The requests themselves are quite standard and resemble those we discussed in the article about ADNL TCP found [here](/v3/documentation/network/protocols/adnl/adnl-tcp#getmasterchaininfo).
 
@@ -81,11 +79,10 @@ For example, the `downloadBlockFull` request follows the familiar block ID schem
 tonNode.downloadBlockFull block:tonNode.blockIdExt = tonNode.DataFull;
 ```
 
-By passing this step, we can download complete information about the block, and in response, we will receive:
+After this step, you can download the full block data, and in response, you will receive:
 
 ```tlb
 tonNode.dataFull id:tonNode.blockIdExt proof:bytes block:bytes is_link:Bool = tonNode.DataFull;
-  or
 tonNode.dataFullEmpty = tonNode.DataFull;
 ```
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-network-protocols-overlay.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/network/protocols/overlay.mdx`

Related issues (from issues.normalized.md):
- [ ] **1461. Clarify overlay ID definition and schema names**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/overlay.mdx?plain=1

Replace the overlay ID text with: “overlay is the 256‑bit SHA256 hash of the TL‑serialized tonNode.shardPublicOverlayId (result type tonNode.ShardPublicOverlayId), i.e., the DHT key ID,” fixing the constructor casing and “a SHA256” phrasing.

---

- [ ] **1462. Use correct response type name (overlay.Nodes)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/overlay.mdx?plain=1

Replace the inline “overlay.nodes” with the schema-correct “overlay.Nodes”.

---

- [ ] **1463. Replace ambiguous “By passing this step”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/overlay.mdx?plain=1

Change “By passing this step, we can download complete information about the block...” to “After this step, you can download the full block data...” for clarity.

---

- [ ] **1464. Remove “addresses ... addresses” repetition**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/overlay.mdx?plain=1

Rephrase to “From these nodes, we can discover additional peers (nodes) in the overlay...” to avoid redundant wording.

---

- [ ] **1466. Correct RLDP expansion**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/overlay.mdx?plain=1

Change “Reliable Layered Datagram Protocol” to “Reliable Large Datagram Protocol (RLDP)”.

---

- [ ] **1467. Remove invalid “or” in TL code block**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/overlay.mdx?plain=1

Delete the standalone “or” line and keep both alternatives as separate TL declarations in the same code block.

---

- [ ] **1468. Soften or cite overlay.query prefix requirement**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/overlay.mdx?plain=1

Add a citation to where overlay.query is defined, or soften “must be prefixed” to descriptive language (e.g., “requests are prefixed by...”).

---

- [ ] **1469. Clarify ADNL/RLDP layering**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/overlay.mdx?plain=1

Rephrase to “send broadcasts over ADNL (using RLDP for large payloads)” to reflect RLDP running atop ADNL.

---

- [ ] **1470. Remove duplicate note on public/private overlays**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/overlay.mdx?plain=1

Delete the repeated sentence under “ADNL vs overlay networks” that restates overlays can be public or private.

---

- [ ] **1471. Cite or qualify peers parameter behavior**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/overlay.mdx?plain=1

Provide an internal reference supporting the peers de-duplication and self-announcement behavior, or qualify the statements to be non-normative (e.g., “typically/ may”).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.