### PR TITLE
Split: update docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx
+++ b/docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx
@@ -1,6 +1,6 @@
 import Feedback from '@site/src/components/Feedback';
 
-# Literals and identifiers
+# Literals and Identifiers
 
 ## Number literals
 
@@ -138,6 +138,7 @@ const optional-type identifier = value-or-expression;
 ```func
 const int101 = 101;                 // Numeric constant
 const str1 = "const1", str2 = "aabbcc"s; // String constants
+const int int1 = 1, int int2 = 2;   // Defined for the expression below
 const int int240 = ((int1 + int2) * 10) << 3; // Computed constant
 const slice str2r = str2;           // Constant referencing another constant
 ```


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-func-docs-literals_identifiers.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx`

Related issues (from issues.normalized.md):
- [ ] **1815. Link `_+_` identifier to identifiers doc**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/global_variables.mdx?plain=1

Link `_+_` to docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx#identifiers to clarify it is the standard addition-operator identifier.

---

- [ ] **1816. Remove escaped quotes in inline code**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx?plain=1#L13-L14

Inline code shows backslash-escaped quotes (e.g., \"string\"), which render the backslashes; replace them with plain quotes inside code spans (e.g., "string").

---

- [ ] **1817. Replace HTML <br /> with Markdown line breaks**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx?plain=1#L13-L15

Remove <br /> tags and use normal Markdown newlines or paragraphs for line breaks.

---

- [ ] **1818. Add FunC language tag to code fence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx?plain=1#L17-L26

Label the code block with func (start the fence with ```func) to enable correct syntax highlighting.

---

- [ ] **1819. Standardize dash style in string type list**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx?plain=1#L30-L36

Use a consistent punctuation style across bullets (e.g., em dashes) instead of mixing en/em dashes.

---

- [ ] **1820. Say “no suffix” instead of “without type”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx?plain=1#L30-L36

In the string types list, change “without type” to “no suffix” for clarity and consistency with the postfix items.

---

- [ ] **1821. Fix and simplify address example description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx?plain=1#L43

Replace the ungrammatical “representing an:” with “representing:” (or “representing an address:”) and simplify the overly detailed TL-B breakdown to a brief description or add a cross-reference.

---

- [ ] **1822. Standardize “built-in” hyphenation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx?plain=1#L59,L80

Use “built-in” consistently in prose (reserve “builtin” only when referring to FunC builtin identifiers by name, if applicable).

---

- [ ] **1823. Clarify backticks rule wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx?plain=1#L113-L116

Rephrase to: “Any character except newlines and internal backticks (other than the opening and closing ones).”

---

- [ ] **1824. Render backtick-quoted identifier examples correctly**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx?plain=1#L118-L121

Use multi-backtick inline code to include literal backticks, e.g., `` `I'm a variable too` `` and `` `any symbols ; ~ () are allowed here...` ``.

---

- [ ] **1825. Fix missing space in “value-or-expression can”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx?plain=1#L134

Insert the missing space so it reads “value-or-expression can be a literal or a pre-computable expression …”.

---

- [ ] **1826. Introduce triple-quoted strings explicitly**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx?plain=1#string-literals

Add a sentence noting that FunC supports triple-quoted multiline string literals ("""…""") and briefly describe their use.

---

- [ ] **1827. Clarify multi-line strings guidance**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx?plain=1#string-literals

Explicitly state that multi-line strings are written using triple quotes """…""" rather than escape sequences like \n.

---

- [ ] **1828. Capitalize CRC32 consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx?plain=1#string-literals

Change “crc32” to “CRC32” in the c-suffix description to match consistent capitalization elsewhere.

---

- [ ] **1829. Remove hard-coded numeric result from example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx?plain=1#string-literals

Delete the trailing numeric result comment (e.g., “623173419”) or mark it as illustrative to avoid unverifiable assertions.

---

- [ ] **1830. Avoid “single-line string” phrasing for identifiers**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx?plain=1#identifiers

Replace with “single-line token” or “single-line character sequence” to prevent confusion with string literals terminology.

---

- [ ] **1831. Resolve '.' and '~' exceptions in identifier rules**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx?plain=1#identifiers

Amend the disallowed symbols rule to note that '.' and '~' are disallowed inside identifiers, but function names may start with '.' or '~'.

---

- [ ] **1832. Clarify braces vs comment delimiters in identifiers**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx?plain=1#identifiers

State that while '{' and '}' are allowed, the comment delimiters “{-” and “-}” are not permitted inside identifiers.

---

- [ ] **1833. Specify comment starters explicitly**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx?plain=1#identifiers

Replace the vague “does not start as a comment or a string literal” with explicit comment starters “;;” (single-line) and “{-” (multi-line).

---

- [ ] **1834. Replace external builtins link with internal docs**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx?plain=1#identifiers

Swap the brittle GitHub source link to builtins.cpp for an internal link to /v3/documentation/smart-contracts/func/docs/builtins.

---

- [ ] **1835. Tighten invalid example explanation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx?plain=1#identifiers

For the invalid example “aa(bb”, explain that it contains “(”, which is not allowed, rather than implying unmatched parentheses.

---

- [ ] **1836. Make constants example self-contained**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx?plain=1#constants

Define int1 and int2 before use (e.g., add “const int int1 = 1, int int2 = 2;”) so the subsequent expression is reproducible.

---

- [ ] **1837. Capitalize page title**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/literals_identifiers.mdx?plain=1

Change the title from “Literals and identifiers” to “Literals and Identifiers” for consistency with section heading style.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.