### PR TITLE
Split: update docs/v3/documentation/smart-contracts/fift/fift-and-tvm-assembly.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/fift/fift-and-tvm-assembly.mdx
+++ b/docs/v3/documentation/smart-contracts/fift/fift-and-tvm-assembly.mdx
@@ -6,9 +6,9 @@ Fift is a stack-based programming language with TON-specific features that can w
 
 ## Key differences
 
-Fift executes at **compile-time** - when your compiler builds the smart contract code BOC after processing FunC code. Fift can appear in different forms:
+Fift executes at **compile-time** - when your compiler builds the smart contract code bag of cells (BoC) after processing FunC code. Fift can appear in different forms:
 
-```
+```fift
 // Tuple primitives
 x{6F0} @Defop(4u) TUPLE
 x{6F00} @Defop NIL
@@ -17,7 +17,7 @@ x{6F02} dup @Defop PAIR @Defop CONS
 ```
 > TVM opcode definitions in Asm.fif
 
-```
+```fift
 "Asm.fif" include
 <{ SETCP0 DUP IFNOTRET // Return if recv_internal
    DUP 85143 INT EQUAL OVER 78748 INT EQUAL OR IFJMP:<{ // "seqno" and "get_public_key" get-methods
@@ -49,15 +49,15 @@ The last code fragment resembles TVM assembly because most of it actually is TVM
 
 Imagine explaining programming concepts to a trainee. Your instructions become part of their program, processed twice - similar to how opcodes in capital letters (SETCP0, DUP, etc.) are processed by both Fift and TVM.
 
-Think of Fift as a teaching language where you can introduce high-level concepts to a learner. Just as a trainee programmer gradually absorbs and applies new concepts, Fift allows you to define custom commands and abstractions. The Asm[Tests].fif file demonstrates this perfectly - it's essentially a collection of TVM opcode definitions.
+Think of Fift as a teaching language where you can introduce high-level concepts to a learner. Just as a trainee programmer gradually absorbs and applies new concepts, Fift allows you to define custom commands and abstractions. The Asm.fif file demonstrates this perfectly - it's essentially a collection of TVM opcode definitions.
 
 TVM assembly, in contrast, is like the trainee's final working program. While it operates with fewer built-in features (it can't perform cryptographic signing, for instance), it has direct access to the blockchain environment during contract execution. Where Fift works at compile-time to shape the contract's code, TVM assembly runs that code on the actual blockchain.
 
 ## Smart contract usage
 
-### [Fift] including large BoCs in contracts
+### [Fift] including a large BoC in contracts
 
-When using `toncli`, you can include large BoCs by:
+When using `toncli`, you can include a large BoC by:
 
 1. Editing `project.yaml` to include `fift/blob.fif`:
 ```yaml
@@ -71,12 +71,12 @@ contract:
 2. Adding the BoC to `fift/blob.boc`
 
 3. Including this code in `fift/blob.fif`:
-```
+```fift
 <b 8 4 u, 8 4 u, "fift/blob.boc" file>B B>boc ref, b> <s @Defop LDBLOB
 ```
 
 Now you can access the blob in your contract:
-```
+```func
 cell load_blob() asm "LDBLOB";
 
 () recv_internal() {
@@ -88,7 +88,7 @@ cell load_blob() asm "LDBLOB";
 
 Fift primitives can't convert integers to strings at runtime because Fift operates at compile-time. For runtime conversion, use TVM assembly like this solution from TON Smart Challenge 3:
 
-```
+```func
 tuple digitize_number(int value)
   asm "NIL WHILE:<{ OVER }>DO<{ SWAP TEN DIVMOD s1 s2 XCHG TPUSH }> NIP";
 
@@ -110,7 +110,7 @@ builder store_signed(builder msg, int v) inline_ref {
 
 Compare these implementations:
 
-```
+```func
 int mul_mod(int a, int b, int m) inline_ref {               ;; 1232 gas units
   (_, int r) = muldivmod(a % m, b % m, m);
   return r;
@@ -122,6 +122,5 @@ int mul_mod_better(int a, int b, int m) inline_ref {        ;; 1110 gas units
 int mul_mod_best(int a, int b, int m) asm "x{A988} s,";     ;; 65 gas units
 ```
 
