### PR TITLE
Split: update docs/v3/documentation/smart-contracts/fift/overview.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/fift/overview.mdx
+++ b/docs/v3/documentation/smart-contracts/fift/overview.mdx
@@ -4,19 +4,27 @@ import Button from "@site/src/components/button";
 
 # Overview
 
-Fift is a stack-based language specifically designed for developing, debugging, and managing TON Blockchain smart contracts.
+Fift is a stack-based programming language specifically designed for developing, debugging, and managing TON Blockchain smart contracts. It provides optimized interaction with:
 
-Here is a simple Hello World example written in Fift:
+- TON Virtual Machine (TVM)
+- TON Blockchain infrastructure
+
 ```fift
 { ."hello " } execute ."world"
 hello world ok
 ```
 
-While most smart contract development cases don't require Fift, it becomes essential for:
+:::info
+While most smart contract development doesn't require Fift, it becomes essential for:
+
 - Solving unique technical challenges
 - Low-level TVM interactions
 - Advanced contract debugging
 
+**Recommended resources**:
+
+- [TVM retracer](https://retracer.ton.org/)
+:::
 
 <Button
   href="https://blog.ton.org/introduction-to-fift"
@@ -26,23 +34,33 @@ While most smart contract development cases don't require Fift, it becomes essen
   Introduction To Fift
 </Button>
 
+<Button
+  href="https://www.youtube.com/watch?v=HVsveTmVowc&list=PLtUBO1QNEKwttRsAs9eacL2oCMOhWaOZs"
+  colorType="secondary"
+  sizeType={"sm"}
+>
+  His majesty Fift
+</Button>
+
+
+
 ## Documentation
 
-- [Fift: A Brief Introduction](https://ton.org/fiftbase.pdf) by Nikolai Durov
-- [TON Virtual Machine](/v3/documentation/tvm/tvm-overview)
-- [Deep dive](/v3/documentation/smart-contracts/fift/fift-deep-dive)
-- [Difference between Fift and TVM assembly](/v3/documentation/smart-contracts/fift/fift-and-tvm-assembly)
+- [Fift: A Brief Introduction](https://docs.ton.org/fiftbase.pdf)
+- [TON Virtual Machine](/v3/documentation/tvm/tvm-overview/)
+
+## Examples
+
+- [Fift smart contract examples](/v3/documentation/smart-contracts/contracts-specs/examples/#fift-smart-contracts)
 
 ## Tutorials
 
-- [His majesty Fift](https://www.youtube.com/playlist?list=PLyDBPwv9EPsCYG-hR4N5FRTKUkfM8POgh) (Russian version only)
+- [Introduction To Fift](https://blog.ton.org/introduction-to-fift)
+- [His majesty Fift](https://www.youtube.com/watch?v=HVsveTmVowc&list=PLtUBO1QNEKwttRsAs9eacL2oCMOhWaOZs) — _@MarcoDaTr0p0je_
+  - [Russian version](https://www.youtube.com/playlist?list=PLyDBPwv9EPsCYG-hR4N5FRTKUkfM8POgh) — _@WikiMar_
 
-## Smart contract examples
-Follow [this link](/v3/documentation/smart-contracts/contracts-specs/examples#fift-smart-contracts) to find various standard smart contracts and examples from the community.
+## Source code
 
-## Recommended resources
-
-- [TVM Retracer](https://retracer.ton.org/)
+- [Standard smart contracts in Fift](https://github.com/ton-blockchain/ton/tree/master/crypto/smartcont)
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-fift-overview.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/fift/overview.mdx`

Related issues (from issues.normalized.md):
### overview (r1) — run_20250828_142245_60d34168

- [ ] **4318. Internal links missing trailing slash**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/fift/overview.mdx?plain=1

Internal links should include a trailing slash to avoid redirects and keep links consistent. Update: - `/v3/documentation/tvm/tvm-overview` → `/v3/documentation/tvm/tvm-overview/` - `/v3/documentation/smart-contracts/contracts-specs/examples#fift-smart-contracts` → `/v3/documentation/smart-contracts/contracts-specs/examples/#fift-smart-contracts` Reference: docs/v3/contribute/content-standardization.mdx#linking-to-internal-pages ("Set a trailing slash to all links").

---

- [ ] **4319. Fift PDF uses non-canonical domain**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/fift/overview.mdx?plain=1

The “Fift: A Brief Introduction” link points to `https://ton.org/fiftbase.pdf`, while the whitepapers page uses `https://docs.ton.org/fiftbase.pdf`. Align to the latter for consistency across docs. Change: - `https://ton.org/fiftbase.pdf` → `https://docs.ton.org/fiftbase.pdf` Reference: docs/v3/documentation/whitepapers/overview.mdx (“Fift Documentation”).

---

- [ ] **4320. Author attribution formatting and handle casing are inconsistent**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/fift/overview.mdx?plain=1

The line `created - _@MarcoDaTr0p0je & @Wikimar_` does not follow the project’s author citation style and uses `@Wikimar` (lowercase “m”), which differs from usage elsewhere (`@WikiMar`). Use the standard author citation style (link — _Author_) by removing the standalone “created” line and attributing authors after the corresponding links: - `- [His majesty Fift](…youtube playlist…) — _@MarcoDaTr0p0je_` - `- [Russian version](…playlist…) — _@WikiMar_` References: - Formatting guidance: docs/v3/contribute/content-standardization.mdx#article-authors. - Handle casing consistency: docs/v3/documentation/smart-contracts/overview.mdx (RU version references `@WikiMar`).

---

- [ ] **4321. Inconsistent casing for “TVM retracer”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/fift/overview.mdx?plain=1

This page uses “TVM Retracer” (capital “R”), while the TVM overview uses “TVM retracer”. For terminology consistency within the docs, use “TVM retracer” here as well. Change the link label to “TVM retracer”. This is a terminology consistency decision. Reference: docs/v3/documentation/tvm/tvm-overview.mdx (tip section lists “TVM retracer”).

---

- [ ] **4322. Non-semantic spacing with `<br></br>`**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/fift/overview.mdx?plain=1

Two consecutive `<br></br>` are used for vertical spacing between buttons and the next section. Remove these and rely on normal Markdown spacing for better semantic structure and accessibility. This is based on general HTML semantics best practices (line breaks should not be used for layout spacing).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.