### PR TITLE
Split: update docs/v3/documentation/smart-contracts/func/docs/functions.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/func/docs/functions.mdx
+++ b/docs/v3/documentation/smart-contracts/func/docs/functions.mdx
@@ -34,7 +34,7 @@ where `[ ... ]` represents an optional entry.
 
 ### Function name
 
-A function name can be any valid [identifier](/v3/documentation/smart-contracts/func/docs/literals_identifiers#identifiers). Additionally, it may start with the symbols `.` or `~`, which have specific meanings explained in the [Statements](/v3/documentation/smart-contracts/func/docs/statements#methods-calls) section.
+A function name can be any valid [identifier](/v3/documentation/smart-contracts/func/docs/literals_identifiers#identifiers). Additionally, it may start with the symbols `.` or `~`, which have specific meanings explained in the [Statements](/v3/documentation/smart-contracts/func/docs/statements#method-calls) section.
 
 For example, `udict_add_builder?`, `dict_set`, and `~dict_set` are all valid function names, and each is distinct. These functions are defined in [stdlib.fc](/v3/documentation/smart-contracts/func/docs/stdlib).
 
@@ -141,8 +141,6 @@ b = store_uint(b, 239, 8);
 builder b = begin_cell();
 b = b.store_uint(239, 8);
 ```
-So the first argument of a function can be passed to it being located before the function name, if separated by `.`. The code can be further simplified:
-
 The function's first argument is passed before the function name, separated by `.`. The syntax can be further condensed into a single statement:
 
 ```func
@@ -156,7 +154,7 @@ builder b = begin_cell().store_uint(239, 8)
                         .store_uint(0xff, 10);
 ```
 
-#### Modifying functions
+#### Modifying methods
 :::info
 A modifying function supports a short form using the `~` and `.` operators.
 :::
@@ -196,7 +194,7 @@ int x = cs~load_uint(8); ;; Modifying method syntax
 
 **Modifying methods with no return value**
 
-Sometimes, a function only modifies its first argument without returning a meaningful value. To enable modifying method syntax, such functions should return a unit type () as the second component.
+Sometimes, a function only modifies its first argument without returning a meaningful value. To enable modifying method syntax, such functions should return a unit type `()` as the second component.
 
 For example, suppose we want to define a function `inc` of type `int → int`, which increments an integer. To use it as a modifying method, we define it as follows:
 
@@ -250,7 +248,7 @@ In FunC, function specifiers modify the behavior of functions. There are three t
 2. `inline`/ `inline_ref`
 3. `method_id`
 
-One, multiple, or none can be used in a function declaration. However, they must appear in a specific order (e.g., `impure` must come before `inline`).
+One, multiple, or none can be used in a function declaration. They are typically written with `impure` before `inline`.
 
 
 #### Impure specifier
@@ -302,7 +300,6 @@ When a function is marked with the `inline_ref` specifier, its code is stored in
 #### method_id
 
 In a TVM program, every function has an internal integer ID that determines how it can be called. 
-By default, ordinary functions are assigned sequential numbers starting from `1`, while contract get-methods use `crc16` hashes of their names.
 The `method_id(<some_number>)` specifier allows you to set a function's ID to a specific value manually. 
 If no ID is specified, the default is calculated as `(crc16(<function_name>) & 0xffff) | 0x10000`. 
 If a function has the `method_id` specifier, it can be invoked by its name as a get-method in lite client or TON explorer.
@@ -311,7 +308,7 @@ If a function has the `method_id` specifier, it can be invoked by its name as a 
 **19-bit limitation**: Method IDs are limited to 19 bits by the TVM assembler, meaning the valid range is **0 to 524,287** (2^19 - 1).
 
 **Reserved ranges**:
-- **0-999**: Reserved for system functions (approximate range)
+- **0-999**: Reserved for system functions
 - **Special functions**: `main`/`recv_internal` (id=0), `recv_external` (id=-1), `run_ticktock` (id=-2)  
 - **65536+**: Default range for user functions when using automatic generation `(crc16() & 0xffff) | 0x10000`
 
@@ -358,9 +355,7 @@ int get_counter() method_id {
 ```
 
 ### Polymorphism with forall
-Before any function declaration or definition, there can be `forall` type variables declarator. It has the following syntax:
-
-A function definition can include a `forall` type variable declaration before its declaration or implementation. The syntax is:
+A function definition can include a `forall` type-variable declarator before the signature, using the following syntax:
 
 ```func
 forall <comma_separated_type_variables_names> ->
@@ -394,10 +389,7 @@ For example, the following function increments an integer and then negates it:
 ```func
 int inc_then_negate(int x) asm "INC" "NEGATE";
 ```
-– a function that increments an integer and then negates it. Calls to this function will be translated to 2 assembler commands `INC` and `NEGATE`. An alternative way to define the function is:
-
-When called, this function is directly translated into the two assembler commands, `INC` and `NEGATE`.
-Alternatively, the function can be written as:
+When called, this function is translated into `INC` and `NEGATE`. Alternatively, it can be written as:
 
 ```func
 int inc_then_negate'(int x) asm "INC NEGATE";
@@ -405,25 +397,25 @@ int inc_then_negate'(int x) asm "INC NEGATE";
 Here, `INC NEGATE` is treated as a single assembler command by FunC, but the Fift assembler correctly interprets it as two separate commands.
 
 :::info
-The list of assembler commands can be found here: [TVM instructions](/v3/documentation/tvm/instructions).
+The list of assembler commands can be found here: [TVM instructions](/v3/documentation/tvm/tvm-overview#tvm-instructions).
 :::
 
 ### Rearranging stack entries
 Sometimes, the order in which function arguments are passed may not match the expected order of an assembler command. Similarly, the returned values may need to be arranged differently. While this can be done manually using stack manipulation primitives, FunC automatically handles it.
 
 :::info
-When manually rearranging arguments, they are computed in the new order. To overwrite this behavior use `#pragma compute-asm-ltr`: [compute-asm-ltr](/v3/documentation/smart-contracts/func/docs/compiler_directives#pragma-compute-asm-ltr)
+When manually rearranging arguments, they are computed in the new order. To override this behavior, use `#pragma compute-asm-ltr`: [compute-asm-ltr](/v3/documentation/smart-contracts/func/docs/compiler_directives#pragma-compute-asm-ltr)
 :::
 
 For instance, the assembler command `STUXQ` takes an integer, a builder, and another integer as input. It then returns the builder and an integer flag indicating whether the operation succeeded. We can define the corresponding function as follows:
 
 ```func
-(builder, int) store_uint_quite(int x, builder b, int len) asm "STUXQ";
+(builder, int) store_uint_quiet(int x, builder b, int len) asm "STUXQ";
 ```
 However, if we need to rearrange the order of arguments, we can specify them explicitly in the `asm` declaration:
 
 ```func
-(builder, int) store_uint_quite(builder b, int x, int len) asm(x b len) "STUXQ";
+(builder, int) store_uint_quiet(builder b, int x, int len) asm(x b len) "STUXQ";
 ```
 So you can indicate the required order of arguments after the `asm` keyword.
 
@@ -432,7 +424,7 @@ This allows us to control the order in which arguments are passed to the assembl
 Similarly, we can rearrange return values using the following notation:
 
 ```func
-(int, builder) store_uint_quite(int x, builder b, int len) asm( -> 1 0) "STUXQ";
+(int, builder) store_uint_quiet(int x, builder b, int len) asm( -> 1 0) "STUXQ";
 ```
 
 
@@ -441,10 +433,10 @@ Here, the numbers indicate the order of return values, where `0` represents the 
 
 Additionally, we can combine these techniques:
 ```func
-(int, builder) store_uint_quite(builder b, int x, int len) asm(x b len -> 1 0) "STUXQ";
+(int, builder) store_uint_quiet(builder b, int x, int len) asm(x b len -> 1 0) "STUXQ";
 ```
 
-### Multiline asms
+### Multiline asm
 Multiline assembler commands, including Fift code snippets, can be defined using triple-quoted strings `"""`.
 
 ```func
@@ -458,4 +450,3 @@ slice hello_world() asm """
 ```
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-func-docs-functions.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/func/docs/functions.mdx`

Related issues (from issues.normalized.md):
- [ ] **1787. Clarify negative vs non‑negative method_id usage**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/functions.mdx?plain=1#L44-L46,L311-L316

Clarify that negative IDs are reserved for special entrypoints (e.g., recv_external = -1, run_ticktock = -2) and that user-defined method_id(...) must be non‑negative within the 19‑bit range (0–524,287).

---

- [ ] **1788. Insert missing space after period**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/functions.mdx?plain=1#L48

Add a space after the period: "recv_internal`.The`" → "recv_internal`. The`".

---

- [ ] **1789. Use “tick‑tock” in prose**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/functions.mdx?plain=1#L48

Use the hyphenated term "tick‑tock" in prose for consistency; keep the identifier run_ticktock unchanged.

---

- [ ] **1790. Fix TVM initialization link anchor**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/functions.mdx?plain=1#L52

Update "/v3/documentation/tvm/tvm-overview#initialization-of-tvm" to "/v3/documentation/tvm/tvm-overview#initializing-tvm".

---

- [ ] **1791. Replace Unicode arrow with ASCII in code sample**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/functions.mdx?plain=1#L70-L76

In the fenced FunC example, replace "→" with "->": "(int -> int) foo'''();" (FunC uses "->" for function types).

---

- [ ] **1792. Fix grammar on argument commas**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/functions.mdx?plain=1#L89

Change "In function arguments, commas separate it." to "Function arguments are separated by commas."

---

- [ ] **1793. Fix non‑modifying methods definition and add first‑argument note**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/functions.mdx?plain=1#L130-L133

Rewrite as "A function with at least one argument can be called using the non‑modifying method syntax." and add a first bullet "The first argument is the builder." before the existing bullets for the second and third arguments.

---

- [ ] **1794. Remove duplicated dot‑call sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/functions.mdx?plain=1#L144-L147

Delete the first sentence ("So the first argument…") and keep "The function's first argument is passed before the function name, separated by `.`."

---

- [ ] **1795. Rename heading to “Modifying methods”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/functions.mdx?plain=1#L159

For consistency with "Non‑modifying methods", change the heading "Modifying functions" to "Modifying methods".

---

- [ ] **1796. Code‑format unit type parentheses**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/functions.mdx?plain=1#L199

Change "unit type ()" to "unit type `()`".

---

- [ ] **1797. Soften or specify specifier order**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/functions.mdx?plain=1#L253

Replace "must appear in a specific order" with non‑normative wording (e.g., "typically written with `impure` before `inline`") unless the exact enforced order, including `method_id`, is documented.

---

- [ ] **1798. Unify method_id default to CRC16 rule**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/functions.mdx?plain=1#L304-L309

Remove the "sequential numbers starting from 1" claim and keep the single rule: the default is "(crc16(<name>) & 0xffff) | 0x10000"; note that get‑methods are invoked by name.

---

- [ ] **1799. Remove vagueness in “reserved ranges”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/functions.mdx?plain=1#L313-L318

Remove the "(approximate range)" qualifier from "0–999: Reserved for system functions" or replace it with an exact, referenced range.

---

- [ ] **1800. Condense redundant forall introduction**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/functions.mdx?plain=1#L360-L366

Replace the repetitive sentences with one: "A function definition can include a `forall` type‑variable declarator before the signature, using the following syntax:".

---

- [ ] **1801. Remove duplicated narration in assembler example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/functions.mdx?plain=1#L394-L405

Remove the stray en‑dash and duplicated explanations; keep one concise sentence before the alternative definition (e.g., "When called, this function is translated into `INC` and `NEGATE`. Alternatively, it can be written as:").

---

- [ ] **1802. Fix broken link to “TVM instructions”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/functions.mdx?plain=1#L407-L409

Change "/v3/documentation/tvm/instructions" to "/v3/documentation/tvm/tvm-overview#tvm-instructions".

---

- [ ] **1803. Use “override” instead of “overwrite”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/functions.mdx?plain=1#L415

Replace "overwrite" with "override" in "To override this behavior use `#pragma compute-asm-ltr`…".

---

- [ ] **1804. Correct typo: store_uint_quite → store_uint_quiet**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/functions.mdx?plain=1#L421-L427,L434-L446

Rename all occurrences of "store_uint_quite" to "store_uint_quiet" to match the "quiet" STUXQ variant.

---

- [ ] **1805. Rename heading to “Multiline asm”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/functions.mdx?plain=1#L447

Change the heading "Multiline asms" to "Multiline asm" (or "Multiline assembly").

---

- [ ] **1840. Rename “Methods calls” heading and update links**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/statements.mdx?plain=1#methods-calls

Rename the heading “### Methods calls” to “### Method calls”, which changes the anchor to “#method-calls”, and update inbound references accordingly (e.g., docs/v3/documentation/smart-contracts/func/docs/functions.mdx#function-name).

---

- [ ] **1851. Add cross‑reference for single‑argument (tuple) convention**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/statements.mdx?plain=1#function-application

After first stating that functions take a single tuple argument, add “see Functions → Argument tensor representation” linking to docs/v3/documentation/smart-contracts/func/docs/functions.mdx#argument-tensor-representation.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.