-The `x{A988}` opcode implements an optimized division operation with built-in multiplication (as specified in [section 5.2 Division](/v3/documentation/tvm/instructions#A988)). This specialized instruction directly computes just the modulo remainder of the operation, skipping unnecessary computation steps. The `s,` suffix then handles the result storage - it takes the resulting slice from the stack's top and efficiently writes it into the target builder. Together, this combination delivers substantial gas savings compared to conventional approaches.
+The `x{A988}` opcode implements an optimized division operation with built-in multiplication (as specified in [TVM instructions](/v3/documentation/tvm/tvm-overview#tvm-instructions)). This specialized instruction directly computes just the modulo remainder of the operation, skipping unnecessary computation steps. The `s,` suffix then handles the result storage - it takes the resulting slice from the stack's top and efficiently writes it into the target builder. Together, this combination delivers substantial gas savings compared to conventional approaches.
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-fift-fift-and-tvm-assembly.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/fift/fift-and-tvm-assembly.mdx`

Related issues (from issues.normalized.md):
- [ ] **1667. Fix broken TVM instructions link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/fift/fift-and-tvm-assembly.mdx?plain=1

Update the “section 5.2 Division” link from /v3/documentation/tvm/instructions#A988 (non-existent) to /v3/documentation/tvm/tvm-overview#tvm-instructions and drop the #A988 anchor.

---

- [ ] **1668. Standardize BoC terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/fift/fift-and-tvm-assembly.mdx?plain=1

Introduce “bag‑of‑cells (BoC)” once and thereafter use “BoC” consistently; replace instances of “BOC” and “BoCs”.

---

- [ ] **1669. Add language tags to code blocks**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/fift/fift-and-tvm-assembly.mdx?plain=1

Tag Fift snippets as ```fift (e.g., “Tuple primitives”, `"Asm.fif" include …`, `fift/blob.fif`) and FunC with inline asm as ```func (e.g., `cell load_blob() … recv_internal() { … }`, integer‑to‑string helpers, `mul_mod*`) to improve syntax highlighting.

---

- [ ] **1670. Clarify file name “Asm[Tests].fif”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/fift/fift-and-tvm-assembly.mdx?plain=1

Replace “Asm[Tests].fif” with “Asm.fif” or explicitly mention both files if both are intended to avoid ambiguity.

---

- [ ] **1671. Clarify Fift’s role and integer‑to‑string rationale**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/fift/fift-and-tvm-assembly.mdx?plain=1

Rephrase “Fift executes at compile‑time …” to “In the compilation pipeline, Fift is used to produce the contract BoC from TVM assembly and can also be used interactively off‑chain,” and clarify that on‑chain integer‑to‑string conversions must use TVM/FunC (Fift does not run on‑chain).

---

- [ ] **1672. Explain or replace raw mode value 160**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/fift/fift-and-tvm-assembly.mdx?plain=1

Replace send_raw_message(load_blob(), 160) with named flags per stdlib (128 + 32 = carry all remaining balance + destroy if zero) or add a brief note explaining 160 = 128 + 32; consider using mode = 3 for a safer general example.

---

- [ ] **1673. Use @addop instead of s, and fix example typing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/fift/fift-and-tvm-assembly.mdx?plain=1

Change asm "x{A988} s," to x{A988} @addop, streamline the explanation (avoid deep internals of s,) and ensure the example’s return type matches the builder operation (or adjust the example accordingly).

---

- [ ] **1674. Soften claim about cryptographic signing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/fift/fift-and-tvm-assembly.mdx?plain=1

Replace “can’t perform cryptographic signing” with a precise statement such as “TVM offers signature verification (e.g., CHKSIGNU); signing is performed off‑chain by clients/tools,” or add an intra‑doc reference clarifying this.

---

- [ ] **1675. Add reproducible reference for toncli project.yaml**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/fift/fift-and-tvm-assembly.mdx?plain=1

Note that the project.yaml setup is tool‑specific and link to a stable source (e.g., https://github.com/disintar/toncli) so readers can reproduce the configuration.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.