### PR TITLE
Split: update docs/v3/documentation/smart-contracts/addresses/address-states.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/addresses/address-states.mdx
+++ b/docs/v3/documentation/smart-contracts/addresses/address-states.mdx
@@ -10,15 +10,15 @@ Understanding these states is crucial for accurately predicting transaction outc
 
 Each address exists in one of the following states:
 
--   **nonexist**: the default state for addresses with no transaction history or that were deleted. Contains no code, data, or balance. All 2<sup>256</sup> addresses start in this state. An address returns to this initial state when its `storage_fees_due` exceeds 1 TON or the outgoing message flag is set to 32.
--   **uninit**: holds a balance and metadata, but no code and persistent data. An address enters this state when it receives funds. It cannot execute logic but retains funds until the contract code is deployed. An address becomes _uninit_ when a no-bounce message with a nonzero `balance` but without `state_init` is sent to a `nonexist` address.
--   **active**: contains code, data, and a balance. Fully deployed and operational, capable of processing messages. An address becomes _active_ when a message with its `state_init` is sent to an `uninit` or `nonexist` address. Note that the hash of `state_init` must match the address for deployment.
--   **frozen**: occurs when `storage_fees_due` exceeds 0.1 TON. Only the hashes of the previous code and data cells are preserved. While frozen, the contract cannot execute. To unfreeze, send a message with the valid `state_init` and sufficient funds for storage fees. Recovery is complex; avoid reaching this state. A project to unfreeze addresses is available [here](https://unfreezer.ton.org/).
+-   **nonexist**: the default state for addresses with no transaction history or those that were deleted. Contains no code, data, or balance. All addresses start in this state. An address returns to this initial state when its `storage_fees_due` exceeds 1 TON or the outgoing message flag is set to 32.
+-   **uninit**: holds a balance and metadata, but no code or persistent data. An address enters this state when it receives funds. It cannot execute logic but retains funds until the contract code is deployed. An address becomes _uninit_ when a no-bounce message with a nonzero `balance` but without `state_init` is sent to a `nonexist` address.
+-   **active**: contains code, data, and a balance. Fully deployed and operational, capable of processing messages. An address becomes `active` when a message with its `state_init` is sent to an `uninit` or `nonexist` address. Note that the hash of `state_init` must match the address for deployment.
+-   **frozen**: occurs when `storage_fees_due` exceeds 0.1 TON. Only the hashes of the previous code and data cells are preserved. While frozen, the contract cannot execute. To unfreeze, send a message with the valid `state_init` and sufficient funds for storage fees. Recovery is complex; avoid reaching this state. See the [TON unfreezer](https://unfreezer.ton.org/).
 
 
 ## State transitions
 
-An address state determines how the network handles incoming messages. We present here a diagram that describes all potential changes in the account state during the receipt of internal or external messages.
+An address’s state determines how the network handles incoming messages. We present here a diagram that describes all potential changes in the account state during the receipt of internal or external messages.
 
 ### Diagram
 In the diagram below, there are four nodes representing the four different address states. Each arrow and loop corresponds to a change in the address state at the end of a given transaction. The parameters in the blocks above the arrows (and loops) briefly describe what caused the transaction and also contain some fields that affect the change in the address state.
@@ -76,7 +76,7 @@ With the diagram **Legend** below, you can inspect all possible changes in the a
 
  We additionally review some important points regarding the states except `nonexist`.
 
-**Sending to `uninit` address**:
+**Sending to an `uninit` address**:
    - **Messages of any type without `state_init`**: changes to `nonexist` if its storage_fees_due exceeds 1 TON. Although such a case is really rare, you need to keep this in mind.
    - **Internal message with valid `state_init`**: changes to `active`.
 
@@ -89,7 +89,7 @@ With the diagram **Legend** below, you can inspect all possible changes in the a
    - **Messages of any type**: if in the action list there is an outgoing message with the flag 32 but the action phase was unsuccessful or the balance after this action is positive, the address state doesn't change.
    - **Internal message with any `state_init`**: New `state_init` will be ignored and therefore doesn't change the address state.
 
-**Deployment strategy**: the standard practice for deploying a wallet is to first send a non-bounceable message with Toncoin to its address. This transitions the address to the `uninit` state. The wallet owner can then deploy the contract in a subsequent transaction, using the pre-funded balance.
+**Deployment strategy**: the standard practice for deploying a wallet is to first send a [non-bounceable message](/v3/documentation/smart-contracts/message-management/non-bounceable-messages) with Toncoin to its address. This transitions the address to the `uninit` state. The wallet owner can then deploy the contract in a subsequent transaction, using the pre-funded balance.
 
 **Protection against errors**: standard wallets and applications manage these complexities by automatically setting the `bounce` flag based on the state of the destination address. Developers of custom applications must implement similar logic to prevent fund loss.
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-addresses-address-states.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/addresses/address-states.mdx`

Related issues (from issues.normalized.md):
- [ ] **1487. Populate empty index or add redirect**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/addresses.mdx?plain=1

This file is empty; either populate it as an index with an H1 “Addresses”, a brief overview, and links to docs/v3/documentation/smart-contracts/addresses/address.mdx, docs/v3/documentation/smart-contracts/addresses/address-formats.mdx, and docs/v3/documentation/smart-contracts/addresses/address-states.mdx, or add a redirect in redirects/redirects.json from /v3/documentation/smart-contracts/addresses to /v3/documentation/smart-contracts/addresses/address.

---

- [ ] **1490. Add Next steps and Feedback**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/addresses.mdx?plain=1

Append a short “Next steps” list linking to docs/v3/documentation/smart-contracts/addresses/address-formats.mdx and docs/v3/documentation/smart-contracts/addresses/address-states.mdx and render the shared <Feedback /> component at the end to match sibling pages.

---

- [ ] **1505. Fix parallelism in nonexist definition**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/addresses/address-states.mdx?plain=1#L12

Change “the default state for addresses with no transaction history or that were deleted.” to “the default state for addresses with no transaction history or those that were deleted.”.

---

- [ ] **1506. Use 'or' in 'no code or persistent data'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/addresses/address-states.mdx?plain=1#L13

Change “holds a balance and metadata, but no code and persistent data.” to “holds a balance and metadata, but no code or persistent data.”.

---

- [ ] **1507. Remove comma after 'Note'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/addresses/address-states.mdx?plain=1#L14

Change “Note, that the hash of `state_init` must match the address for deployment.” to “Note that the hash of `state_init` must match the address for deployment.”.

---

- [ ] **1508. Format state name 'active' as code**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/addresses/address-states.mdx?plain=1#L14

Change “An address becomes _active_ …” to “An address becomes `active` …” to match code formatting used for state names.

---

- [ ] **1509. Use descriptive link text 'TON unfreezer'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/addresses/address-states.mdx?plain=1#L15

Replace the non‑descriptive “here” link with descriptive text: “See the [TON unfreezer](https://unfreezer.ton.org/).”.

---

- [ ] **1510. Use possessive 'address’s state'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/addresses/address-states.mdx?plain=1#L20

Change “An address state determines how the network handles incoming messages:” to “An address’s state determines how the network handles incoming messages:”.

---

- [ ] **1511. Add article before 'uninit'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/addresses/address-states.mdx?plain=1#L22

Change the heading/text “Sending to `uninit` address” to “Sending to an `uninit` address”.

---

- [ ] **1512. Code-format bounce flags and remove HTML entity**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/addresses/address-states.mdx?plain=1#L24-L25

Wrap the bounce flag values in code and replace the non‑breaking space: write “Without `state_init` (`bounce: true`)” and “Without `state_init` (`bounce: false`)”, and change “minus&nbsp;fees.” to “minus fees.”.

---

- [ ] **1513. Generalize “All 2^256 addresses” phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/addresses/address-states.mdx?plain=1

Replace “All 2^256 addresses start in this state.” with the less over‑specific “All addresses start in this state.”.

---

- [ ] **1514. Clarify frozen state stores combined state hash**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/addresses/address-states.mdx?plain=1

Replace “Only the hashes of the previous code and data cells are preserved.” with “Only the combined state hash of the previous code and data is preserved.”.

---

- [ ] **1515. Remove wallets auto-set bounce claim; advise manual non-bounceable flow**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/addresses/address-states.mdx?plain=1

Reword the wallet behavior note to: “Many wallets (e.g., via TON Connect) always send bounceable messages and don’t expose control of the bounce flag; if you need a non‑bounceable message (e.g., to initialize an address), construct and sign it manually, and ensure custom apps implement correct bounce handling.”.

---

- [ ] **1516. Link “non-bounceable message” to its guide**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/addresses/address-states.mdx?plain=1

Link the phrase “non‑bounceable message” to /v3/documentation/smart-contracts/message-management/non-bounceable-messages.

---

- [ ] **1517. Clarify deployment from nonexist with StateInit**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/addresses/address-states.mdx?plain=1

Add a clarification of allowed transitions: explicitly state whether a non‑bounceable internal message with `StateInit` can deploy directly to a `nonexist` address (add a “Sending to `nonexist` address” subsection) or document the recommended flow (fund to `uninit` then deploy).

---

- [ ] **3301. Remove unsupported ‘-1 TON’ deletion threshold**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Delete the hard “-1 TON” value and state that contracts can be deleted when accumulated storage fees exceed the configured delete limits, citing docs/v3/documentation/network/configs/blockchain-configs.mdx#param-20-and-21 and docs/v3/documentation/smart-contracts/addresses/address-states.mdx.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.