### PR TITLE
Split: update docs/v3/documentation/smart-contracts/func/docs/global_variables.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/func/docs/global_variables.mdx
+++ b/docs/v3/documentation/smart-contracts/func/docs/global_variables.mdx
@@ -2,15 +2,14 @@ import Feedback from '@site/src/components/Feedback';
 
 # Global variables
 
-A FunC program primarily consists of function declarations/definitions and global variable declarations. 
-This section focuses on the latter.
+A FunC program is a list of function declarations, function definitions, and global variable declarations. This section focuses on global variables.
 
 **A global variable** is declared using the `global` keyword, followed by the variable's type and name. For example:
 
 ```func
 global ((int, int) -> int) op;
 ```
-Here's a simple program demonstrating how to use a global functional variable:
+Here's a simple program demonstrating how to use a function-typed global variable:
 
 ```func
 int check_assoc(int a, int b, int c) {
@@ -23,12 +22,12 @@ int main() {
 }
 ```
 
-In this example, the global variable `op` is assigned the addition operator `_+_`. The program then verifies the associativity of addition using three sample integers: 2, 3, and 9.
+In this example, the global variable `op` is assigned the addition operator [`_+_`](/v3/documentation/smart-contracts/func/docs/literals_identifiers#identifiers). The program then verifies the associativity of addition using three sample integers: 2, 3, and 9.
 
-Under the hood, global variables in FunC are stored in the `c7` control register of the TVM, with a maximum limit of 31 variables.
+ 
 
 
-In FunC, you can _omit the type_ of global variable. 
+In FunC, you can _omit the type_ of a global variable. 
 In this case, the compiler determines the type based on how the variable is used. 
 For example, you can rewrite the previous program like this:
 
@@ -45,9 +44,9 @@ int main() {
 }
 ```
 
-**Declaring multiple global variables**
+## Declaring multiple global variables
 
-FunC allows users to declare multiple global variables using a single `global` keyword. 
+FunC allows you to declare multiple global variables using a single `global` keyword. 
 The following examples are equivalent:
 
 ```func
@@ -59,7 +58,7 @@ global C;
 global int A, cell B, C;
 ```
 
-**Restrictions on global and local variable names**
+## Restrictions on global and local variable names
 
 A local variable **cannot** have the same name as a previously declared global variable. The following example is invalid and will not compile:
 
@@ -77,13 +76,11 @@ However, the following example is valid:
 global int C;
 
 int main() {
-  int C = 3;
+  C = 3; ;; assigns to global C (not a local declaration)
   return C;
 }
 ```
 
-In this case, `int C = 3;` is not declaring a new local variable 
-but instead assigning value `3` to the global variable `C`. 
+In this case, this is not declaring a new local variable but instead assigning the value `3` to the global variable `C`. 
 This behavior is explained in more detail in the section on [statements](/v3/documentation/smart-contracts/func/docs/statements#variable-declaration).
 <Feedback />
-

--- a/docs/v3/documentation/smart-contracts/func/docs/global_variables.mdx
+++ b/docs/v3/documentation/smart-contracts/func/docs/global_variables.mdx
@@ -9,7 +9,7 @@ A FunC program is a list of function declarations, function definitions, and glo
 ```func
 global ((int, int) -> int) op;
 ```
-Here's a simple program demonstrating how to use a function-typed global variable:
+Here's a simple program demonstrating how to use a global functional variable:
 
 ```func
 int check_assoc(int a, int b, int c) {
@@ -24,8 +24,8 @@ int main() {
 
 In this example, the global variable `op` is assigned the addition operator [`_+_`](/v3/documentation/smart-contracts/func/docs/literals_identifiers#identifiers). The program then verifies the associativity of addition using three sample integers: 2, 3, and 9.
 
- 
 
+Under the hood, global variables in FunC are stored in the `c7` control register of the TVM, with a maximum limit of 31 variables.
 
 In FunC, you can _omit the type_ of a global variable. 
 In this case, the compiler determines the type based on how the variable is used. 
@@ -74,13 +74,14 @@ However, the following example is valid:
 
 ```func
 global int C;
-
 int main() {
-  C = 3; ;; assigns to global C (not a local declaration)
+  int C = 3;
   return C;
 }
 ```
 
-In this case, this is not declaring a new local variable but instead assigning the value `3` to the global variable `C`. 
+In this case, `int C = 3;` is not declaring a new local variable but instead assigning value `3` to the global variable `C`.
+
 This behavior is explained in more detail in the section on [statements](/v3/documentation/smart-contracts/func/docs/statements#variable-declaration).
+
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-func-docs-global_variables.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/func/docs/global_variables.mdx`

Related issues (from issues.normalized.md):
- [x] **1806. Replace slashes and 'the latter'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/global_variables.mdx?plain=1#L5-L6

Replace “function declarations/definitions” and “the latter” with explicit parallel wording: “A FunC program is a list of function declarations, function definitions, and global variable declarations. This section focuses on global variables.”

---

- [ ] **1807. Use “function-typed global variable” terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/global_variables.mdx?plain=1#L13

Replace “global functional variable” with “function-typed global variable” (or “global variable of function type”) for precision.

---

- [ ] **1808. Include global declaration or label as fragment in example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/global_variables.mdx?plain=1#L13-L24

Either add `global ((int, int) -> int) op;` at the top of the program block or rephrase to “program fragment”/“usage example” so the external `op` declaration (see L10–L12) is explicit.

---

- [ ] **1809. Remove unverified c7 storage and 31-variable limit claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/global_variables.mdx?plain=1#L28

Delete “Under the hood, global variables in FunC are stored in the `c7` control register of the TVM, with a maximum limit of 31 variables.” unless a reliable source is cited; if retained, rephrase “maximum limit” to “a maximum” and add a citation.

---

- [x] **1810. Add article: “type of a global variable”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/global_variables.mdx?plain=1#L31

Change to “In FunC, you can omit the type of a global variable.”

---

- [x] **1811. Use second person: “allows you”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/global_variables.mdx?plain=1#L50-L51

Change “FunC allows users to declare...” to “FunC allows you to declare...” or “You can declare...” for voice consistency.

---

- [ ] **1812. Add article: “assigning the value 3”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/global_variables.mdx?plain=1#L85-L86

Change to “...but instead assigning the value `3` to the global variable `C`.”

---

- [x] **1813. Convert pseudo-headings to proper markdown headings**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/global_variables.mdx?plain=1

Replace bolded pseudo-headings (e.g., “Declaring multiple global variables”, “Restrictions on global and local variable names”) with `##` headings to align with site conventions and enable anchors.

---

- [ ] **1814. Clarify global assignment vs local declaration in example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/global_variables.mdx?plain=1

In the valid example, change `int C = 3;` inside `main()` to `C = 3;` or add an inline comment (e.g., “;; assigns to global C (not a local declaration)”) to avoid misreading.

---

- [x] **1815. Link `_+_` identifier to identifiers doc**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/global_variables.mdx?plain=1

Link `_+_` to docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx#identifiers to clarify it is the standard addition-operator identifier.

---

- [ ] **1852. Cite sources for try‑catch register labels**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/statements.mdx?plain=1#try-catch-statements

Append citations confirming the mappings by linking to docs/v3/documentation/smart-contracts/func/docs/stdlib.mdx#commit for c4/c5 and docs/v3/documentation/smart-contracts/func/docs/global_variables.mdx#global-variables for c7.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.