### PR TITLE
Split: update docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx
+++ b/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx
@@ -1,11 +1,10 @@
 import Feedback from '@site/src/components/Feedback';
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+ 
 
 # Single nominator pool
 
-The [single nominator](https://github.com/ton-blockchain/single-nominator) contract is a security-focused smart contract that lets validators securely stake Toncoins without needing other participants. Designed for validators with sufficient self-stake, it keeps signing keys separate from staked funds using a cold wallet for maximum security. The contract provides an alternative simplified implementation for the [nominator pool](/v3/documentation/smart-contracts/contracts-specs/nominator-pool) smart contract that supports a single nominator only. The benefit of this implementation is that it's more secure since the attack surface is considerably smaller. This is due to a massive reduction in the complexity of the nominator pool that has to support multiple third-party nominators.
+The [single nominator](https://github.com/ton-blockchain/single-nominator) contract is a security-focused smart contract that lets validators securely stake Toncoin without needing other participants. Designed for validators with sufficient self-stake, it keeps signing keys separate from staked funds using a cold wallet for maximum security. The contract provides an alternative simplified implementation for the [nominator pool](/v3/documentation/smart-contracts/contracts-specs/nominator-pool) smart contract that supports a single nominator only. The benefit of this implementation is that it's more secure since the attack surface is considerably smaller. This is due to a massive reduction in the complexity of the nominator pool that has to support multiple third-party nominators.
 
 ## The go-to solution for validators
 
@@ -20,7 +19,7 @@ This smart contract is the recommended solution for TON validators with a suffic
    *Issues*: Unmaintained and susceptible to gas drainage attacks
 
 3. **Nominator pool**  
-   [Single-nominator setup](https://github.com/ton-blockchain/nominator-pool)  
+   [Nominator pool](https://github.com/ton-blockchain/nominator-pool)  
    *Drawback*: Unnecessary complexity for solo validators
 
 For a complete feature comparison, see:  
@@ -29,7 +28,7 @@ For a complete feature comparison, see:
 
 ## Official code hash
 
-Check this in https://verifier.ton.org before sending funds to a live contract.
+Verify this on [TON Verifier](https://verifier.ton.org) before sending funds to a live contract.
 
 Single nominator v1.0
 
@@ -45,14 +44,14 @@ zA05WJ6ywM/g/eKEVmV6O909lTlVrj+Y8lZkqzyQT70=
 
 ## Architecture
 
-The architecture is nearly identical to the [nominator pool](https://github.com/ton-blockchain/nominator-pool) contract:
+The architecture is nearly identical to the [nominator pool](/v3/documentation/smart-contracts/contracts-specs/nominator-pool) contract:
 
-![image](/img/nominator-pool/single-nominator-architecture.png)
+![Single‑nominator architecture diagram](/img/nominator-pool/single-nominator-architecture.png)
 
-### Separation to two roles
+### Separation into two roles
 
 - _Owner_ - cold wallet (private key that is not connected to the Internet) that owns the funds used for staking and acts as the single nominator
-- _Validator_ - the wallet whose private key is on the validator node (can sign blocks but can't steal the funds used for stake)
+- _Validator_ - the wallet whose private key is on the validator node (can sign blocks but can't steal the funds used for staking)
 
 ### Workflow
 
@@ -81,11 +80,11 @@ The architecture is nearly identical to the [nominator pool](https://github.com/
 
 - In an extreme emergency, _Owner_ can set the code of _SingleNominator_ and override its current logic to address unforeseen circumstances.
 
-The standard [nominator pool](https://github.com/ton-blockchain/nominator-pool) can't prevent all attack scenarios - a malicious validator operator could potentially steal from nominators. This risk doesn't exist with _SingleNominator_ since both the _Owner_ and _Validator_  are controlled by the same entity.
+The standard [nominator pool](https://github.com/ton-blockchain/nominator-pool) can't prevent all attack scenarios - a malicious validator operator could potentially steal from nominators. This risk doesn't exist with _SingleNominator_ since both the _Owner_ and _Validator_ are controlled by the same entity.
 
 ### Security audits
 
-Certik conducted a full security audit, which is available in this repo: [Certik audit](https://github.com/ton-blockchain/single-nominator/blob/main/certik-audit.pdf).
+CertiK conducted a full security audit, which is available in this repo: [CertiK audit](https://github.com/ton-blockchain/single-nominator/blob/main/certik-audit.pdf).
 
 ## Comparison of existing alternatives
 
@@ -93,9 +92,9 @@ Assuming that you are a validator with enough stake to validate independently, t
 
 ### 1. Simple hot wallet
 
-This basic setup connects MyTonCtrl directly to the [standard wallet](https://github.com/ton-blockchain/ton/blob/master/crypto/smartcont/wallet3-code.fc) holding your funds. Because this wallet remains internet-connected, it operates as a hot wallet.
+This basic setup connects MyTonCtrl directly to the [standard wallet](https://github.com/ton-blockchain/ton/blob/master/crypto/smartcont/wallet3-code.fc) holding your funds. Because this wallet remains Internet-connected, it operates as a hot wallet.
 
-![image](/img/nominator-pool/hot-wallet.png)
+![Hot wallet diagram](/img/nominator-pool/hot-wallet.png)
 
 This is insecure because an attacker can get the private key as soon as it's connected to the Internet. With the private key, the attacker can send the staking funds to anyone.
 
@@ -103,7 +102,7 @@ This is insecure because an attacker can get the private key as soon as it's con
 
 This setup replaces the standard wallet with a [restricted-wallet](https://github.com/EmelyanenkoK/nomination-contract/blob/master/restricted-wallet/wallet.fc) that allows outgoing transactions to be sent only to restricted destinations such as the _Elector_ and the owner's address.
 
-![image](/img/nominator-pool/restricted-wallet.png)
+![Restricted wallet diagram](/img/nominator-pool/restricted-wallet.png)
 
 The restricted wallet is unmaintained (replaced by nominator-pool) and has unresolved attack vectors like gas drainage attacks. Since the same wallet holds gas fees and the stake principal in the same balance, an attacker who compromises the private key can generate transactions that will cause significant principal losses. In addition, there's a race condition between the attacker and the owner when trying to withdraw due to seqno collisions.
 
@@ -111,7 +110,7 @@ The restricted wallet is unmaintained (replaced by nominator-pool) and has unres
 
 The [nominator-pool](https://github.com/ton-blockchain/nominator-pool) was the first to introduce a clear separation between the stake owners (nominators) and the validator connected to the Internet. This setup supports up to 40 nominators staking together on the same validator.
 
-![image](/img/nominator-pool/nominator-pool.png)
+![Nominator pool diagram](/img/nominator-pool/nominator-pool.png)
 
 The nominator pool contract is overly complex due to the support of 40 concurrent nominators. In addition, the contract has to protect the nominators from the contract deployer because those are separate entities. This setup is considered ok but is very difficult to audit in full due to the size of the attack surface. The solution makes sense mostly when the validator does not have enough stake to validate alone or wants to do a rev-share with third-party stakeholders.
 
@@ -119,17 +118,17 @@ The nominator pool contract is overly complex due to the support of 40 concurren
 
 This is the setup implemented in this repo. It's a very simplified version of the nominator pool that supports a single nominator. There is no need to protect this nominator from the contract deployer, as they are the same entity.
 
-![image](/img/nominator-pool/single-nominator-architecture.png)
+![Single‑nominator architecture diagram](/img/nominator-pool/single-nominator-architecture.png)
 
-If you have a single nominator who holds all stakes for validation, this is the most secure setup you can use. In addition to its simplicity, this contract provides the owner multiple emergency safeguards to recover stakes even in extreme scenarios like _Elector_ upgrades that break the recover stake interface.
+If you have a single nominator who holds all stakes for validation, this is the most secure setup you can use. In addition to its simplicity, this contract provides the owner with multiple emergency safeguards to recover stakes even in extreme scenarios like _Elector_ upgrades that break the RECOVER_STAKE interface.
 
-## Owner only messages
+## Owner-only messages
 
 The nominator owner can perform 4 operations:
 
-#### 1. Withdraw
-Used to withdraw funds to the owner's wallet. To withdraw the funds the owner should send a message with a body that includes: opcode=0x1000 (32 bits), query_id (64 bits) and withdraw amount (stored as coin variable). The nominator contract will send the funds with BOUNCEABLE flag and mode=64. <br/><br/>
-In case the owner is using a **hot wallet** (not recommended), [withdraw-deeplink.ts](https://github.com/ton-blockchain/single-nominator/blob/main/scripts/ts/withdraw-deeplink.ts) can be used to generate a deeplink to initiate a withdrawal from tonkeeper wallet. <br/>
+### 1. Withdraw
+Used to withdraw funds to the owner's wallet. To withdraw the funds the owner should send a message with a body that includes: `opcode=0x1000` (32 bits), `query_id` (64 bits) and `withdraw amount` (stored as a coin). The nominator contract will send the funds in bounceable mode (`mode=64`). <br/><br/>
+In case the owner is using a **hot wallet** (not recommended), [withdraw-deeplink.ts](https://github.com/ton-blockchain/single-nominator/blob/main/scripts/ts/withdraw-deeplink.ts) can be used to generate a deeplink to initiate a withdrawal from Tonkeeper wallet. <br/>
 
 Command line: `ts-node scripts/ts/withdraw-deeplink.ts single-nominator-addr withdraw-amount` where:
 
@@ -138,41 +137,41 @@ Command line: `ts-node scripts/ts/withdraw-deeplink.ts single-nominator-addr wit
 
 The owner should run the deeplink from a phone with the tonkeeper wallet.
 
-If the owner is using a **cold wallet** (recommended), [withdraw.fif](https://github.com/ton-blockchain/single-nominator/blob/main/scripts/fift/withdraw.fif) can be used to generate a boc body that includes the withdraw opcode and the amount to withdraw.
+If the owner is using a **cold wallet** (recommended), [withdraw.fif](https://github.com/ton-blockchain/single-nominator/blob/main/scripts/fift/withdraw.fif) can be used to generate a BOC body that includes the withdraw opcode and the amount to withdraw.
 
 Command line: `fift -s scripts/fif/withdraw.fif withdraw-amount` where withdraw-amount is the amount to withdraw from the nominator contract to the owner's wallet. As described above, the nominator contract will leave at least 1 TON in the contract.
 
-This script will generate a boc body (named withdraw.boc) that should be signed and sent from the owner's wallet.
+This script will generate a BOC body (named withdraw.boc) that should be signed and sent from the owner's wallet.
 
-From the black computer, the owner should run the following:
+From the offline (air‑gapped) computer, the owner should run the following:
 
-- create and sign the tx: `fift -s wallet-v3.fif my-wallet single_nominator_address sub_wallet_id seqno amount -B withdraw.boc` where my-wallet is the owner's pk file (without extension). The amount of 1 TON should be enough to pay fees (the remaining amount will be returned to the owner). The withdraw.boc is the boc generated above.
-- from a computer with access to the internet, run: `lite-client -C global.config.json -c 'sendfile wallet-query.boc'` to send the boc file (wallet-query.boc) generated in the previous step.
+- create and sign the tx: `fift -s wallet-v3.fif my-wallet single_nominator_address sub_wallet_id seqno amount -B withdraw.boc` where my-wallet is the owner's private key file (without extension). The amount of 1 TON should be enough to pay fees (the remaining amount will be returned to the owner). The withdraw.boc is the BOC generated above.
+- from a computer with access to the Internet, run: `lite-client -C global.config.json -c 'sendfile wallet-query.boc'` to send the BOC file (wallet-query.boc) generated in the previous step.
 
 ### 2. Change validator
 
-Used to change the validator address. The validator can only send NEW_STAKE and RECOVER_STAKE to the elector. If the validator's private key is compromised, the validator's address can be changed. The funds are safe in this case, as only the owner can withdraw them.
+Used to change the validator address. The validator can only send `NEW_STAKE` and `RECOVER_STAKE` to the elector. If the validator's private key is compromised, the validator's address can be changed. The funds are safe in this case, as only the owner can withdraw them.
 
 In case the owner is using a **hot wallet** (not recommended), [change-validator-deeplink.ts](https://github.com/ton-blockchain/single-nominator/blob/main/scripts/ts/change-validator-deeplink.ts) can be used to generate a deeplink to change the validator address.
 
 Command line: `ts-node scripts/ts/change-validator-deeplink.ts single-nominator-addr new-validator-address` where:
 
 - single-nominator-addr is the single nominator address.
-- new-validator-address (defaults to ZERO address) is the address of the new validator. If you want to disable the validator immediately and only later set a new validator, it might be convenient to set the validator address to the ZERO address.
+- new-validator-address (defaults to zero address) is the address of the new validator. If you want to disable the validator immediately and only later set a new validator, it might be convenient to set the validator address to the zero address.
 
-The owner should run the deeplink from a phone with a tonkeeper wallet.
+The owner should run the deeplink from a phone with a Tonkeeper wallet.
 
-If the owner is using a **cold wallet** (recommended), [change-validator.fif](https://github.com/ton-blockchain/single-nominator/blob/main/scripts/fift/change-validator.fif) can be used to generate a boc body that includes the change-validator opcode and the new validator address.
+If the owner is using a **cold wallet** (recommended), [change-validator.fif](https://github.com/ton-blockchain/single-nominator/blob/main/scripts/fift/change-validator.fif) can be used to generate a BOC body that includes the change-validator opcode and the new validator address.
 
 Command line: `fift -s scripts/fif/change-validator.fif new-validator-address`.
-This script will generate a boc body (change-validator.boc) that should be signed and sent from the owner's wallet.
+This script will generate a BOC body (change-validator.boc) that should be signed and sent from the owner's wallet.
 
-From the black computer, the owner should run the following:
+From the offline (air‑gapped) computer, the owner should run the following:
 
-- create and sign the tx: `fift -s wallet-v3.fif my-wallet single_nominator_address sub_wallet_id seqno amount -B change-validator.boc` where my-wallet is the owner's pk file (without extension). The amount of 1 TON should be enough to pay fees (the remaining amount will be returned to the owner). The change-validator.boc is the boc generated above.
-- from a computer with access to the internet, run: `lite-client -C global.config.json -c 'sendfile wallet-query.boc'` to send the boc file (wallet-query.boc) generated in the previous step.
+- create and sign the tx: `fift -s wallet-v3.fif my-wallet single_nominator_address sub_wallet_id seqno amount -B change-validator.boc` where my-wallet is the owner's private key file (without extension). The amount of 1 TON should be enough to pay fees (the remaining amount will be returned to the owner). The change-validator.boc is the BOC generated above.
+- from a computer with access to the Internet, run: `lite-client -C global.config.json -c 'sendfile wallet-query.boc'` to send the BOC file (wallet-query.boc) generated in the previous step.
 
-### 3. Send raw msg
+### 3. Send raw message
 
 This opcode is not expected to be used under normal conditions.
 
@@ -186,7 +185,7 @@ Use this opcode to recover funds from a changed Elector contract address where s
 
 ### 4. Upgrade
 
-This emergency opcode (0x9903) should only be used to upgrade the nominator contract in critical situations. The message must include:
+This emergency opcode (`0x9903`) should only be used to upgrade the nominator contract in critical situations. The message must include:
 - `opcode=0x9903` (32 bits)
 - `query_id` (64 bits)
 - New contract code cell reference
@@ -195,7 +194,6 @@ This emergency opcode (0x9903) should only be used to upgrade the nominator cont
 
 - [Single nominator pool](https://github.com/ton-blockchain/single-nominator)
 - [How to use single nominator pool](/v3/guidelines/smart-contracts/howto/single-nominator-pool)
-- [Orbs single nominator pool contract(legacy)](https://github.com/orbs-network/single-nominator)
+- [Orbs single nominator pool contract (legacy)](https://github.com/orbs-network/single-nominator)
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-contracts-specs-single-nominator-pool.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx`

Related issues (from issues.normalized.md):
- [ ] **1606. Remove unused MDX imports**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1#L3-L4

Tabs and TabItem are imported but never used; remove these imports to avoid confusion and reduce bundle size.

---

- [ ] **1607. Use 'Toncoin' as mass noun**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1#L8

Replace plural “Toncoins” with the mass noun “Toncoin” (or ticker “TON”); e.g., “stake Toncoin.”

---

- [ ] **1608. Fix link text to 'Nominator pool'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1#L22-L24

Change the link text “Single-nominator setup” to “Nominator pool” (or “Nominator pool repository”) to match the target repository and avoid confusion.

---

- [ ] **1609. Add descriptive alt text to images**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1#L50,L98,L106,L114,L122

Replace generic “image” alt texts with descriptive ones (e.g., “Single‑nominator architecture diagram,” “Hot wallet diagram,” “Restricted wallet diagram,” “Nominator pool diagram”) for accessibility.

---

- [ ] **1610. Fix heading to 'Separation into two roles'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1#L52

Change the subsection title from “Separation to two roles” to the idiomatic “Separation into two roles.”

---

- [ ] **1611. Remove double space before 'are'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1#L84

Replace the double space in “_Owner_ and _Validator_ are” with a single space.

---

- [ ] **1612. Correct brand casing 'CertiK'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1#L88

Change “Certik” to the proper brand casing “CertiK.”

---

- [ ] **1613. Standardize capitalization of 'Internet'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1#L96,L150,L173

Use capitalized “Internet” consistently (e.g., “Internet‑connected,” “access to the Internet”).

---

- [ ] **1614. Use 'OK' instead of 'ok'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1#L116

Change “ok” to “OK” (or “okay”) for stylistic consistency.

---

- [ ] **1615. Replace 'rev-share' with 'revenue share'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1#L116

Use the clearer term “revenue share” instead of “rev‑share.”

---

- [ ] **1616. Use precise name 'RECOVER_STAKE' in interface reference**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1#L124

Change “break the recover stake interface” to “break the RECOVER_STAKE interface” for precision and consistency.

---

- [ ] **1617. Hyphenate 'Owner-only messages'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1#L126

Update the heading to the correctly hyphenated “Owner‑only messages.”

---

- [ ] **1618. Add comma after introductory clause**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1#L131

Insert a comma after the introductory clause: “To withdraw the funds, the owner should send a message…”.

---

- [ ] **1619. Format withdraw message fields as code**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1#L131

Wrap technical tokens in code style for consistency: `opcode=0x1000`, `query_id`, and the “withdraw amount” field (coin value).

---

- [ ] **1620. Capitalize 'Tonkeeper'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1#L132,L139,L163

Change “tonkeeper” to “Tonkeeper” in all occurrences.

---

- [ ] **1621. Use uppercase 'BOC' for data format**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1#L141,L145,L149,L165,L168,L172

Refer to the data format as “BOC” (e.g., “BOC body,” “BOC file”), keeping the filename extension as .boc.

---

- [ ] **1622. Replace 'black computer' with 'offline (air‑gapped) computer'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1#L147,L170

Use a clear term like “offline (air‑gapped) computer” instead of the ambiguous “black computer.”

---

- [ ] **1623. Expand 'pk file' to 'private key file'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1#L149,L172

Clarify “pk file” as “private key file,” e.g., “where `my-wallet` is the owner’s private key file (without extension).”

---

- [ ] **1624. Standardize 'Elector' styling**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1#L154,L181

Use a consistent style for the Elector contract (e.g., italicized “_Elector_”) to match earlier usage on this page.

---

- [ ] **1625. Expand heading to 'Send raw message'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1#L175

Change the heading “Send raw msg” to “Send raw message” for clarity and consistency.

---

- [ ] **1626. Wrap opcode value in code**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1#L189

Format the opcode value as code: change “(0x9903)” to “(`0x9903`).”

---

- [ ] **1627. Add space before '(legacy)'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1#L198

Insert a space in the link text: “Orbs single nominator pool contract (legacy).”

---

- [ ] **1628. Fix heading level for 'Withdraw'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1

Change “1. Withdraw” from an H4 (####) to an H3 (###) to align with sibling subsections.

---

- [ ] **1629. Use 'bounceable mode' and format mode value**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1

In the withdraw description, say “bounceable mode (`mode=64`)” instead of “BOUNCEABLE flag and mode=64,” and wrap the mode in code.

---

- [ ] **1630. Lowercase 'zero address'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1

Change “ZERO address” to “zero address” for capitalization consistency across docs.

---

- [ ] **1631. Use 'used for staking' phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1

Change “funds used for stake” to “funds used for staking” for proper wording.

---

- [ ] **1632. Add 'with' after 'provides the owner'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1

Fix grammar to “provides the owner with multiple emergency safeguards…”.

---

- [ ] **1633. Replace bare URL with 'TON Verifier' link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1

Replace the raw URL with a titled link and clearer phrasing, e.g., “Verify this on [TON Verifier](https://verifier.ton.org).”

---

- [ ] **1634. Link to internal nominator pool spec**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1

In the Architecture section, link to the internal spec page (/v3/documentation/smart-contracts/contracts-specs/nominator-pool) instead of the GitHub repository for consistency.

---

- [ ] **1635. Format op names as code in 'Change validator'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool.mdx?plain=1

Wrap operation names in code formatting: `NEW_STAKE` and `RECOVER_STAKE` when referring to messages sent to the Elector.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.