### PR TITLE
Split: update docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx
+++ b/docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx
@@ -18,17 +18,17 @@ Any given external message (transfer request) to a Highload wallet v3 contains:
 - subwallet ID (32 bits)
 - message to send as a reference (the serialized internal message that will be sent)
 - send mode for the message (8 bits)
-- composite query ID — 13-bit shift and 10-bit bit number; however, the bit number can only go up to 1022 (not 1023), and the last usable query ID (8388605) is reserved for emergencies and should not normally be used
+composite query ID - 13 bits of "shift" and 10 bits of "bit number", however the 10 bits of bit number can only go up to 1022, not 1023, and also the last such usable query ID (8388605) is reserved for emergencies and should not be normally used
 - created_at (message timestamp)
 - timeout
 
 Timeout is stored in the Highload wallet as a parameter and is checked against the timeout in all requests—so the timeout for all requests is equal. The message should not be older than the timeout at the time of arrival to the Highload wallet, or in code it is required that `created_at > now() - timeout`. Query IDs are stored for the purposes of replay protection for at least timeout and possibly up to 2 \* timeout; however, one should not expect them to be stored for longer than timeout. The subwallet ID is checked against the one stored in the wallet. The inner reference’s hash is checked along with the signature against the public key of the wallet.
 
-A single transaction can create up to 255 messages; a common pattern uses one self-call to continue processing, leaving up to 254 outgoing messages per external message.
+Highload v3 can only send 1 message from any given external message, however it can send that message to itself with a special op code, allowing one to set any action cell on that internal message invocation, effectively making it possible to send up to 254 messages per 1 external message (possibly more if another message is sent to Highload wallet again among these 254).
 
 Highload wallet v3 will always store the query ID (replay protection) once all the checks pass; however, a message may not be sent due to some conditions, including but not limited to:
 
-- **containing state init** (such messages, if required, may be sent using the special opcode to set the action cell after an internal message from Highload wallet to itself)
+- **containing state init** (such messages, if required, may be sent using the special op code to set the action cell after an internal message from Highload wallet to itself)
 - not enough balance
 - invalid message structure (that includes external-out messages — only internal messages may be sent straight from the external message)
 
