### PR TITLE
Split: update docs/v3/documentation/smart-contracts/contracts-specs/examples.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/contracts-specs/examples.mdx
+++ b/docs/v3/documentation/smart-contracts/contracts-specs/examples.mdx
@@ -2,7 +2,7 @@ import Feedback from '@site/src/components/Feedback';
 
 # Examples of smart contracts
 
-On this page, you can find TON smart contract references implemented for various program software.
+On this page, you can find TON smart contract references implemented in various software projects.
 
 :::info
 Make sure you have thoroughly tested contracts before using them in a production environment. This is a critical step to ensure the proper functioning and security of your software.
@@ -54,9 +54,9 @@ Make sure you have thoroughly tested contracts before using them in a production
 | [whitelisted-wallet.fc](https://github.com/tonwhales/ton-contracts/blob/master/contracts/whitelisted-wallet.fc) <br /> <small>🪄 [Run in WebIDE](https://ide.ton.org/?importURL=https://github.com/tonwhales/ton-contracts/blob/master/contracts/whitelisted-wallet.fc&name=whitelisted-wallet.fc)</small> | Simple Whitelisted Wallet Contract                                                                                                          |
 | [delab-team/jetton-pool](https://github.com/delab-team/contracts/tree/main/jetton-pool) <br /> <small>🪄 [Run in WebIDE](https://ide.ton.org/?importURL=https://github.com/delab-team/contracts/tree/main/jetton-pool&name=delab-team/jetton-pool)</small>                                                 | The Jetton Pool TON smart contract is designed to create farming pools.                                                                     |
 | [ston-fi/contracts](https://github.com/ston-fi/dex-core/tree/main/contracts) <br /> <small>🪄 [Run in WebIDE](https://ide.ton.org/?importURL=https://github.com/ston-fi/dex-core/tree/main/contracts&name=ston-fi/contracts)</small>                                                                       | Stonfi DEX core contracts                                                                                                                   |
-| [onda-ton](https://github.com/0xknstntn/onda-ton) <br /> <small>🪄 [Run in WebIDE](https://ide.ton.org/?importURL=https://github.com/0xknstntn/onda-ton&name=onda-ton)</small>                                                                                                                             | Onda Lending Pool - Core smart contracts of the first lending protocol on TON                                                               |
+| [onda-ton](https://github.com/0xknstntn/onda-ton) <br /> <small>🪄 [Run in WebIDE](https://ide.ton.org/?importURL=https://github.com/0xknstntn/onda-ton&name=onda-ton)</small>                                                                                                                             | Core smart contracts of a lending protocol on TON.                                                                 |
 | [ton-stable-timer](https://github.com/ProgramCrafter/ton-stable-timer) <br /> <small>🪄 [Run in WebIDE](https://ide.ton.org/?importURL=https://github.com/ProgramCrafter/ton-stable-timer&name=ton-stable-timer)</small>                                                                                   | TON Stable Timer contract                                                                                                                   |
-| [HipoFinance/contract](https://github.com/HipoFinance/contract) <br /> <small>🪄 [Run in WebIDE](https://ide.ton.org/?importURL=https://github.com/HipoFinance/contract&name=HipoFinance)</small>                                                                                                          | hTON is a decentralized, permission-less, open-source liquid staking protocol on TON Blockchain                                             |
+| [HipoFinance/contract](https://github.com/HipoFinance/contract) <br /> <small>🪄 [Run in WebIDE](https://ide.ton.org/?importURL=https://github.com/HipoFinance/contract&name=HipoFinance)</small>                                                                                                          | hTON is a decentralized, permissionless, open-source liquid staking protocol on TON Blockchain                                             |
 
 ### Learning contracts
 
@@ -65,15 +65,13 @@ Make sure you have thoroughly tested contracts before using them in a production
 | [counter.fc](https://github.com/ton-community/blueprint/blob/main/example/contracts/counter.fc) <br /> <small>🪄 [Run in WebIDE](https://ide.ton.org/?importURL=https://github.com/ton-community/blueprint/blob/main/example/contracts/counter.fc&name=counter.fc)</small>                                                      | Counter smart contract with comments.                                   |
 | [simple-distributor](https://github.com/ton-community/simple-distributor) <br /> <small>🪄 [Run in WebIDE](https://ide.ton.org/?importURL=https://github.com/ton-community/simple-distributor&name=simple-distributor)</small>                                                                                                  | Simple TON distributor.                                                 |
 | [ping-pong.fc](https://github.com/tonwhales/ton-nft/blob/main/packages/nft/ping-pong/ping-pong.fc) <br /> <small>🪄 [Run in WebIDE](https://ide.ton.org/?importURL=https://github.com/tonwhales/ton-nft/blob/main/packages/nft/ping-pong/ping-pong.fc&name=ping-pong.fc)</small>                                                | Simple contract to test sending Toncoin in different modes.             |
-| [ton-random](https://github.com/puppycats/ton-random) <br /> <small>🪄 [Run in WebIDE](https://ide.ton.org/?importURL=https://github.com/puppycats/ton-random&name=ton-random)</small>                                                                                                                                          | Two contracts that will help you in generating random numbers on-chain. |
+| [ton-random](https://github.com/puppycats/ton-random) <br /> <small>🪄 [Run in WebIDE](https://ide.ton.org/?importURL=https://github.com/puppycats/ton-random&name=ton-random)</small>                                                                                                                                          | Two contracts that will help you generate random numbers on-chain. |
 | [Blueprint simple contract](https://github.com/liminalAngel/1-func-project/blob/master/contracts/main.fc) <br /> <small>🪄 [Run in WebIDE](https://ide.ton.org/?importURL=https://github.com/liminalAngel/1-func-project/blob/master/contracts/main.fc&name=simple_contract)</small>                                            | Example smart contract                                                  |
 | [Blueprint jetton_minter.fc](https://github.com/liminalAngel/func-blueprint-tutorial/blob/master/6/contracts/jetton_minter.fc) <br /> <small>🪄 [Run in WebIDE](https://ide.ton.org/?importURL=https://github.com/liminalAngel/func-blueprint-tutorial/blob/master/6/contracts/jetton_minter.fc&name=jetton_minter.fc)</small> | Smart contract example to mint Jettons on-chain.                        |
-| [Simple TON DNS Subdomain manager](https://github.com/Gusarich/simple-subdomain) <br /> <small>🪄 [Run in WebIDE](https://ide.ton.org/?importURL=https://github.com/Gusarich/simple-subdomain&name=Simple_TON_DNS_Subdomain_manager)</small>                                                                                    | TON DNS subdomains manager.                                             |
+| [Simple TON DNS Subdomain manager](https://github.com/Gusarich/simple-subdomain) <br /> <small>🪄 [Run in WebIDE](https://ide.ton.org/?importURL=https://github.com/Gusarich/simple-subdomain&name=Simple_TON_DNS_Subdomain_manager)</small>                                                                                    | TON DNS subdomain manager.                                              |
 | [disintar/sale-dapp](https://github.com/disintar/sale-dapp/tree/master/func) <br /> <small>🪄 [Run in WebIDE](https://ide.ton.org/?importURL=https://github.com/disintar/sale-dapp/tree/master/func&name=disintar/sale-dapp)</small>                                                                                            | React + NFT sale DApp with FunC                                         |
 
 ### TON smart challenges
-
-Below, you can find materials created during [TON Contest](https://t.me/toncontests/) activities.
 
 #### TON Smart Challenge 1
 
@@ -145,8 +143,26 @@ Below, you can find materials created during [TON Contest](https://t.me/tonconte
 - [wallet.fif](https://github.com/ton-blockchain/ton/blob/master/crypto/smartcont/wallet.fif)
 - [wallet-v3-code.fif](https://github.com/ton-blockchain/ton/blob/master/crypto/smartcont/wallet-v3-code.fif)
 
+## FunC libraries and helpers
+
+- [https://github.com/ton-blockchain/ton/blob/master/crypto/smartcont/stdlib.fc](https://github.com/ton-blockchain/ton/blob/master/crypto/smartcont/stdlib.fc)
+- [https://github.com/TonoxDeFi/open-contracts/tree/main/contracts/crypto/elliptic-curves](https://github.com/TonoxDeFi/open-contracts/tree/main/contracts/crypto/elliptic-curves)
+- [https://github.com/TonoxDeFi/open-contracts/tree/main/contracts/math](https://github.com/TonoxDeFi/open-contracts/tree/main/contracts/math)
+- [https://github.com/TonoxDeFi/open-contracts/tree/main/contracts/messages](https://github.com/TonoxDeFi/open-contracts/tree/main/contracts/messages)
+- [https://github.com/TonoxDeFi/open-contracts/tree/main/contracts/slices](https://github.com/TonoxDeFi/open-contracts/tree/main/contracts/slices)
+- [https://github.com/TonoxDeFi/open-contracts/tree/main/contracts/strings](https://github.com/TonoxDeFi/open-contracts/tree/main/contracts/strings)
+- [https://github.com/TonoxDeFi/open-contracts/tree/main/contracts/tuples](https://github.com/TonoxDeFi/open-contracts/tree/main/contracts/tuples)
+- [https://github.com/TonoxDeFi/open-contracts/tree/main/contracts/utils](https://github.com/TonoxDeFi/open-contracts/tree/main/contracts/utils)
+- [https://github.com/disintar/sale-dapp/tree/master/func](https://github.com/disintar/sale-dapp/tree/master/func)
+
 ## Add reference
 
 If you want to share a new example smart contract, make your PR for this [page](https://github.com/ton-community/ton-docs/tree/main/docs/v3/documentation/smart-contracts/contracts-specs/examples.mdx).
+
+## See also
+
+- [Develop Smart Contracts Introduction](/v3/documentation/smart-contracts/overview)
+- [How to work with wallet smart contracts](/v3/guidelines/smart-contracts/howto/wallet)
+- [YouTube: TON Dev Study — FunC & Blueprint lessons](https://www.youtube.com/watch?v=7omBDfSqGfA&list=PLtUBO1QNEKwtO_zSyLj-axPzc9O9rkmYa)
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-contracts-specs-examples.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/contracts-specs/examples.mdx`

Related issues (from issues.normalized.md):
- [ ] **1527. Rename 'Production-used contracts' heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/examples.mdx?plain=1#L13

Rename the heading to "Contracts used in production" for idiomatic phrasing.

---

- [ ] **1528. Rephrase Wallet v4 description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/examples.mdx?plain=1#L17

Rephrase to "Wallet v4 smart contract with plugin support" to avoid speculative roadmap claims.

---

- [ ] **1529. Remove inconsistent 'LSt' acronym**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/examples.mdx?plain=1#L18

Change "Liquid Staking (LSt)" to "Liquid Staking" by removing the inconsistent acronym.

---

- [ ] **1530. Code-format modern_jetton methods and add article**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/examples.mdx?plain=1#L19

Update to "Implementation of the standard jetton with additional `withdraw_tons` and `withdraw_jettons`."

---

- [ ] **1531. Improve multisig row grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/examples.mdx?plain=1#L27

Replace the description with "An `(n, k)` multisig wallet is a wallet with `n` private key holders; it accepts requests to send messages if the request collects at least `k` signatures."

---

- [ ] **1532. Normalize token contracts row capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/examples.mdx?plain=1#L28

Change to "Fungible, non-fungible, and semi-fungible token smart contracts" with sentence-style capitalization and correct plurality.

---

- [ ] **1533. Rephrase .ton zone description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/examples.mdx?plain=1#L29

Change "Smart contracts of `.ton` zone." to "Smart contracts for the .ton zone." and remove backticks.

---

- [ ] **1534. Fix single-nominator WebIDE link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/examples.mdx?plain=1#L31

Set the WebIDE link to https://ide.ton.org/?importURL=https://github.com/orbs-network/single-nominator&name=single-nominator to match the GitHub repo.

---

- [ ] **1535. Correct 'Telegram Usenames' typo**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/examples.mdx?plain=1#L39

Correct to "Telegram Usernames (`nft-item.fc`) and Telegram Numbers (`nft-item-no-dns.fc`) contracts."

---

- [ ] **1536. Fix subject–verb in contract-verifier description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/examples.mdx?plain=1#L46

Change to "Sources registry contracts that store an on-chain proof per code cell hash" to fix subject–verb agreement.

---

- [ ] **1537. Improve vanity-contract phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/examples.mdx?plain=1#L47

Change “allows to 'mine' any suitable address …” to “allows you to 'mine' any suitable address …”.

---

- [ ] **1538. Use 'on TON Blockchain' preposition**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/examples.mdx?plain=1#L48

Use "on TON Blockchain" instead of "in TON Blockchain" for consistency.

---

- [ ] **1539. Add article in Ratelance description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/examples.mdx?plain=1#L49

Change to "Ratelance is a freelance platform …" by adding the article.

---

- [ ] **1540. Remove unsupported 'first' claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/examples.mdx?plain=1#L57

Remove the superlative by changing to "Core smart contracts of a lending protocol on TON."

---

- [ ] **1541. Use 'permissionless' in HipoFinance description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/examples.mdx?plain=1#L59

Replace "permission-less" with "permissionless."

---

- [ ] **1542. Streamline ton-random description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/examples.mdx?plain=1#L68

Rephrase to "will help you generate random numbers on-chain" for concision.

---

- [ ] **1543. Use singular in DNS subdomain manager**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/examples.mdx?plain=1#L71

Change "TON DNS subdomains manager" to "TON DNS subdomain manager."

---

- [ ] **1544. Normalize YouTube link label and 'Blueprint' capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/examples.mdx?plain=1#L166

Update the label to "YouTube: TON Dev Study — FunC & Blueprint lessons" using "YouTube" (no space) and capitalized "Blueprint."

---

- [ ] **1545. Rephrase intro sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/examples.mdx?plain=1

Replace with "On this page, you can find TON smart contract references implemented in various software projects."

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.