### PR TITLE
Split: update docs/v3/documentation/network/protocols/rldp.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/network/protocols/rldp.mdx
+++ b/docs/v3/documentation/network/protocols/rldp.mdx
@@ -10,7 +10,7 @@ Please see the implementations:
 
 ## Overview
 
-The Reliable Large Datagram Protocol (RLDP) operates on top of the ADNL UDP protocol and is designed for transferring large data blocks. It incorporates Forward Error Correction (FEC) algorithms, which allow it to replace acknowledgment packets typically sent from the receiver back to the sender.
+The Reliable Large Datagram Protocol (RLDP) operates on top of ADNL over UDP and is designed for transferring large data blocks. It incorporates Forward Error Correction (FEC) algorithms, which allow it to replace acknowledgment packets typically sent from the receiver back to the sender.
 
 This capability enables more efficient data transfer between network components, although it results in increased traffic consumption.
 
@@ -34,13 +34,13 @@ rldp.query query_id:int256 max_answer_size:long timeout:int data:bytes = rldp.Me
 rldp.answer query_id:int256 data:bytes = rldp.Message;
 ```
 
-The serialized structure is encapsulated in the `adnl.message.custom` TL schema and transmitted over ADNL UDP.
+The serialized structure is encapsulated in the [`adnl.message.custom`](/v3/documentation/network/protocols/adnl/adnl-udp#adnlmessagecustom) TL schema and transmitted over ADNL UDP.
 
 RLDP transfers are utilized for sending large amounts of data. A random `transfer_id` is generated, and the data is then processed using the FEC algorithm.
 
 The resulting segments are wrapped in a `rldp.messagePart` structure and sent to the peer until the peer responds with `rldp.complete` or a timeout occurs.
 
-Once the receiver has gathered the necessary `rldp.messagePart` pieces to reconstruct the complete message, it concatenates them, decodes them using FEC, and then deserializes the resulting byte array into either an `rldp.query` or `rldp.answer` structure, depending on the type indicated by the `tl prefix id`.
+Once the receiver has gathered the necessary `rldp.messagePart` pieces to reconstruct the complete message, it concatenates them, decodes them using FEC, and then deserializes the resulting byte array into either an `rldp.query` or `rldp.answer` structure, depending on the type indicated by the TL schema ID (constructor ID prefix).
 
 ### FEC
 
@@ -58,15 +58,17 @@ All the generated symbols are combined and sent to the recipient, allowing for t
 
 The symbols are transmitted to the peer until they confirm that all data has been received and successfully restored (decoded) by applying the same discrete operations.
 
-[\[Please see implementation example of RaptorQ in Golang\]](https://github.com/xssnick/tonutils-go/tree/46dbf5f820af066ab10c5639a508b4295e5aa0fb/adnl/rldp/raptorq).
+[\[Please see implementation example of RaptorQ in Go\]](https://github.com/xssnick/tonutils-go/tree/46dbf5f820af066ab10c5639a508b4295e5aa0fb/adnl/rldp/raptorq).
 
 ## RLDP-HTTP
 
-To interact with TON Sites, the RLDP (Reverse Lightweight Data Protocol) is used to wrap HTTP requests. The host sets up their site on any standard HTTP web server and runs `rldp-http-proxy` alongside it.
+To interact with TON Sites, RLDP (Reliable Large Datagram Protocol) is used to wrap HTTP requests. The host sets up their site on any standard HTTP web server and runs `rldp-http-proxy` alongside it.
 
-All incoming requests from the TON network are directed to the proxy via the RLDP protocol. The proxy then converts these requests into standard HTTP format and calls the original web server locally.
+All incoming requests from the TON network are directed to the proxy via RLDP. The proxy then converts these requests into standard HTTP format and calls the original web server locally.
 
 On the user's side, they launch a proxy, such as [Tonutils Proxy](https://github.com/xssnick/TonUtils-Proxy), to access the .ton sites. All traffic is wrapped in the reverse order: requests are sent to the local HTTP proxy, which then forwards them via RLDP to the remote TON site.
+
+See also: [Run your own TON Proxy to connect to TON Sites](/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy).
 
 HTTP communication within RLDP is structured using TL formats:
 
@@ -81,21 +83,21 @@ http.getNextPayloadPart id:int256 seqno:int max_chunk_size:int = http.PayloadPar
 
 This is not pure HTTP in text form; everything is wrapped in a binary TL and unwrapped before being sent to the web server or browser by the proxy itself.
 
-The scheme of work is as follows:
+The workflow is as follows:
 
 - Client sends `http.request`
 - The server checks the `Content-Length` header when receiving a request
   - If not 0, sends a `http.getNextPayloadPart` request to the client
   - When receiving a request, the client sends `http.payloadPart` - the requested body piece depending on `seqno` and `max_chunk_size`.
   - The server repeats requests, incrementing `seqno`, until it receives all the chunks from the client, i.e. until the `last:Bool` field of the last chunk received is true.
-- After processing the request, the server sends `http.response`, the client checks the `Content-Length` header
-  - If it is not 0, then sends a `http.getNextPayloadPart` request to the server, and the operations are repeated, as in the case of the client but vice-versa.
+- After processing the request, the server sends `http.response`. The client checks the `no_payload:Bool` flag in the response.
+  - If `no_payload` is false, it sends a `http.getNextPayloadPart` request to the server, and the operations are repeated (mirroring the request flow) until the `last:Bool` field is true.
 
 ## Request the TON site
 
 To understand how RLDP works, let's look at an example of getting data from the TON site `foundation.ton`.
 
-Assuming say we have already got its ADNL address by calling the Get method of the NFT-DNS contract, [determined the address and port of the RLDP service using DHT](https://github.com/xssnick/ton-deep-doc/blob/master/DHT.md), and [connected to it over ADNL UDP](https://github.com/xssnick/ton-deep-doc/blob/master/ADNL-UDP-Internal.md).
+Assume we have already obtained its ADNL address by calling the get method of the DNS contract, [determined the address and port of the RLDP service using DHT](/v3/documentation/network/protocols/dht/dht-deep-dive), and [connected to it over ADNL UDP](/v3/documentation/network/protocols/adnl/adnl-udp).
 
 ### Send a GET request to `foundation.ton`
 
@@ -170,7 +172,7 @@ rldp.messagePart transfer_id:int256 fec_type:fec.Type part:int total_size:long s
 - `seqno` - for the first packet will be equal to 0, and for each subsequent packet it will increase by 1, will be used as parameter to decode and encode symbol.
 - `data` - our encoded symbol, 768 bytes in size.
 
-After serializing `rldp.messagePart`, wrap it in `adnl.message.custom` and send it over ADNL UDP.
+After serializing `rldp.messagePart`, wrap it in [`adnl.message.custom`](/v3/documentation/network/protocols/adnl/adnl-udp#adnlmessagecustom) and send it over ADNL UDP.
 
 We will send packets in a continuous loop, incrementing the `seqno` each time, until we either receive the `rldp.complete` message from the peer or reach a timeout. Once we have sent a number of packets equal to the number of our symbols, we can slow down the transmission and send additional packets, for example, once every 10 milliseconds or even less frequently.
 
@@ -182,9 +184,7 @@ These extra packets are intended for recovery in case of data loss, as UDP is a 
 
 During the sending process, we can expect a response from the server. In our case, we are waiting for `rldp.answer` containing `http.response`.
 
-The response will arrive in the same format as it was sent during the request, but the `transfer_id` will be inverted (each byte will undergo an `XOR` operation with `0xFF`).
-
-We will receive `adnl.message.custom` messages that include `rldp.messagePart`.
+We will receive [`adnl.message.custom`](/v3/documentation/network/protocols/adnl/adnl-udp#adnlmessagecustom) messages that include `rldp.messagePart`.
 
 First, we need to extract FEC information from the initial message received during the transfer. Specifically, we are looking for the `data_size`, `symbol_size`, and `symbols_count` parameters from the `fec.raptorQ` messagePart structure.
 
@@ -200,7 +200,7 @@ http.response http_version:string status_code:int reason:string headers:(vector 
 
 The main fields are generally straightforward, as they function similarly to those in HTTP.
 
-One notable flag is `no_payload`. If this flag is set to true, it indicates that there is no body in the response, meaning `Content-Length` is 0. In this case, the response from the server can be considered received.
+One notable flag is `no_payload`. If this flag is set to true, it indicates that there is no body in the response. In this case, the response from the server can be considered received.
 
 If `no_payload` is false, this means there is content in the response, and we need to retrieve it. To do this, we should send a request using the TL schema `http.getNextPayloadPart`, which should be wrapped in `rldp.query`.
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-network-protocols-rldp.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/network/protocols/rldp.mdx`