@@ -39,7 +39,7 @@ When iterating (incrementing) query ID, it is cheaper (in terms of TON spent on 
 ## Highload wallet v2
 
 :::danger
-Legacy contract — use Highload wallet v3 instead.
+Legacy contract, it is suggested to use Highload wallet v3.
 :::
 
 This wallet is made for those who need to send hundreds of transactions in a short period of time. For example, crypto exchanges.
@@ -57,10 +57,11 @@ It is not recommended to set too high an expiration date: the number of queries 
 
 ## How to
 
-See the [Highload wallet tutorial(s)](/v3/guidelines/smart-contracts/howto/wallet#-high-load-wallet-v3).
+You can also read [Highload wallet tutorials](/v3/guidelines/smart-contracts/howto/wallet#-high-load-wallet-v3)
 
 Wallet source code:
 
-- [ton/crypto/smartcont/new-highload-wallet-v2.fif](https://github.com/ton-blockchain/ton/blob/master/crypto/smartcont/new-highload-wallet-v2.fif)
+
+- [ton/crypto/smartcont/Highload-wallet-v2-code.fc](https://github.com/ton-blockchain/ton/blob/master/crypto/smartcont/new-highload-wallet-v2.fif)
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-contracts-specs-highload-wallet.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx`

Related issues (from issues.normalized.md):
- [x] **1563. Fix missing articles and phrasing in introduction**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx?plain=1

Replace “there is a need for special wallet called Highload wallet” with “there is a need for a special wallet called a Highload wallet,” and prefer “in a short period of time” (or “in a short time”) for clarity.

---

- [x] **1564. Standardize capitalization for “Highload wallet v3/v2”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx?plain=1

Use “Highload wallet v3” and “Highload wallet v2” consistently across headings, link text, and body.

---

- [x] **1565. Fix run‑on and parallelism in v3 intro sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx?plain=1

Change to “With the advent of Highload wallet v3, this problem has been solved at the contract‑architecture level, and the contract consumes less gas.”

---

- [x] **1566. Correct “for who need” to “for those who need”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx?plain=1

Change “This wallet is made for who need to send transactions...” to “This wallet is made for those who need to send transactions (e.g., crypto exchanges)...”.

---

- [x] **1567. Clean up parameter bullets: hyphenation, terminology, and punctuation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx?plain=1

In the bullets, use “top‑level cell; the other parameters are stored in a reference of that cell,” prefer “reference” or wrap “ref” in backticks, clarify the composite query ID text (13‑bit shift + 10‑bit bit number; last usable ID 8388605 is reserved), and use “created_at (message timestamp)”.

---

- [ ] **1568. Use “opcode” instead of “op code”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx?plain=1

Replace all occurrences of “op code” with “opcode” (e.g., self‑call description and state‑init bullet).

---

- [ ] **1569. Clarify message limit wording and 254/255 consistency**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx?plain=1

Rephrase to “A single transaction can create up to 255 messages; a common pattern uses one self‑call to continue processing, leaving up to 254 outgoing messages per external message,” and avoid “per 1 external message”/“1 message” phrasing.

---

- [x] **1570. Replace “externals” with “external messages”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx?plain=1

Change “multiple externals...” to “multiple external messages...” for correct terminology.

---

- [ ] **1571. Standardize “subwallet ID” casing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx?plain=1

Use “subwallet ID” (lowercase “subwallet”) consistently throughout.

---

- [x] **1572. Use “action phase” consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx?plain=1

Refer to the “action phase” (lowercase) instead of “ActionPhase” in prose.

---

- [x] **1573. Improve legacy contract warning**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx?plain=1

Replace “Legacy contract, it is suggest to use Highload wallet v3.” with “Legacy contract — use Highload wallet v3 instead.”

---

- [ ] **1574. Fix caution note lead‑in grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx?plain=1

Change “Note, when dealing with Highload wallet the following limits need to be checked and taken into account.” to “Note: when dealing with the Highload wallet, the following limits must be considered.”

---

- [ ] **1575. Clarify storage size limit text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx?plain=1

Rewrite to “The size of the contract storage must be less than 65,535 cells; if the size of `old_queries` grows beyond this limit, an exception will be thrown during the action phase and the transaction will fail, and the failed transaction may be replayed.”

---

- [ ] **1576. Clarify gas limit text and fix grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx?plain=1

Rewrite to “The gas limit is 1'000'000 gas units, which limits how many old queries can be cleaned in one transaction; if the number of expired queries is higher, the contract may become stuck.”

---

- [ ] **1577. Improve expiration guidance wording and numerals**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx?plain=1

Rewrite to “It is not recommended to set too high an expiration date: the number of queries within the expiration window should not exceed 1,000, and the number of expired queries cleaned in one transaction should be no more than 100.”

---

- [ ] **1578. Fix “How to” reference phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx?plain=1

Change “You can also read Highload wallet tutorials article.” to “See the Highload wallet tutorial(s).”

---

- [ ] **1579. Make v2 source‑code link text match target**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx?plain=1

Update the “Wallet source code” link text to ton/crypto/smartcont/new-highload-wallet-v2.fif to match the actual target file.

---

- [ ] **1580. Standardize “external‑out” terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx?plain=1

Use “external‑out messages” (hyphenated) consistently on this page.

---

- [ ] **1581. Add citations or soften unverified numeric limits**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx?plain=1

Provide citations within the docs for the stated limits (storage < 65,535 cells, gas 1'000'000 units, ≤1,000 queries in window, <100 cleaned per tx), or rephrase as qualitative guidance/remove specific numbers until confirmed.

---

- [x] **1582. Clarify “Highload” reference in timeout sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx?plain=1

Change “Timeout is stored in Highload as a parameter...” to “Timeout is stored in the Highload wallet as a parameter...”.

---

- [ ] **1583. Improve “Inner ref’s hash” grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx?plain=1

Change “Inner ref’s hash is checked...” to “The inner reference’s hash is checked...” for clarity and correctness.

---

- [ ] **1584. Cite composite query ID bit layout and reserved ID**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/highload-wallet.mdx?plain=1

Add a citation to a specification for the composite query ID bit allocation (13‑bit shift + 10‑bit bit number) and the reserved last usable ID (8388605), or remove these specifics until sourced.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.