### PR TITLE
Split: update docs/v3/documentation/smart-contracts/func/docs/statements.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/func/docs/statements.mdx
+++ b/docs/v3/documentation/smart-contracts/func/docs/statements.mdx
@@ -85,7 +85,7 @@ int x = foo(1, 2, 3);
 ```
 
 However, unlike many conventional languages, FunC treats functions as taking a single argument. 
-In the example above, `foo` is a function that takes one tuple argument of type `(int, int, int)` (see [Functions → Argument tensor representation](/v3/documentation/smart-contracts/func/docs/functions#argument-tensor-representation)).
+In the example above, `foo` is a function that takes one tuple argument of type `(int, int, int)` (see [Functions → Argument tensor representation](/v3/documentation/smart-contracts/func/docs/functions#function-arguments)).
 
 **Function composition**
 
@@ -420,7 +420,7 @@ If an error occurs, all changes made within the `try` block are completely rolle
 Unlike many other languages, in FunC, all changes are **undone** if an error occurs inside the `try` block. These modifications include updates to local and global variables and changes to storage registers (`c4` for storage, `c5` for action/messages, `c7` for context, etc.). 
 Any contract storage updates and outgoing messages are also reverted.
 
-For register details, see [stdlib → commit](/v3/documentation/smart-contracts/func/docs/stdlib#commit) for `c4`/`c5` and [Global variables](/v3/documentation/smart-contracts/func/docs/global_variables#global-variables) for `c7`.
+For register details, see [stdlib → commit](/v3/documentation/smart-contracts/func/docs/stdlib#commit) for `c4`/`c5` and [Global variables](/v3/documentation/smart-contracts/func/docs/global_variables) for `c7`.
 
 However, certain TVM state parameters are not rolled back, such as:
 - Codepage settings


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-func-docs-statements.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/func/docs/statements.mdx`

Related issues (from issues.normalized.md):
- [x] **1838. Rephrase intro sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/statements.mdx?plain=1

Replace “This section briefly overviews FunC statements” with “This section provides a brief overview of FunC statements.”

---

- [ ] **1839. Remove redundant Haskell-style preface**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/statements.mdx?plain=1#function-application

Remove the sentence “Also Haskell-style calls are possible, but not always (to be fixed later):” and keep the clearer “FunC also supports Haskell-style function application, but with some limitations:”.

---

- [x] **1840. Rename “Methods calls” heading and update links**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/statements.mdx?plain=1#methods-calls

Rename the heading “### Methods calls” to “### Method calls”, which changes the anchor to “#method-calls”, and update inbound references accordingly (e.g., docs/v3/documentation/smart-contracts/func/docs/functions.mdx#function-name).

---

- [x] **1841. Format “Without return values” as a subheading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/statements.mdx?plain=1

Promote the plain line “Without return values” to a subheading for consistency, e.g., “#### Modifying methods with no return value”.

---

- [x] **1842. Add missing space after `c5`**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/statements.mdx?plain=1#try-catch-statements

Insert a space after “`c5`” in “`c5`for action/messages” so it reads “`c5` for action/messages”.

---

- [ ] **1843. Clarify if-not explanation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/statements.mdx?plain=1#if-statements

Replace “Negated condition, which is equivalent to `if` (`~flag`):” with “Negated condition (equivalent to `if (~flag)`):”.

---

- [x] **1844. Clean up If examples (names, comment, blank line)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/statements.mdx?plain=1#if-statements

In the If examples, remove the stray blank line and the vague comment “;; Some specific features” and use consistent function names (e.g., do_something()/do_alternative() or matching numbered pairs).

---

- [x] **1845. Use “operands” in operator descriptions**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/statements.mdx?plain=1#operators

Replace “argument(s)” with “operand(s)” for unary and binary operators and state that operators should be separated from the operand(s).

---

- [ ] **1846. Replace Unicode superscripts in repeat bounds**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/statements.mdx?plain=1#repeat-loop

Replace “-2³¹” and “2³¹ - 1” with “-2^31” and “2^31 - 1” for consistency and copy/paste safety.

---

- [ ] **1847. Store result in try-catch cast example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/statements.mdx?plain=1#try-catch-statements

Assign the result of x.cast_to_int() to a variable (e.g., “int xi = x.cast_to_int();”) and update the comment and subsequent expression to use that variable.

---

- [x] **1848. Improve non‑modifying methods phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/statements.mdx?plain=1#methods-calls

Rephrase to “a function with at least one argument can be invoked as a non‑modifying method using the `.` syntax.”

---

- [ ] **1849. Replace confusing multi-init example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/statements.mdx?plain=1#variable-declaration

Replace “(int x = 1, int y = 2, int z = 3);” with the consistent tuple assignment “(int x, int y, int z) = (1, 2, 3);”.

---

- [x] **1850. Remove double space in repeat sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/statements.mdx?plain=1#repeat-loop

Collapse the double space in “an `int` expression” to a single space: “an `int` expression”.

---

- [ ] **1851. Add cross‑reference for single‑argument (tuple) convention**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/statements.mdx?plain=1#function-application

After first stating that functions take a single tuple argument, add “see Functions → Argument tensor representation” linking to docs/v3/documentation/smart-contracts/func/docs/functions.mdx#argument-tensor-representation.

---

- [ ] **1852. Cite sources for try‑catch register labels**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/statements.mdx?plain=1#try-catch-statements

Append citations confirming the mappings by linking to docs/v3/documentation/smart-contracts/func/docs/stdlib.mdx#commit for c4/c5 and docs/v3/documentation/smart-contracts/func/docs/global_variables.mdx#global-variables for c7.

---

- [ ] **1853. Remove time‑relative phrasing in lambda note**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/statements.mdx?plain=1#lambda-expressions

Change “Lambda expressions are not yet supported in FunC.” to “Lambda expressions are not supported in FunC.”.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.