### PR TITLE
Split: update docs/v3/documentation/smart-contracts/contracts-specs/precompiled-contracts.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/contracts-specs/precompiled-contracts.mdx
+++ b/docs/v3/documentation/smart-contracts/contracts-specs/precompiled-contracts.mdx
@@ -6,9 +6,9 @@ A _precompiled smart contract_ is a contract with a C++ implementation in the no
 
 ## Config
 
-The list of precompiled contracts is stored in the masterchain configuration:
+The list of precompiled contracts is stored in the MasterChain configuration:
 
-```
+```tlb
 precompiled_smc#b0 gas_usage:uint64 = PrecompiledSmc;
 precompiled_contracts_config#c0 list:(HashmapE 256 PrecompiledSmc) = PrecompiledContractsConfig;
 _ PrecompiledContractsConfig = ConfigParam 45;
@@ -21,26 +21,25 @@ The `list:(HashmapE 256 PrecompiledSmc)` represents a mapping of `(code_hash -> 
 Transactions for precompiled smart contracts (those with code hashes in `ConfigParam 45`) follow this execution flow:
 
 1. Retrieve the `gas_usage` value from the masterchain config
-2. If the contract balance cannot cover the `gas_usage` cost, the compute phase fails with `cskip_no_gas`
+2. If the contract balance cannot cover the `gas_usage` cost, the compute phase fails with [`cskip_no_gas`](/v3/documentation/tvm/tvm-overview#when-the-compute-phase-is-skipped)
 3. Execution proceeds via one of two paths:
-   - **TVM execution**: Used if precompiled execution is disabled or the C++ implementation is unavailable in the node version. TVM runs with a 1M gas limit.
+   - **TVM execution**: Used if precompiled execution is disabled or the C++ implementation is unavailable in the node version. TVM executes with the gas limits defined by the network configuration (see [gas and fee parameters](/v3/documentation/smart-contracts/limits#gas-and-fee-parameters) and [Param20/Param21](/v3/documentation/network/configs/blockchain-configs#param-20-and-21)).
    - **Native execution**: Used when precompiled implementation is both enabled and available, executing the C++ code directly
 4. Compute phase values are overridden:
    - `gas_used` set to `gas_usage`
    - `vm_steps`, `vm_init_state_hash`, and `vm_final_state_hash` set to zero
 5. Computation fees are calculated based on `gas_usage` rather than actual TVM gas consumption
 
-For precompiled contracts executed in TVM, the 17th element of `c7` contains the `gas_usage` value (accessible via `GETPRECOMPILEDGAS`). Non-precompiled contracts return `null` for this value.
+For precompiled contracts, the 17th element of `c7` (index `16`) holds the precompiled `gas_usage` value for the current contract as defined in `ConfigParam 45`; see [c7](/v3/documentation/tvm/changelog/tvm-upgrade-2024-04#c7). The `GETPRECOMPILEDGAS` opcode is currently reserved and returns `null`; when activated, it will return the precompiled contract gas usage; see [new opcodes](/v3/documentation/tvm/changelog/tvm-upgrade-2024-04#new-opcodes). Non-precompiled contracts return `null` for this value.
 
-**Note**: Enable precompiled contract execution by running `validator-engine` with the `--enable-precompiled-smc` flag. Both execution methods produce identical transactions, allowing validators with and without C++ implementations to coexist in the network. This enables gradual adoption when adding new entries to `ConfigParam 45`.
+**Note**: Enable precompiled contract execution by running `validator-engine` with the [`--enable-precompiled-smc`](/v3/documentation/infra/nodes/node-commands) (experimental) flag. Both execution methods produce identical transactions, allowing validators with and without C++ implementations to coexist in the network. This enables gradual adoption when adding new entries to `ConfigParam 45`.
 
 ## Available implementations
 
-Hic sunt dracones.
+No implementations are listed yet.
 
 ## See also
 
 - [Governance contracts](/v3/documentation/smart-contracts/contracts-specs/governance)
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-contracts-specs-precompiled-contracts.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/contracts-specs/precompiled-contracts.mdx`

Related issues (from issues.normalized.md):
- [ ] **1599. Clarify c7 index and GETPRECOMPILEDGAS status**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/precompiled-contracts.mdx?plain=1

Clarify that the 17th element (index 16) of c7 holds gas_usage and note that GETPRECOMPILEDGAS is currently reserved and returns null; when activated it will return the precompiled contract gas usage (link to tvm-upgrade-2024-04.mdx#c7 and #new-opcodes).

---

- [ ] **1600. Avoid hardcoded 1M gas limit**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/precompiled-contracts.mdx?plain=1

Replace “TVM runs with a 1M gas limit” with “TVM executes with the gas limits defined by the network configuration” and link to smart-contracts/limits.mdx#gas-and-fee-parameters and network/configs/blockchain-configs.mdx#param-20-and-21.

---

- [ ] **1601. Replace placeholder in Available implementations**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/precompiled-contracts.mdx?plain=1

Remove “Hic sunt dracones.” and replace the section content with a neutral note such as “No implementations are listed yet.”

---

- [ ] **1602. Capitalize MasterChain consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/precompiled-contracts.mdx?plain=1

Change “masterchain configuration” to “MasterChain configuration” to match terminology used in related configuration docs.

---

- [ ] **1603. Link cskip_no_gas to compute-phase docs**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/precompiled-contracts.mdx?plain=1

Link the term cskip_no_gas to docs/v3/documentation/tvm/tvm-overview.mdx#when-the-compute-phase-is-skipped for the canonical explanation of skip reasons.

---

- [ ] **1604. Link validator flag and mark experimental**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/precompiled-contracts.mdx?plain=1

Link --enable-precompiled-smc to docs/v3/documentation/infra/nodes/node-commands.mdx and append “(experimental)” to match the node commands reference.

---

- [ ] **1605. Add language tag to TL‑B code block**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/precompiled-contracts.mdx?plain=1

Add a code fence language tag (e.g., ```tlb) to the TL‑B snippet in the Config section for proper syntax highlighting.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.