### PR TITLE
Split: update docs/v3/documentation/smart-contracts/func/cookbook.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/func/cookbook.mdx
+++ b/docs/v3/documentation/smart-contracts/func/cookbook.mdx
@@ -1,22 +1,20 @@
 import Feedback from '@site/src/components/Feedback';
 
-# Cookbook
+# FunC cookbook
 The FunC cookbook was created to consolidate all the knowledge and best practices from experienced FunC developers in one place. The goal is to make it easier for future developers to build smart contracts efficiently.
 
-Unlike the [FunC documentation](/v3/documentation/smart-contracts/func/docs/types), this guide focuses on solving everyday challenges that FunC developers encounter during smart contract development.
+Unlike the official [FunC documentation](/v3/documentation/smart-contracts/func/docs/types), this guide focuses on solving everyday challenges that FunC developers encounter during smart contract development.
 
 ## Basics
 
 ### How to write an if statement
-
-Let's say we want to check if any event is relevant. To do this, we use the flag variable. Remember that in FunC `true` is `-1` and `false` is `0`.
 
 To check whether an event is relevant, use a flag variable. In FunC, `true` is represented by `-1`, and `false` is `0`.
 
 ```func
 int flag = 0; ;; false
 
-if (flag) {
+if (flag) { 
     ;; do something
 }
 else {
@@ -25,7 +23,7 @@ else {
 ```
 **Note:** The `==` operator is unnecessary, as `0` already evaluates to `false`, and any nonzero value is considered `true`.
 
