### PR TITLE
Split: update docs/v3/documentation/smart-contracts/contracts-specs/vesting-contract.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/contracts-specs/vesting-contract.mdx
+++ b/docs/v3/documentation/smart-contracts/contracts-specs/vesting-contract.mdx
@@ -2,7 +2,7 @@ import Feedback from '@site/src/components/Feedback';
 
 # Vesting contract
 
-The vesting contract is a smart contract implementation on the TON blockchain, enabling secure, scheduled distribution of Toncoin assets. This contract provides a robust framework for token management, ensuring the controlled release of funds based on predetermined schedules and conditions.
+The vesting contract is a smart contract implementation on the TON Blockchain, enabling secure, scheduled distribution of Toncoin assets. This contract provides a robust framework for token management, ensuring the controlled release of funds based on predetermined schedules and conditions.
 
 ## Core functionality
 
@@ -12,17 +12,17 @@ The contract is a secure escrow service that locks a specified amount of Toncoin
 
 During deployment, the system establishes the following parameters, which cannot be changed and remain fixed throughout the entire duration of the contract:
 
-| Parameter                | Description                                     | Example values       |
-| ------------------------ | ----------------------------------------------- | -------------------- |
-| `vesting_total_amount`   | Total locked Toncoins (in nanotons)             | 500 TON              |
-| `vesting_start_time`     | Unix timestamp marking vesting period beginning | Current time + delay |
+| Parameter                | Description                                     | Example values                         |
+| ------------------------ | ----------------------------------------------- | -------------------------------------- |
+| `vesting_total_amount`   | Total locked Toncoin (in nanotons)              | 500,000,000,000 nanotons (500 TON)     |
+| `vesting_start_time`     | Unix timestamp marking the start of the vesting period | Current time + delay             |
 | `vesting_total_duration` | Total vesting period duration (seconds)         | 31104000 (one year)  |
 | `unlock_period`          | Time interval between releases (seconds)        | 2592000 (monthly)    |
 | `cliff_duration`         | Initial lock period before first release        | 5184000 (two months) |
 | `vesting_sender_address` | Authorized address for locked funds management  | Configurable         |
 | `owner_address`          | Beneficiary address for Toncoin distribution    | Configurable         |
 
-You can acquire these specific parameters using the `get_vesting_data()` method.
+You can retrieve these specific parameters using the `get_vesting_data()` method.
 
 The parameters must satisfy these conditions:
 
