### PR TITLE
Split: update docs/v3/documentation/smart-contracts/func/docs/compiler_directives.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/func/docs/compiler_directives.mdx
+++ b/docs/v3/documentation/smart-contracts/func/docs/compiler_directives.mdx
@@ -145,4 +145,6 @@ All `asm` reordering will occur only after computation.
 
 `#pragma compute-asm-ltr` works only for code after the pragma.
 
+**Note:** `#pragma compute-asm-ltr` applies only to the code after the directive in the file.
+
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-func-docs-compiler_directives.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/func/docs/compiler_directives.mdx`

Related issues (from issues.normalized.md):
- [x] **1757. Improve #include directive phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/compiler_directives.mdx?plain=1#L11

Replace “enables the inclusion of another FunC source file parsed in place of the directive” with “enables another FunC source file to be parsed in place of the directive.”

---

- [x] **1758. Make verbosity sentence more direct**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/compiler_directives.mdx?plain=1#L19

Change “A warning will be issued if the verbosity level is 2 or higher.” to “A warning is issued when the verbosity level is set to 2 or higher.”

---

- [x] **1759. Use inline code for version tokens and operators**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/compiler_directives.mdx?plain=1#L41-L48,L50-L60

Style version constraints and operators as inline code (e.g., `>=a.b.c`, `^a.b`, `<a.b.c`, `<=a`) instead of italics to avoid escaping issues and improve readability.

---

- [x] **1760. Move punctuation outside version tokens**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/compiler_directives.mdx?plain=1#L42,L53

Remove trailing dots inside the tokens and place sentence punctuation after them (e.g., change "_a.b.c._" and "_a.b.0._" to the token followed by a period).

---

- [x] **1761. Standardize em dash spacing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/compiler_directives.mdx?plain=1#L44

Remove the stray space after the em dash so “— Requires” becomes “—Requires.”

---

- [x] **1762. Fix `^a.b` description formatting and grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/compiler_directives.mdx?plain=1#L47

Remove the stray escaped asterisk and rewrite as: “`^a.b`—Requires the major compiler version to be equal to the a part and the minor to be no lower than the b part.”

---

- [x] **1763. Clarify `^a` semantics to fixed major**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/compiler_directives.mdx?plain=1#L48

Clarify to: “`^a`—Requires the major compiler version to equal a (any minor/patch).”

---

- [x] **1764. Remove stray space before comma**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/compiler_directives.mdx?plain=1#L50

Delete the extra space before the comma: change “) ,” to “),”.

---

- [x] **1765. Remove duplicated word “version”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/compiler_directives.mdx?plain=1#L54

Delete the trailing “version” so the sentence ends with “`a.0.1`.”

---

- [x] **1766. Make list item punctuation consistent**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/compiler_directives.mdx?plain=1#L41-L60

Use a single style for list terminators by ending all items with periods and adding any missing ones.

---

- [ ] **1767. Use `load_uint` consistently in examples**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/compiler_directives.mdx?plain=1#L78-L100

Replace `load_bits(8)` with `load_uint(8)` in the pragma-enabled example and accompanying explanation to match the earlier examples, unless the difference is intentional and explained.

---

- [ ] **1768. Add missing semicolons in FunC snippets**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/compiler_directives.mdx?plain=1#L79,L85,L111

Terminate the shown statements with semicolons so each example is syntactically valid.

---

- [ ] **1769. Remove trailing whitespace in code block**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/compiler_directives.mdx?plain=1#L94

Remove the trailing space after the semicolon at the end of the line.

---

- [ ] **1770. Clarify `asm` reordering timing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/compiler_directives.mdx?plain=1#L144

Rewrite as: “Arguments are evaluated left to right; any `asm` reordering is applied after argument evaluation.”

---

- [ ] **1771. Remove duplicate note about pragma scope**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/compiler_directives.mdx?plain=1#L146,L148

Delete the redundant note that repeats the statement that the pragma applies only to code after it.

---

- [x] **1772. Clarify “matches all of them” example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/compiler_directives.mdx?plain=1#pragma-version

Replace the ambiguous phrase with an explicit rule or examples, e.g., “`^a.1` matches any `a.x.y` where `x >= 1` (e.g., `a.1.3`, `a.2.3`, `a.1.0`).”

---

- [ ] **1773. Specify failure result for `#pragma not-version`**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/compiler_directives.mdx?plain=1#pragma-not-version

Clarify the outcome to: “Compilation fails if the specified condition is met.”

---

- [ ] **1774. Verify or remove “Introduced in v0.4.1” annotations**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/compiler_directives.mdx?plain=1#pragma-allow-post-modification

Either remove the “Introduced in FunC v0.4.1” notes (for both `#pragma allow-post-modification` and `#pragma compute-asm-ltr`) or provide a citation to the changelog/release notes that documents this version.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.