Related issues (from issues.normalized.md):
- [ ] **1425. Replace vague 'tunnels'/'TCP‑like stream' with RLDP reference**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/adnl/overview.mdx?plain=1

Remove or rephrase mentions of “tunnels (chains of proxies)” and a “TCP‑like stream protocol”; instead, state that higher‑level protocols such as RLDP operate over ADNL and link to docs/v3/documentation/network/protocols/rldp.mdx.

---

- [ ] **1472. Use "ADNL over UDP" phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/rldp.mdx?plain=1#L13

Replace “on top of the ADNL UDP protocol” with “on top of ADNL over UDP.”

---

- [ ] **1473. Clarify TL schema ID terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/rldp.mdx?plain=1#L43

Replace “tl prefix id” with “TL schema ID (constructor ID prefix)” for consistency with TL docs.

---

- [ ] **1474. Change “Golang” to “Go” in RaptorQ example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/rldp.mdx?plain=1#L61

Update the link text to say “implementation example of RaptorQ in Go.”

---

- [ ] **1475. Correct RLDP expansion**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/rldp.mdx?plain=1#L65

Change the parenthetical to “Reliable Large Datagram Protocol” (e.g., “RLDP (Reliable Large Datagram Protocol) is used to wrap HTTP requests.”).

---