-**Reference:** [`If statement` in docs](/v3/documentation/smart-contracts/func/docs/statements#if-statements)
+**Reference:** [`If statements` in docs](/v3/documentation/smart-contracts/func/docs/statements#if-statements)
 
 ### How to write a repeat loop
 A repeat loop helps execute an action a fixed number of times. The example below demonstrates exponentiation:
@@ -45,7 +43,7 @@ repeat(degree - 1) {
 
 ### How to write a while loop
 
-A while loop is useful when the number of iterations is unknown. The following example processes a `cell` which can store up to four references to other cells:
+A while loop is useful when the number of iterations is unknown. The following example processes a `cell`, which can store up to four references to other cells:
 
 ```func
 cell inner_cell = begin_cell() ;; Create a new empty builder
@@ -58,7 +56,7 @@ cell message = begin_cell()
         .end_cell();
 
 slice msg = message.begin_parse(); ;; Convert cell to slice
-while (msg.slice_refs_empty?() != -1) { ;; We should remind that -1 is true
+while (~ msg.slice_refs_empty?()) {
     cell inner_cell = msg~load_ref(); ;; Load cell from slice msg
     ;; do something
 }
@@ -76,12 +74,12 @@ while (msg.slice_refs_empty?() != -1) { ;; We should remind that -1 is true
 ### How to write a do until loop
 Use a `do-until` loop when the loop must execute at least once.
 
-```func
+```func 
 int flag = 0;
 
 do {
-    ;; do something even flag is false (0)
-} until (flag == -1); ;; -1 is true
+    ;; do something even flag is false (0) 
+} until (flag);
 ```
 
 **Reference:** [`Until loop` in docs](/v3/documentation/smart-contracts/func/docs/statements#until-loop)
@@ -103,7 +101,7 @@ slice_with_bits_only.slice_empty?();
 
 ;; Creating slice which contains refs only
 slice slice_with_refs_only = begin_cell()
-    .store_maybe_ref
+    .store_maybe_ref(null())
     .end_cell()
     .begin_parse();
 ;; `slice_empty?()` returns `false` because the slice has `refs`.
@@ -131,7 +129,7 @@ slice_with_bits_and_refs.slice_empty?();
 
 If only the presence of `bits` matters and `refs` in `slice` can be ignored, use the `slice_data_empty?()`.
 
-```func
+```func 
 ;; Creating empty slice
 slice empty_slice = "";
 ;; `slice_data_empty?()` returns `true` because the slice doesn't have any `bits`.
@@ -144,7 +142,7 @@ slice_with_bits_only.slice_data_empty?();
 
 ;; Creating slice which contains refs only
 slice slice_with_refs_only = begin_cell()
-    .store_ref(null())
+    .store_ref(begin_cell().end_cell())
     .end_cell()
     .begin_parse();
 ;; `slice_data_empty?()` returns `true` because the slice doesn't have any `bits`
@@ -153,7 +151,7 @@ slice_with_refs_only.slice_data_empty?();
 ;; Creating slice which contains bits and refs
 slice slice_with_bits_and_refs = begin_cell()
     .store_slice("Hello, world!")
-    .store_ref(null())
+    .store_ref(begin_cell().end_cell())
     .end_cell()
     .begin_parse();
 ;; `slice_data_empty?()` returns `false` because the slice has `bits`.
@@ -171,11 +169,9 @@ slice_with_bits_and_refs.slice_data_empty?();
 
 ### How to determine if slice is empty (no refs, but may have bits)
 
-In case we are only interested in `refs`, we should check their presence using `slice_refs_empty?()`.
-
 If only `refs` are of interest, their presence can be checked using the `slice_refs_empty?()`.
 
-```func
+```func 
 ;; Creating empty slice
 slice empty_slice = "";
 ;; `slice_refs_empty?()` returns `true` because the slice doesn't have any `refs`.
@@ -262,8 +258,8 @@ else {
 
 **References:**
 - [`dict_empty?()` in docs](/v3/documentation/smart-contracts/func/docs/stdlib#dict_empty)
-- [`new_dict()` in docs](/v3/documentation/smart-contracts/func/docs/stdlib/#new_dict), creating an empty dict
-- [`dict_set()` in docs](/v3/documentation/smart-contracts/func/docs/stdlib/#dict_set), adding some elements in dict `d` with function, so it is not empty
+- [`new_dict()` in docs](/v3/documentation/smart-contracts/func/docs/stdlib#new_dict)
+- [`udict_set()` in docs](/v3/documentation/smart-contracts/func/docs/stdlib#udict_set)
 
 ### How to determine if a tuple is empty
 
@@ -287,32 +283,37 @@ When working with `tuples`, checking for existing values before extracting them 
     }
 }
 ```
-**Note:**
-We are defining the `tlen` assembly function. You can find more details [here](/v3/documentation/smart-contracts/func/docs/functions#assembler-function-body-definition) and a see a [list of assembler commands](/v3/documentation/tvm/instructions).
+**Note:** 
+We are defining the `tlen` assembly function. You can find more details [here](/v3/documentation/smart-contracts/func/docs/functions#assembler-function-body-definition) and see a [list of assembler commands](/v3/documentation/tvm/tvm-overview#tvm-instructions).
 
 **References:**
-- [`empty_tuple?()` in docs](/v3/documentation/smart-contracts/func/docs/stdlib#empty_tuple)
+- [`empty_tuple()` in docs](/v3/documentation/smart-contracts/func/docs/stdlib#empty_tuple)
 - [`tpush()` in docs](/v3/documentation/smart-contracts/func/docs/stdlib/#tpush)
 - [`Exit codes` in docs](/v3/documentation/tvm/tvm-exit-codes)
 
 ### How to determine if a lisp-style list is empty
 
-We can use the [cons](/v3/documentation/smart-contracts/func/docs/stdlib/#cons) function to add an element to determine if a lisp-style list is empty. For example, adding 100 to the list ensures it is not empty.
-
+Use the [cons](/v3/documentation/smart-contracts/func/docs/stdlib#cons) function to add an element to a lisp-style list. Check emptiness before and after inserting an element.
 
 ```func
 tuple numbers = null();
+
+;; empty case
+if (numbers.null?()) {
+    ;; lisp-style list is empty
+}
+
+;; add an element
 numbers = cons(100, numbers);
 
-if (numbers.null?()) {
-    ;; list-style list is empty
-} else {
-    ;; list-style list is not empty
+;; non-empty case
+if (~ numbers.null?()) {
+    ;; lisp-style list is not empty
 }
 ```
 
-### How to determine a state of the contract is empty
-Consider a smart contract with a `counter` that tracks the number of transactions. This variable does not exist in the contract state during the first transaction because it is empty.
+### How to determine if the contract state is empty
+Consider a smart contract with a `counter` that tracks the number of transactions. This variable does not exist in the contract state during the first transaction because it is empty. 
 It is important to handle this scenario by checking if the state is empty and initializing the `counter` accordingly.
 
 ```func
@@ -335,7 +336,7 @@ else {
 ```
 
 **Note:**
-The contract state can be determined as empty by verifying whether the [cell is empty](/v3/documentation/smart-contracts/func/cookbook#how-to-determine-if-a-cell-is-empty).
+The contract state can be determined by verifying whether the [cell is empty](/v3/documentation/smart-contracts/func/cookbook#how-to-determine-if-a-cell-is-empty).
 
 
 **References:**
@@ -349,7 +350,7 @@ The contract state can be determined as empty by verifying whether the [cell is 
 When a smart contract needs to send an internal message, it must first construct the message as a `cell`. This includes specifying technical flags, the recipient's address, and additional data.
 
 ```func
-;; We use literal `a` to get valid address inside slice from string containing address
+;; We use literal `a` to get valid address inside slice from string containing address 
 slice addr = "EQArzP5prfRJtDM5WrMNWyr9yUTAi0c9o6PfR4hkWy9UQXHx"a;
 int amount = 1000000000;
 ;; we use `op` for identifying operations
@@ -363,10 +364,10 @@ cell msg = begin_cell()
     .store_uint(op, 32)
 .end_cell();
 
-send_raw_message(msg, 3); ;; mode 3 - pay fees separately and ignore errors
+send_raw_message(msg, 3); ;; mode 3 - pay fees separately and ignore errors 
 ```
 **Note:**
-- In this example, we use the literal `a` to obtain an address. More details on string literals can be found in the [documentation](/v3/documentation/smart-contracts/func/docs/literals_identifiers#string-literals).
+- In this example, we use the literal `a` to obtain an address. More details on string literals can be found in the [documentation](/v3/documentation/smart-contracts/func/docs/literals_identifiers#string-literals). 
 - You can find more details in the [documentation](/v3/documentation/smart-contracts/message-management/sending-messages). A direct link to the [layout](/v3/documentation/smart-contracts/message-management/sending-messages#message-layout) is also available.
 
 **References:**
@@ -384,7 +385,7 @@ The message body can contain `int`, `slices`, or `cells` following flags and oth
 Alternatively, if there is sufficient space, the message body can be stored in the same `cell` as the header. In this case, the bit should be set to `0`.
 
 ```func
-;; We use literal `a` to get valid address inside slice from string containing address
+;; We use literal `a` to get valid address inside slice from string containing address 
 slice addr = "EQArzP5prfRJtDM5WrMNWyr9yUTAi0c9o6PfR4hkWy9UQXHx"a;
 int amount = 1000000000;
 int op = 0;
@@ -392,7 +393,7 @@ cell message_body = begin_cell() ;; Creating a cell with message
     .store_uint(op, 32)
     .store_slice("❤")
 .end_cell();
-
+    
 cell msg = begin_cell()
     .store_uint(0x18, 6)
     .store_slice(addr)
@@ -402,16 +403,14 @@ cell msg = begin_cell()
     .store_ref(message_body)
 .end_cell();
 
-send_raw_message(msg, 3); ;; mode 3 - pay fees separately and ignore errors
+send_raw_message(msg, 3); ;; mode 3 - pay fees separately and ignore errors 
 ```
 
 **Note:**
 - In this example, we use the literal `a` to obtain an address. More details on string literals can be found in the [documentation](/v3/documentation/smart-contracts/func/docs/literals_identifiers#string-literals).
-- The example uses [`mode 3`](/v3/documentation/smart-contracts/message-management/sending-messages#mode3), which ensures the contract deducts the specified amount while covering the transaction fee from the contract balance and ignoring errors.
-  - `mode 64` returns all received tokens, subtracting the commission.
-  - `mode 128` transfers the entire balance.
+- This example uses [mode 3](/v3/documentation/smart-contracts/message-management/sending-messages#mode3). For other options, see mode 64 and mode 128 on the same page.
 - The [message](/v3/documentation/smart-contracts/func/cookbook#how-to-build-an-internal-message-cell) is constructed with the body added separately.
-
+  
 
 **References:**
 - [`begin_cell()` in docs](/v3/documentation/smart-contracts/func/docs/stdlib#begin_cell)
@@ -425,12 +424,12 @@ send_raw_message(msg, 3); ;; mode 3 - pay fees separately and ignore errors
 
 A message body can be sent as either a `cell` or a `slice`. In this example, the body is sent inside a `slice`.
 
-```func
-;; We use literal `a` to get valid address inside slice from string containing address
+```func 
+;; We use literal `a` to get valid address inside slice from string containing address 
 slice addr = "EQArzP5prfRJtDM5WrMNWyr9yUTAi0c9o6PfR4hkWy9UQXHx"a;
 int amount = 1000000000;
 int op = 0;
-slice message_body = "❤";
+slice message_body = "❤"; 
 
 cell msg = begin_cell()
     .store_uint(0x18, 6)
@@ -441,7 +440,7 @@ cell msg = begin_cell()
     .store_slice(message_body)
 .end_cell();
 
-send_raw_message(msg, 3); ;; mode 3 - pay fees separately and ignore errors
+send_raw_message(msg, 3); ;; mode 3 - pay fees separately and ignore errors 
 ```
 **Note:**
 - The literal `a` is used to obtain an address. See the [documentation](/v3/documentation/smart-contracts/func/docs/literals_identifiers#string-literals) for details on string literals.
@@ -459,7 +458,7 @@ forall X -> (tuple) to_tuple (X x) asm "NOP";
 () main () {
     tuple t = to_tuple([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     int len = t.tlen();
-
+    
     int i = 0;
     while (i < len) {
         int x = t.at(i);
@@ -491,7 +490,7 @@ For example, while `tpush`, which adds an element to a `tuple`, exists, there is
 
 ```func
 ;; ~ means it is modifying method
-forall X -> (tuple, X) ~tpop (tuple t) asm "TPOP";
+forall X -> (tuple, X) ~tpop (tuple t) asm "TPOP"; 
 ```
 We must determine its length if we want to iterate over a `tuple`. We can achieve this by writing a new function using the `TLEN` asm instruction.
 
@@ -555,8 +554,8 @@ global int max_value;
 
 **References:**
 - [`global variables` in docs](/v3/documentation/smart-contracts/func/docs/global_variables)
-- [`~dump` in docs](/v3/documentation/smart-contracts/func/docs/builtins#dump-variable)
-- [`TVM instructions` in docs](/v3/documentation/tvm/instructions)
+- [`~dump` in docs](/v3/documentation/smart-contracts/func/docs/builtins#dumping-a-variable)
+- [`TVM instructions` in docs](/v3/documentation/tvm/tvm-overview#tvm-instructions) 
 
 
 ### Basic operations with tuples
@@ -567,14 +566,14 @@ forall X -> (tuple, X) ~tpop (tuple t) asm "TPOP";
 
 () main () {
     ;; creating an empty tuple
-    tuple names = empty_tuple();
-
+    tuple names = empty_tuple(); 
+    
     ;; push new items
     names~tpush("Naito Narihira");
     names~tpush("Shiraki Shinichi");
     names~tpush("Akamatsu Hachemon");
     names~tpush("Takaki Yuichi");
-
+    
     ;; pop last item
     slice last_name = names~tpop();
 
@@ -584,7 +583,7 @@ forall X -> (tuple, X) ~tpop (tuple t) asm "TPOP";
     ;; get an item by index
     slice best_name = names.at(2);
 
-    ;; getting the length of the list
+    ;; getting the length of the list 
     int number_names = names.tlen();
 }
 ```
@@ -607,7 +606,7 @@ forall X -> (tuple, X) ~tpop (tuple t) asm "TPOP";
 
 forall X -> () resolve_type (X value) impure {
     ;; Value here is of type X, since we dont know what is the exact value - we would need to check what is the value and then cast it
-
+    
     if (is_null(value)) {
         ;; do something with the null
     }
@@ -641,16 +640,16 @@ forall X -> () resolve_type (X value) impure {
 }
 ```
 
-**Reference:** [`TVM instructions` in docs](/v3/documentation/tvm/instructions)
+**Reference:** [`TVM instructions` in docs](/v3/documentation/tvm/tvm-overview#tvm-instructions) 
 
 
 ### How to get current time
 
 ```func
 int current_time = now();
-
+  
 if (current_time > 1672080143) {
-    ;; do some stuff
+    ;; do some stuff 
 }
 ```
 
@@ -672,7 +671,7 @@ int c = random();
 
 ### Modulo operations
 
-As an example, let’s say we need to perform the following calculation for all 256 numbers:
+As an example, let’s say we need to perform the following calculation for all 256 numbers: 
 
 `(xp + zp) * (xp - zp)`.
 
@@ -682,9 +681,9 @@ Since these operations are commonly used in cryptography, we utilize the modulo 
 Variable names like `xp+zp` are valid as long as there are no spaces between the operators.
 
 ```func
-(int) modulo_operations (int xp, int zp) {
+(int) modulo_operations (int xp, int zp) {  
    ;; 2^255 - 19 is a prime number for montgomery curves, meaning all operations should be done against its prime
-   int prime = 57896044618658097711785492504343953926634992332820282019728792003956564819949;
+   int prime = 57896044618658097711785492504343953926634992332820282019728792003956564819949; 
 
    ;; muldivmod handles the next two lines itself
    ;; int xp+zp = (xp + zp) % prime;
@@ -694,7 +693,7 @@ Variable names like `xp+zp` are valid as long as there are no spaces between the
 }
 ```
 
-**Reference:** [`muldivmod` in docs](/v3/documentation/tvm/instructions#A98C)
+**Reference:** [`TVM instructions` in docs](/v3/documentation/tvm/tvm-overview#tvm-instructions)
 
 
 ### How to throw errors
@@ -711,6 +710,7 @@ throw(36); ;; the error will be triggered anyway
 
 [Standard TVM exception codes](/v3/documentation/tvm/tvm-exit-codes)
 
+See also: [Throwing exceptions](/v3/documentation/smart-contracts/func/docs/builtins#throwing-exceptions)
 ### Reversing tuples
 Since tuples behave as stacks in FunC, sometimes we need to **reverse** them to access data from the opposite end.
 
@@ -735,7 +735,7 @@ forall X -> (tuple) to_tuple (X x) asm "NOP";
 }
 ```
 
-**Reference:** [`tpush()` in docs](/v3/documentation/smart-contracts/func/docs/stdlib/#tpush)
+**Reference:** [`tpush()` in docs](/v3/documentation/smart-contracts/func/docs/stdlib#tpush)
 
 
 ### How to remove an item with a certain index from the list
@@ -752,7 +752,7 @@ int tlen (tuple t) asm "TLEN";
         if (i != place) {
             new_tuple~tpush(el);
         }
-        i += 1;
+        i += 1;  
     }
     return (new_tuple, ());
 }
@@ -766,7 +766,7 @@ int tlen (tuple t) asm "TLEN";
 
     ~dump(numbers); ;; [19 999 54]
 
-    numbers~remove_item(1);
+    numbers~remove_item(1); 
 
     ~dump(numbers); ;; [19 54]
 }
@@ -798,8 +798,8 @@ int are_slices_equal_2? (slice a, slice b) asm "SDEQ";
 ```
 
 **References:**
-- [`slice_hash()` in docs](/v3/documentation/smart-contracts/func/docs/stdlib/#slice_hash)
-- [`SDEQ` in docs](/v3/documentation/tvm/instructions#C705)
+- [`slice_hash()` in docs](/v3/documentation/smart-contracts/func/docs/stdlib#slice_hash)
+- [`TVM instructions` in docs](/v3/documentation/tvm/tvm-overview#tvm-instructions)
 
 ### Determine if the cells are equal
 We can determine if two cells are equal by comparing their hashes.
@@ -847,18 +847,18 @@ int are_cells_equal? (cell a, cell b) {
 
 (int) are_tuples_equal? (tuple t1, tuple t2) {
     int equal? = -1; ;; initial value to true
-
+    
     if (t1.tuple_length() != t2.tuple_length()) {
         ;; if tuples are differ in length they cannot be equal
         return 0;
     }
 
     int i = t1.tuple_length();
-
+    
     while (i > 0 & equal?) {
         var v1 = t1~tpop();
         var v2 = t2~tpop();
-
+        
         if (is_null(v1) & is_null(v2)) {
             ;; nulls are always equal
         }
@@ -897,7 +897,7 @@ int are_cells_equal? (cell a, cell b) {
     tuple t1 = cast_to_tuple([[2, 6], [1, [3, [3, 5]]], 3]);
     tuple t2 = cast_to_tuple([[2, 6], [1, [3, [3, 5]]], 3]);
 
-    ~dump(are_tuples_equal?(t1, t2)); ;; -1
+    ~dump(are_tuples_equal?(t1, t2)); ;; -1 
 }
 ```
 
@@ -941,9 +941,9 @@ We use the TL-B scheme from [block.tlb](https://github.com/ton-blockchain/ton/bl
 
 slice generate_external_address (int address) {
     ;; addr_extern$01 len:(## 9) external_address:(bits len) = MsgAddressExt;
-
+    
     int address_length = ubitsize(address);
-
+    
     return begin_cell()
         .store_uint(1, 2) ;; addr_extern$01
         .store_uint(address_length, 9)
@@ -953,7 +953,7 @@ slice generate_external_address (int address) {
 ```
 Since we need to find the exact number of bits occupied by the address, we must [declare an asm function](#how-to-write-custom-functions-using-asm-keyword) with the `UBITSIZE` opcode. This function will return the minimum number of bits required to store a given number.
 
-**Reference:** [TVM instructions in docs](/v3/documentation/tvm/instructions#B603)
+**Reference:** [`TVM instructions` in docs](/v3/documentation/tvm/tvm-overview#tvm-instructions)
 
 ### How to store and load dictionary in a local storage
 
@@ -1050,7 +1050,7 @@ send_raw_message(msg, 128); ;; mode = 128 is used for messages that are to carry
 
 ### How to send a message with a long text comment
 
-A `cell` can store up to 127 characters (`<1023 bits`).
+A `cell` can store up to 127 characters (`<1023 bits`). 
 A sequence of linked cells ("snake cells") must be used if more space is required.
 
 ```func
@@ -1073,7 +1073,7 @@ cell body = begin_cell()
 
 cell msg = begin_cell()
     .store_uint(0x18, 6) ;; flags
-    ;; We use literal `a` to get valid address inside slice from string containing address
+    ;; We use literal `a` to get valid address inside slice from string containing address 
     .store_slice("EQBIhPuWmjT7fP-VomuTWseE8JNWv2q7QYfsVQ1IZwnMk8wL"a) ;; destination address
     .store_coins(100) ;; amount of nanoTons to send
     .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1) ;; default message headers (see sending messages page)
@@ -1207,7 +1207,7 @@ d~udict_set(256, 12, "value 3");
 (int key, slice val, int flag) = d.udict_get_min?(256);
 while (flag) {
     ;; do something with pair key->val
-
+    
     (key, val, flag) = d.udict_get_next?(256, key);
 }
 ```
@@ -1324,7 +1324,7 @@ forall X -> (tuple, (X)) pop_back (tuple t) asm "UNCONS";
     .end_cell();
 
   ;; mode 64 - carry the remaining value in the new message
-  send_raw_message(msg, 64);
+  send_raw_message(msg, 64); 
 }
 
 () deploy_with_stateinit_body(cell message_header, cell state_init, cell body) impure {
@@ -1337,7 +1337,7 @@ forall X -> (tuple, (X)) pop_back (tuple t) asm "UNCONS";
     .end_cell();
 
   ;; mode 64 - carry the remaining value in the new message
-  send_raw_message(msg, 64);
+  send_raw_message(msg, 64); 
 }
 ```
 
@@ -1361,7 +1361,7 @@ forall X -> (tuple, (X)) pop_back (tuple t) asm "UNCONS";
 
 ```func
 () calc_address(cell state_init) {
-  var future_address = begin_cell()
+  var future_address = begin_cell() 
     .store_uint(2, 2) ;; addr_std$10
     .store_uint(0, 1) ;; anycast:(Maybe Anycast)
     .store_uint(0, 8) ;; workchain_id:int8
@@ -1376,7 +1376,7 @@ Below is an example of a simple `CounterV1` smart contract that allows the count
 ```func
 () recv_internal (slice in_msg_body) {
     int op = in_msg_body~load_uint(32);
-
+    
     if (op == op::increase) {
         int increase_by = in_msg_body~load_uint(32);
         ctx_counter += increase_by;
@@ -1397,7 +1397,7 @@ After interacting with the contract, you may realize that the functionality for 
 ```func
 () recv_internal (slice in_msg_body) {
     int op = in_msg_body~load_uint(32);
-
+    
     if (op == op::increase) {
         int increase_by = in_msg_body~load_uint(32);
         ctx_counter += increase_by;
@@ -1440,4 +1440,3 @@ await contractV1.sendUpgrade(provider.sender(), {
 
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-func-cookbook.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/func/cookbook.mdx`

Related issues (from issues.normalized.md):
- [ ] **1707. Remove duplicate boolean explanation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L12-L15

Two consecutive sentences restate that a flag is used and that true is -1 and false is 0; keep a single concise sentence and delete the duplicate.

---

- [ ] **1708. Fix link text to “If statements”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L28

The link text says “If statement” but the target heading is plural; change the link text to “If statements” to match `/v3/documentation/smart-contracts/func/docs/statements#if-statements`.

---

- [ ] **1709. Add comma in non-restrictive clause**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L48

Change “processes a `cell` which can store up to four references” to “processes a `cell`, which can store up to four references …” to correctly punctuate a non‑restrictive clause.

---

- [ ] **1710. Simplify while-loop truth check**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L61

Replace `while (msg.slice_refs_empty?() != -1)` with `while (~ msg.slice_refs_empty?()) { ... }` (or compare to `0`) to follow FunC truth semantics and improve readability.

---

- [ ] **1711. Use flag directly in do–until condition**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L76-L85

Change `until (flag == -1)` to `until (flag);` and adjust the preceding note accordingly to avoid boolean equality checks and keep guidance consistent.

---

- [ ] **1712. Correct `.store_maybe_ref` usage and restore truncated lines**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L104-L116

Call `.store_maybe_ref` with parentheses and an argument (e.g., `.store_maybe_ref(null())`) and fix the truncated code lines so the block compiles (e.g., complete `.store_slice("Hello, world!")` and subsequent lines).

---

- [ ] **1713. Clarify `store_maybe_ref` vs definite `store_ref` examples**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L147-L160

Explain that `.store_maybe_ref(null())` encodes an absent reference, while a definite child must be constructed and stored with `.store_ref(begin_cell().end_cell())`; remove uses of `.store_ref(null())`. Also apply the same clarification at L189-L204.

---

- [ ] **1714. Remove duplicate sentence in refs‑only slice section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L174-L176

Two adjacent sentences convey the same guidance about using `slice_refs_empty?()`; keep one concise sentence and delete the duplicate.

---

- [ ] **1715. Fix dictionary emptiness example and reference texts**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L238-L266

Do not label a populated dict as empty; either check emptiness before inserts or negate the condition after inserts (e.g., `if (~ d.dict_empty?()) { ;; dict is not empty }`). Also tighten the reference list by removing explanatory fragments from link texts and use concise function names.

---

- [ ] **1716. Normalize stdlib anchors (remove extra slash before hash)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L262-L266

Change links like `/v3/documentation/smart-contracts/func/docs/stdlib/#new_dict` to `/v3/documentation/smart-contracts/func/docs/stdlib#new_dict`; apply similarly where used (e.g., L375-L379, L418-L422, L824-L825).

---

- [ ] **1717. Fix tuple emptiness reference text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L287

Change reference text from `empty_tuple?()` to `empty_tuple()`; keep the anchor `/v3/documentation/smart-contracts/func/docs/stdlib#empty_tuple`.

---

- [ ] **1718. Correct lisp‑style list emptiness section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L298-L312

Demonstrate both the empty and non‑empty cases (e.g., check `numbers.null?()` before and after `cons`) and standardize the term to “lisp‑style list” in the text.

---

- [ ] **1719. Fix heading grammar: contract state emptiness**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L314

Change “How to determine a state of the contract is empty” to “How to determine if the contract state is empty.”

---

- [ ] **1720. Complete the cut note sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L337-L341

Finish the truncated note so it reads coherently (e.g., “can be determined by verifying whether the cell is empty”) and keep the existing in‑page link.

---

- [ ] **1721. Clarify internal message mode note and casing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L401-L418

Rephrase to “This example uses mode 3. For other options, see mode 64 and mode 128 on the same page,” keep links to `/sending-messages#mode3` and `/func/docs/stdlib#send_raw_message`, and use lowercase “mode” consistently.

---

- [ ] **1722. Align internal message header comments with message layout**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L386-L445

Ensure the header bit-length sums and the body-as-ref flag explanation match the “Message layout” on the Sending messages page; update comments or counts so they are consistent and unambiguous.

---

- [ ] **1723. Cite or replace tuple `at()`**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L465-L473

Since examples use `t.at(i)` without defining it, either add a note/link to the built‑ins page where `at` is documented, or replace with primitives (e.g., iterate via `TLEN`/`tpop` or use asm `INDEX`).

---

- [ ] **1724. Replace “pre‑prepared methods” wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L488

Change “pre‑prepared methods” to “functions provided by stdlib.fc” for clarity and consistency with stdlib terminology.

---

- [ ] **1725. Fix TVM instruction links to use the overview**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L511-L513

Replace opcode‑anchored links like `/v3/documentation/tvm/instructions#…` with `/v3/documentation/tvm/tvm-overview#tvm-instructions` (apply similarly at L559-L560, L644-L645, L800-L803, L885-L900, L956).

---

- [ ] **1726. Standardize comment punctuation and casing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L550-L553

Normalize comment style (e.g., sentence‑case and end with periods) for consistency across examples.

---

- [ ] **1727. Update `~dump` link anchor**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L557-L559

Point to `/v3/documentation/smart-contracts/func/docs/builtins#dumping-a-variable` instead of `#dump-variable` to match the section anchor.

---

- [ ] **1728. Add built‑ins reference for throwing exceptions**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L700-L709

Add a reference bullet to Built‑ins “Throwing exceptions” for `throw_if`, `throw_unless`, and `throw`: `/v3/documentation/smart-contracts/func/docs/builtins#throwing-exceptions`.

---

- [ ] **1729. Note `?` predicate naming convention**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L777-L787

Add a brief note linking to identifier conventions that allow `?` suffix for predicates: `/v3/documentation/smart-contracts/func/docs/literals_identifiers`.

---

- [ ] **1730. Use comparable slice types in equality example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L793-L796

Replace the mixed example (text vs address slice) with either two text slices or two addresses to better illustrate equality/inequality.

---

- [ ] **1731. Generalize internal address workchain comment**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L921

Remove the hardcoded “workchain_id: -1” comment or rephrase to “workchain_id: int8” to avoid implying a fixed value.

---

- [ ] **1732. Use method form for `slice_empty?`**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L962-L968

Prefer `if (~ local_storage.slice_empty?()) { ... }` over the free‑function form for consistency with earlier examples.

---

- [ ] **1733. Normalize currency terms and article usage**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L406

Ensure consistent terminology (e.g., “nanotons”/“nanotoncoins”) and add missing articles where needed (“a message body”, “an internal address”); also apply at L958.

---

- [ ] **1734. Align simple message header length**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L992

Match the minimal layout expression with the Sending messages page (e.g., `.store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)`), or explain any intentional variation.

---

- [ ] **1735. Rename proxy section heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L1001

Change “How to send a message with an incoming account” to “How to send a message via a proxy contract” for clarity.

---

- [ ] **1736. Clarify proxy value and gas acceptance**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L1005-L1024

Note that the hardcoded `100` is an example value (or replace with an `amount` variable) and mention that acceptance/fee handling (e.g., `accept_message()`) is omitted for brevity with a link to the general guidance.

---

- [ ] **1737. Clarify 127‑character cell limit**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L1053-L1061

Rephrase to explain that a cell can store up to 1023 bits (about 127 ASCII characters), so longer strings must be stored across referenced cells.

---

- [ ] **1738. Cross‑reference `list_next` in lisp‑style iteration**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L1063-L1071

Add a reference to stdlib’s `list_next` (and/or unify examples to use the same approach) for consistency with list iteration helpers.

---

- [ ] **1739. Fix broken `preload_bits()` reference formatting**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L1103-L1105

Ensure the `preload_bits()` bullet renders as a single intact link (not split across lines) consistent with neighboring bullets.

---

- [ ] **1740. Fix dictionary iteration references and typo**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L1203-L1211

Make the reference names match the unsigned example (`udict_get_min?`, `udict_get_max?`, `udict_get_next?`, `udict_set()`) and correct the misspelling to “Dictionaries primitives”; also fix the same typo at L1216.

---

- [ ] **1741. Improve heading grammar for delete operation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L1213

Change “How to delete value from dictionaries” to “How to delete a value from a dictionary.”

---

- [ ] **1742. Remove placeholder artifact lines**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1

Delete placeholders like “[... omitted N of M lines ...]” that appear to be artifact markers; restore full content or remove the markers to avoid confusion.

---

- [ ] **1743. Add `func` language tags to code fences**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1

Ensure all code blocks specify the `func` language (e.g., sections around L520+) for proper syntax highlighting and consistency.

---

- [ ] **1744. Normalize code formatting in reference lists**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/cookbook.mdx?plain=1#L263-L266

In “References” bullets, wrap function names in backticks and include parentheses consistently (e.g., `begin_cell()`, `send_raw_message()`), matching the style used elsewhere on the page.

---

- [ ] **3748. Explain workchain() helper**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/get-methods.mdx?plain=1#L165-L169

Add a note that workchain() returns the current workchain ID and link to docs/v3/documentation/smart-contracts/func/cookbook.mdx#generate-an-internal-address.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.