### PR TITLE
Split: update docs/v3/documentation/smart-contracts/func/changelog.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/func/changelog.mdx
+++ b/docs/v3/documentation/smart-contracts/func/changelog.mdx
@@ -1,6 +1,6 @@
 import Feedback from '@site/src/components/Feedback';
 
-# History of FunC 
+# History of FunC
 
 ## Initial version
 The initial version of FunC was developed by Telegram, but active development stopped after May 2020.
@@ -10,10 +10,10 @@ We refer to the May 2020 release as the "initial" version.
 Released in [May 2022](https://github.com/ton-blockchain/ton/releases/tag/v2022.05/).
 
 **New features:**
-- [Constants](/v3/documentation/smart-contracts/func/docs/literals_identifiers#constants/)
-- [Extended string literals](/v3/documentation/smart-contracts/func/docs/literals_identifiers#string-literals/)
-- [Semver pragmas](/v3/documentation/smart-contracts/func/docs/compiler_directives#pragma-version/)
-- [Includes](/v3/documentation/smart-contracts/func/docs/compiler_directives#pragma-version/)
+- [Constants](/v3/documentation/smart-contracts/func/docs/literals_identifiers#constants).
+- [Extended string literals](/v3/documentation/smart-contracts/func/docs/literals_identifiers#string-literals).
+- [semver pragmas](/v3/documentation/smart-contracts/func/docs/compiler_directives#pragma-version).
+- [Includes](/v3/documentation/smart-contracts/func/docs/compiler_directives#include).
 
 **Fixes:**
 - Resolved rare bugs in `Asm.fif`.
@@ -29,7 +29,7 @@ Released in [Aug 2022](https://github.com/ton-blockchain/ton/releases/tag/v2022.
 - FunC incorrectly handles `while(false)` loops [(#377)](https://github.com/ton-blockchain/ton/issues/377/).
 - FunC generates incorrect code for `if/else` branches [(#374)](https://github.com/ton-blockchain/ton/issues/374/).
 - FunC incorrectly returns from conditions in inline functions [(#370)](https://github.com/ton-blockchain/ton/issues/370/).
-- `Asm.fif`: splitting large function bodies incorrectly interferes with inline [(#375)](https://github.com/ton-blockchain/ton/issues/375/).
+- `Asm.fif`: splitting large function bodies incorrectly interferes with inlining [(#375)](https://github.com/ton-blockchain/ton/issues/375/).
 
 
 
@@ -51,10 +51,9 @@ Released in [Jan 2023](https://github.com/ton-blockchain/ton/releases/tag/v2023.
 
 
 **Fixes:**
-- Disallowed ambiguous modification of local variables after their usage in the same expression. For example, `var x = (ds, ds~load_uint(32), ds~load_unit(64));` is forbidden, while `var x = (ds~load_uint(32), ds~load_unit(64), ds);` is allowed. 
+- Disallowed ambiguous modification of local variables after their usage in the same expression. For example, `var x = (ds, ds~load_uint(32), ds~load_uint(64));` is forbidden, while `var x = (ds~load_uint(32), ds~load_uint(64), ds);` is allowed. 
 - Allowed empty inline functions.
 - Fixed a rare optimization bug in `while` loops.
 
 
 <Feedback />
-

--- a/docs/v3/documentation/smart-contracts/func/changelog.mdx
+++ b/docs/v3/documentation/smart-contracts/func/changelog.mdx
@@ -12,7 +12,7 @@ Released in [May 2022](https://github.com/ton-blockchain/ton/releases/tag/v2022.
 **New features:**
 - [Constants](/v3/documentation/smart-contracts/func/docs/literals_identifiers#constants).
 - [Extended string literals](/v3/documentation/smart-contracts/func/docs/literals_identifiers#string-literals).
-- [semver pragmas](/v3/documentation/smart-contracts/func/docs/compiler_directives#pragma-version).
+- [Semver pragmas](/v3/documentation/smart-contracts/func/docs/compiler_directives#pragma-version).
 - [Includes](/v3/documentation/smart-contracts/func/docs/compiler_directives#include).
 
 **Fixes:**


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-func-changelog.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/func/changelog.mdx`

Related issues (from issues.normalized.md):
- [x] **1698. Remove trailing space in H1 heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/changelog.mdx?plain=1#L3

The H1 title has a trailing space; remove it so the line reads exactly "# History of FunC".

---

- [x] **1699. Make bullet punctuation consistent**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/changelog.mdx?plain=1#L12-L16, L48-L50

Add terminal periods to these bullet items to match the punctuation style used elsewhere in the list.

---

- [x] **1700. Remove trailing slash from "Constants" link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/changelog.mdx?plain=1#L13

The link fragment ends with a slash; change /v3/documentation/smart-contracts/func/docs/literals_identifiers#constants/ to /v3/documentation/smart-contracts/func/docs/literals_identifiers#constants.

---

- [x] **1701. Remove trailing slash from "Extended string literals" link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/changelog.mdx?plain=1#L14

The link fragment ends with a slash; change /v3/documentation/smart-contracts/func/docs/literals_identifiers#string-literals/ to /v3/documentation/smart-contracts/func/docs/literals_identifiers#string-literals.

---

- [x] **1702. Remove trailing slash from "Semver pragmas" link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/changelog.mdx?plain=1#L15

The link fragment ends with a slash; change /v3/documentation/smart-contracts/func/docs/compiler_directives#pragma-version/ to /v3/documentation/smart-contracts/func/docs/compiler_directives#pragma-version.

---

- [x] **1703. Use lowercase "semver" in link text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/changelog.mdx?plain=1#L15

Change the visible text "Semver pragmas" to "semver pragmas" for terminology consistency.

---

- [x] **1704. Point "Includes" link to #include**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/changelog.mdx?plain=1#L16

The link targets the wrong section; update it to /v3/documentation/smart-contracts/func/docs/compiler_directives#include (no trailing slash).

---

- [x] **1705. Change "interferes with inline" to "inlining"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/changelog.mdx?plain=1#L32

Improve grammar by replacing "interferes with inline" with "interferes with inlining".

---

- [x] **1706. Replace load_unit with load_uint in example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/changelog.mdx?plain=1#L54

In the example under Version 0.4.0, replace both instances of ds~load_unit(64) with ds~load_uint(64).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.