- [ ] **1476. Remove redundant “protocol” after RLDP**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/rldp.mdx?plain=1#L67

Change “…via the RLDP protocol” to “…via RLDP.”

---

- [ ] **1477. Fix TL type: http.request should produce http.Request**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/rldp.mdx?plain=1#L78

In both TL blocks (around lines 78 and 105), change the right-hand side to “= http.Request;” and ensure the http.Request type is defined.

---

- [ ] **1478. Replace “scheme of work” with “workflow”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/rldp.mdx?plain=1#L84

Change “The scheme of work is as follows” to “The workflow is as follows:” (or “The sequence is as follows:”).

---

- [ ] **1479. Use “vice versa” (no hyphen)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/rldp.mdx?plain=1#L92

Replace “vice-versa” with “vice versa.”

---

- [ ] **1480. Improve example preface grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/rldp.mdx?plain=1#L98

Rewrite “Assuming say we have already got …” to “Assume we have already obtained …” and simplify the sentence structure.

---

- [ ] **1481. Use no_payload flag for body retrieval**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/rldp.mdx?plain=1#rldp-http

Update the flow to check the http.response no_payload:Bool; if no_payload is false, request the body via http.getNextPayloadPart instead of relying on Content-Length.

---

- [ ] **1482. Use “DNS contract” terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/rldp.mdx?plain=1#request-the-ton-site

Replace “NFT‑DNS contract” with “DNS contract” and keep “get method” casing consistent with the rest of the docs.

---

- [ ] **1483. Prefer internal links for DHT and ADNL over UDP**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/rldp.mdx?plain=1#request-the-ton-site

Replace external references with internal links: DHT → /v3/documentation/network/protocols/dht/dht-deep-dive; ADNL over UDP → /v3/documentation/network/protocols/adnl/adnl-udp.

---

- [ ] **1484. Cite or remove unverified transfer_id XOR detail**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/rldp.mdx?plain=1#processing-the-response-from-foundationton

Either add a reliable citation for the claim that response transfer_id is bytewise XOR 0xFF or remove/clarify it as an implementation-specific note.

---

- [ ] **1485. Link adnl.message.custom to its definition**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/rldp.mdx?plain=1

Link mentions of adnl.message.custom to /v3/documentation/network/protocols/adnl/adnl-udp#adnlmessagecustom for easy cross-reference.

---

- [ ] **1486. Add “See also” link to TON proxy guide**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/network/protocols/rldp.mdx?plain=1#rldp-http

Append a “See also” pointing to /v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy after the RLDP-HTTP intro.

---

- [ ] **4392. Prefer “HTTP requests” over “HTTP queries”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx?plain=1

Replace “HTTP queries” with “HTTP requests” for consistency with RLDP documentation (see docs/v3/documentation/network/protocols/rldp.mdx#rldp-http).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.