@@ -37,29 +37,29 @@ vesting_total_duration mod unlock_period == 0
 cliff_duration mod unlock_period == 0
 ```
 
-Before sending Toncoins to the deployed smart contract, users can verify parameter compliance using the get method, even though the contract itself does not perform these checks.
+Before sending Toncoin to the deployed smart contract, users can verify parameter compliance using a get-method such as `get_vesting_data()`, even though the contract itself does not perform these checks.
 
 ## Lock mechanism
 
 Before `vesting_start_time`, the contract locks the entire `vesting_total_amount`.
 
-Starting at `vesting_start_time`, it unlocks the amount proportionately. For example, if the `vesting_total_duration` is 10 months, the `unlock_period` is 1 month, and the `vesting_total_amount` is 500 TON, then the contract unlocks 50 TON (500 \* 10/100) each month, fully releasing all 500 TON in 10 months.
+Starting at `vesting_start_time`, it unlocks the amount proportionately. For example, if the `vesting_total_duration` is 10 months, the `unlock_period` is 1 month, and the `vesting_total_amount` is 500 TON, then the contract unlocks 50 TON (500 / 10 = 50) each month, fully releasing all 500 TON in 10 months.
 
-If a cliff period exists, no amount unlocks during that time. Once the cliff period ends, the contract unlocking according to the same formula. For instance, with a `cliff_period` of 3 months, the contract unlocks nothing in the first 3 months, then unlocks 150 TON at once, followed by 50 TON each month thereafter.
+If a cliff period exists, no amount unlocks during that time. Once the cliff period ends, the contract unlocks according to the same formula. For instance, with a `cliff_duration` of 3 months, the contract unlocks nothing in the first 3 months, then unlocks 150 TON at once, followed by 50 TON each month thereafter.
 
-You can use the `get_locked_amount(int at_time)` method to calculate how much will be locked at a specific time. The contract allows you to transfer locked Toncoins only to whitelisted addresses or the `vesting_sender_address`. Once unlocked, you can freely send the Toncoins wherever you like.
+You can use the `get_locked_amount(int at_time)` method to calculate how much will be locked at a specific time. The contract allows you to transfer locked Toncoin only to whitelisted addresses or the `vesting_sender_address`. Once unlocked, you can freely send the Toncoin wherever you like.
 
 ## Whitelist
 
-A whitelist contains addresses to which you can send Toncoins, even if the coins remain locked.
+A whitelist contains addresses to which you can send Toncoin, even if the coins remain locked.
 
-The `get_whitelist()` method retrieves all whitelist addresses as a list of (wc, hash_part) tuples. You can use the `is_whitelisted(slice address)` method to check if a specific address is on the whitelist.
+The `get_whitelist()` method retrieves all whitelist addresses as a list of (workchain_id, hash_part) tuples. You can use the `is_whitelisted(slice address)` method to check if a specific address is on the whitelist.
 
 The `vesting_sender_address` can add new addresses to the whitelist at any time using the `op::add_whitelist` message, but no addresses can be removed from the whitelist. You can always send locked coins to the `vesting_sender_address` without adding it to the whitelist.
 
 ## Top-up
 
-You can send Toncoins to the vesting contract from any address.
+You can send Toncoin to the vesting contract from any address.
 
 ## Wallet smart contract
 
@@ -69,9 +69,7 @@ The contract maintains `seqno`, `subwallet_id`, and `public_key`, accepts extern
 
 ## Send
 
-The public key owner can initiate the sending of Toncoins from the vesting contract by an external message, just like in standard wallets.
-
-The owner initiates Toncoin transfers by sending an `op::send` internal message from their owner address. In typical usage, the same user owns both the public key and the `owner address`.
+The public key owner initiates the sending of Toncoin from the vesting contract by an external message, just like in standard wallets.
 
 ## Whitelist restrictions
 
@@ -109,7 +107,7 @@ Other whitelisted destinations permit:
   - `op::vote_for_proposal`
   - `op::vote_for_complaint`
 
-Addresses outside the whitelist operate without restrictions. Unlocked Toncoins remain unrestricted regardless of destination, including whitelisted addresses and `vesting_sender_address`.
+Addresses outside the whitelist operate without restrictions. Unlocked Toncoin remains unrestricted regardless of destination, including whitelisted addresses and `vesting_sender_address`.
 
 ## Project structure
 
@@ -150,4 +148,3 @@ npx blueprint create ContractName` or `yarn blueprint create ContractName`
 - [vesting-contract](https://github.com/ton-blockchain/vesting-contract)
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-contracts-specs-vesting-contract.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/contracts-specs/vesting-contract.mdx`

Related issues (from issues.normalized.md):
- [ ] **1636. Align units for vesting_total_amount example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/vesting-contract.mdx?plain=1

The table states amounts are in nanotons but the example shows "500 TON"; change the example to "500,000,000,000 nanotons (500 TON)" to match the stated units.

---

- [ ] **1637. Use cliff_duration consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/vesting-contract.mdx?plain=1

Replace code-styled references to `cliff_period` with `cliff_duration`; use plain-text "cliff period" only in prose if needed.

---

- [ ] **1638. Fix grammar: "contract unlocking" → "contract unlocks"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/vesting-contract.mdx?plain=1

Change "Once the cliff period ends, the contract unlocking according to the same formula." to "Once the cliff period ends, the contract unlocks according to the same formula."

---

- [ ] **1639. Clarify unlock math in example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/vesting-contract.mdx?plain=1

Replace the parenthetical "(500 * 10/100)" with "500 / 10 = 50" to clearly show the total divided by the number of periods.

---

- [ ] **1640. Resolve external vs internal message contradiction**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/vesting-contract.mdx?plain=1

Choose a single initiation mechanism and update both sentences consistently—either state that sending is initiated by an external message signed by the owner’s key, or that the owner sends an `op::send` internal message from `owner_address`.

---

- [ ] **1641. Fix malformed command code blocks**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/vesting-contract.mdx?plain=1

Remove stray inline backticks and place each command on separate lines within a bash fence (e.g., "npx blueprint build", then "# or", then "yarn blueprint build"); apply the same pattern to Build, Test, Deploy/Run, and Add a new contract.

---

- [ ] **1642. Clarify vesting start timestamp phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/vesting-contract.mdx?plain=1

Replace "Unix timestamp marking vesting period beginning" with "Unix timestamp marking the start of the vesting period".

---

- [ ] **1643. Standardize Toncoin vs TON usage**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/vesting-contract.mdx?plain=1

Use the brand name "Toncoin" in prose and the ticker "TON" for numeric amounts; replace plural "Toncoins" where "TON" with numerals is clearer.

---

- [ ] **1644. Correct 2^32 seconds ≈ years**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/vesting-contract.mdx?plain=1

Change "135 years (2^32 seconds)" to "≈136 years (2^32 seconds)" to match the correct approximation.

---

- [ ] **1645. Use `owner_address` consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/vesting-contract.mdx?plain=1

Replace "owner address" with inline code `owner_address` wherever referring to the parameter/field.

---

- [ ] **1646. Specify the get-method by name**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/vesting-contract.mdx?plain=1

Replace "using the get method" with "using a get-method such as `get_vesting_data()`" to remove ambiguity.

---

- [ ] **1647. Use "retrieve" for get-methods**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/vesting-contract.mdx?plain=1

Change "You can acquire these specific parameters..." to "You can retrieve these specific parameters..." for clearer terminology.

---

- [ ] **1648. Clarify `wc` as `workchain_id`**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/vesting-contract.mdx?plain=1

In the `get_whitelist()` description, use `workchain_id` instead of `wc`, or explicitly state that `wc` means `workchain_id`.

---

- [ ] **1649. Clarify whitelist scope for unlocked transfers**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/vesting-contract.mdx?plain=1

Qualify the statement to "For unlocked transfers, addresses outside the whitelist operate without restrictions" to avoid contradicting the rule for locked Toncoin.

---

- [ ] **1650. Capitalize "TON Blockchain"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/vesting-contract.mdx?plain=1

Change "TON blockchain" to "TON Blockchain" for consistency across the documentation.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.