### PR TITLE
Split: update docs/v3/documentation/smart-contracts/func/docs/types.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/func/docs/types.mdx
+++ b/docs/v3/documentation/smart-contracts/func/docs/types.mdx
@@ -45,7 +45,6 @@ allowing a variable of type `A` to store either a valid value or `null`.
 This transformation happens automatically and is not enforced by the type checker.
 
 ## Hole types
-
 FunC has support for type inference. Types `_` and `var` represent type "holes" which can later be filled with some actual type during type checking. For example, `var x = 2;` is a definition of variable `x` equal to `2`. The type checker can infer that `x` has type `int`, because `2` has type `int`, and the left and right sides of the assignment must have equal types.
 
 FunC supports type inference. The hole types `_` and `var` serve as placeholders that are resolved during type checking.


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-func-docs-types.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/func/docs/types.mdx`

Related issues (from issues.normalized.md):
- [ ] **1879. Distinguish atomic tuple from composite tuple types**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/types.mdx?plain=1#L23

Readers may conflate atomic `tuple` with composite tuple types; add a note stating they are not interchangeable (e.g., `tuple` ≠ `[int, cell]`) and cannot be converted to each other (also reference the “Tuple types” section around L115–L125).

---

- [ ] **1880. Clarify optional types and remove implicit A→A^? claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/types.mdx?plain=1#L36-L45

Replace the null/Maybe text to state that optional types are written `A^?` (“Maybe A”), a variable of type `A` cannot hold `null`, passing `null` where a non-null `A` is required is an error, and remove the claim that `A` is implicitly transformed into `A^?`.

---

- [ ] **1881. Remove duplicate “Hole type” text and fix code fence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/types.mdx?plain=1#L48-L58

Delete the repeated paragraph so the section explains `_` and `var` once with a single example, and remove the leading space from the closing code fence at L55.

---

- [x] **1882. Add “the” before domain/codomain**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/types.mdx?plain=1#L66-L69

In “Functional type,” change “called domain/codomain” to “called the domain/codomain.”

---

- [x] **1883. Fix tuple example parenthetical punctuation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/types.mdx?plain=1#L90-L97

Change “(2, 3, and 9)” to “(2, 3, 9)” inside the parenthetical stack entry list.

---

- [x] **1884. Fix misaligned code fence in tuple example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/types.mdx?plain=1#L94-L97

Remove the leading space on the closing triple backticks so it aligns with the opening fence.

---

- [x] **1885. Insert missing space before `()` in “unit type”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/types.mdx?plain=1#L100

Change “unit type`()” to “unit type `()`” to render the inline code correctly.

---

- [ ] **1886. Fix unit examples: use ~dump, format identifiers, add periods**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/types.mdx?plain=1#L106-L109

Replace undefined “print_int” with documented “~dump” (`X -> ()`), format “random” as inline code, and end the two unit-type bullets with periods.

---

- [ ] **1887. Remove duplicate “(A) equals A” statement**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/types.mdx?plain=1#L111-L114

Keep a single note that `(A)` is treated as identical to `A` and delete the duplicate occurrence.

---

- [x] **1888. Rename heading to “Tuple types”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/types.mdx?plain=1#L115-L117

Change the section header from “Tuples types” to “Tuple types.”

---

- [ ] **1889. Remove duplicate explanation in polymorphism example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/types.mdx?plain=1#L139-L144

Delete the repeated narrative so the example is explained once concisely (either inline or as bullets).

---

- [x] **1890. Rename heading to “Hole types”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/docs/types.mdx?plain=1

Update the heading from “Hole type” to “Hole types” to match that the section covers both `_` and `var`.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.