### PR TITLE
Split: update docs/v3/documentation/smart-contracts/func/docs/builtins.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/func/docs/builtins.mdx
+++ b/docs/v3/documentation/smart-contracts/func/docs/builtins.mdx
@@ -41,6 +41,5 @@ It uses a 513-bit intermediate result to prevent overflow if the final result fi
 ## Other primitives
 - `null?` checks if the given argument is `null`. In FunC, the value `null` belongs to the TVM type `Null`, which represents the absence of a value for certain atomic types. See [null values](/v3/documentation/smart-contracts/func/docs/types#null-values) for details.
 - `touch` and `~touch` push a variable to the top of the stack.
-- `at` returns the value of a tuple element at the specified position.
+- For tuple element access, use the stdlib tuple accessors (`first`, `second`, `third`, `fourth`).
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-func-docs-builtins.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/func/docs/builtins.mdx`

Related issues (from issues.normalized.md):
- [ ] **1745. Normalize stdlib link (drop trailing slash)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/builtins.mdx?plain=1#L6

Change [stdlib.fc](/v3/documentation/smart-contracts/func/docs/stdlib/) to [stdlib.fc](/v3/documentation/smart-contracts/func/docs/stdlib) for consistency and to avoid duplicate URLs.

---

- [ ] **1746. Fix singular wording for parameterized exceptions**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/builtins.mdx?plain=1

Rewrite to: "Conditional exceptions with a parameter: `throw_arg_if` and `throw_arg_unless`; in these versions, the first argument is a parameter of any type, the second is the error code, and for conditional forms a third argument is the condition."

---

- [ ] **1747. Align boolean wording with Types**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/builtins.mdx?plain=1#L25-L27

Replace with: "FunC has no boolean type; false is 0, true is -1 (all bits set); in conditionals, any nonzero integer is treated as true."

---

- [ ] **1748. Document ~strdump signature and byte alignment**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/builtins.mdx?plain=1#L32

Change to: "Use `~strdump(slice)` to output a slice to the debug log; the slice’s bit length must be a multiple of 8 (byte‑aligned)."

---

- [ ] **1749. Remove unsupported 513-bit claim for muldiv**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/builtins.mdx?plain=1#L36-L37

Replace "uses a 513-bit intermediate result" with "uses a wider intermediate to avoid overflow when the final result fits in 257 bits."

---

- [ ] **1750. Clarify divmod operand order and return tuple**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/builtins.mdx?plain=1#L38

State that `divmod` takes two numbers and returns a pair (quotient, remainder) for the division of the first argument by the second.

---

- [ ] **1751. Replace undocumented touch/~touch with ~impure_touch**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/builtins.mdx?plain=1#L43

Replace mentions of `touch`/`~touch` with the documented `~impure_touch(X x)` and describe it as "marks a variable as used."

---

- [ ] **1752. Remove undocumented at() and link to tuple accessors**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/builtins.mdx?plain=1#L44

Remove the undocumented `at` and direct readers to the stdlib tuple accessors (`first`, `second`, `third`, `fourth`).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.