### PR TITLE
Split: update docs/v3/documentation/smart-contracts/func/docs/comments.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/func/docs/comments.mdx
+++ b/docs/v3/documentation/smart-contracts/func/docs/comments.mdx
@@ -11,7 +11,7 @@ int x = 1; ;; assigns 1 to x
 ```
 
 **Multi-line** comments begin with `{-` and end with `-}`.
-Unlike other languages, FunC allows nested multi-line comments.
+FunC allows nested multi-line comments.
 Example:
 
 ```func
@@ -21,17 +21,17 @@ Example:
 ```
 
 
-Additionally, single-line comments `;;` can appear inside multi-line comments, and they take precedence over multi-line comments `{- -}`. In the following example:
+Within a multi-line comment, `;;` starts a single-line comment. Any `-}` after `;;` on that line is ignored, so the multi-line comment does not close on that line. In the following example:
 
 ```func
 {-
   Start of the comment
 
-;; This comment’s ending is itself commented out -> -}
+;; This comment's ending is itself commented out -> -}
 
 const a = 10;
 
-;; This comment’s beginning is itself commented out -> {-
+;; This comment's beginning is itself commented out -> {-
 
   End of the comment
 -}
@@ -39,4 +39,3 @@ const a = 10;
 
 Here, `const a = 10;` is inside a multi-line comment and is effectively commented out.
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-func-docs-comments.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/func/docs/comments.mdx`

Related issues (from issues.normalized.md):
- [x] **1753. Remove overgeneralization about nesting**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/comments.mdx?plain=1#L13-L15

Replace “Unlike other languages, FunC allows nested multi-line comments.” with the neutral statement “FunC allows nested multi-line comments.”

---

- [x] **1754. Clarify `;;` precedence inside multi-line comments**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/comments.mdx?plain=1#L24

Rewrite the sentence to: “Within a multi-line comment, `;;` starts a single-line comment. Any `-}` after `;;` on that line is ignored, so the multi-line comment does not close on that line.”

---

- [x] **1755. Correct multi-line delimiter notation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/comments.mdx?plain=1#L24

Change “multi-line comments `{- -}`” to “multi-line comments delimited by `{-` and `-}`” to correctly name the two markers.

---

- [x] **1756. Replace smart quotes with straight apostrophes in code block**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/comments.mdx?plain=1#L30-L34

Replace the curly apostrophes in “comment’s” with straight ASCII apostrophes: “comment's” (both instances).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.