### PR TITLE
Split: update docs/v3/documentation/smart-contracts/func/overview.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/func/overview.mdx
+++ b/docs/v3/documentation/smart-contracts/func/overview.mdx
@@ -1,14 +1,14 @@
 import Feedback from '@site/src/components/Feedback';
 
-import Button from '@site/src/components/button'
+import Button from '@site/src/components/button';
 
 # Overview
 
-FunC is minimalist, domain-specific, functional-style language designed for writing low-level TON smart contracts, tightly bound to the TVM model.
+**FunC** is a high-level language used to program smart contracts on TON.
 
-Here is a simple example of a method for sending money written in FunC:
+FunC is a domain-specific, C-like, statically typed language. Here is a simple example of a method for sending money written in FunC:
 
-```func
+```c
 () send_money(slice address, int amount) impure inline {
     var msg = begin_cell()
         .store_uint(0x10, 6) ;; nobounce
@@ -22,7 +22,7 @@ Here is a simple example of a method for sending money written in FunC:
 
 The compiler converts FunC programs into Fift assembler code, generating the corresponding bytecode for the [TON Virtual Machine](/v3/documentation/tvm/tvm-overview/).
 
-Developers and engineers can use its bytecode, which is structured as a [tree of cells](/v3/concepts/dive-into-ton/ton-blockchain/cells-as-data-storage/) like all data in the TON Blockchain, to create smart contracts or run it on a local instance of the TVM.
+Developers can use this bytecode, which is structured as a [tree of cells](/v3/concepts/dive-into-ton/ton-blockchain/cells-as-data-storage/) like all data in the TON Blockchain, to deploy smart contracts or run this bytecode on a local instance of the TVM.
 
 <Button href="/v3/documentation/smart-contracts/func/cookbook" colorType={'primary'} sizeType={'sm'}>
   FunC cookbook
@@ -34,27 +34,51 @@ Developers and engineers can use its bytecode, which is structured as a [tree of
 
 ## Compiler
 
-### Blueprint
+### Compile with JS
 
-Using the Blueprint framework is the most convenient and quickest way to begin developing and compiling smart contracts.
+Using the Blueprint development environment is the most convenient and quickest way to begin developing and compiling smart contracts.
 Read more in the [Blueprint](/v3/documentation/smart-contracts/getting-started/javascript/) section.
 
-### GitHub
+```bash
+npm create ton@latest
+```
 
-FunC binaries can be downloaded from the [GitHub repository](https://github.com/ton-blockchain/ton/releases) or [compiled manually](/v3/guidelines/smart-contracts/howto/compile/compilation-instructions#func) from sources.
+### Use precompiled binaries
+
+If you want to use the FunC compiler locally, you need to set up the TON compiler binaries on your machine.
+FunC compiler binaries for Windows, macOS (Intel/Apple Silicon), and Linux can be downloaded from:
+
+- [Precompiled binaries](/v3/documentation/archive/precompiled-binaries/)
+
+:::info
+Alternatively, you can build binaries from source code,
+such as the [compiler's source code for FunC](https://github.com/ton-blockchain/ton/tree/master/crypto/func/).
+Read [how to compile](/v3/guidelines/smart-contracts/howto/compile/compilation-instructions#func) it from source.
+:::
+
+## TON Blockchain course
+
+The [TON Blockchain course](https://stepik.org/course/176754/) covers FunC and smart contract development.
+
+<Button href="https://stepik.org/course/176754/promo" colorType={'primary'} sizeType={'sm'}>
+  Check TON Blockchain course
+</Button>
+
+<Button href="https://stepik.org/course/201638/promo" colorType={'secondary'} sizeType={'sm'}>
+  Chinese
+</Button>
+
+<Button href="https://stepik.org/course/201855/promo" colorType={'secondary'} sizeType={'sm'}>
+  Russian
+</Button>
 
 ## Tutorials
 
 :::tip starter tip
-The best place to start developing on TON is the [Quick start](/v3/guidelines/quick-start/getting-started) section.
+The best place to start developing with FunC is the [Introduction](/v3/documentation/smart-contracts/overview/) section.
 :::
 
-The [TON Blockchain course](/v3/documentation/smart-contracts/overview#ton-blockchain-course) includes Module 4,
-which covers FunC and smart contract development.
-
 Below, you can find additional materials shared by community experts:
-
-- [TON Hello World: step-by-step guide for writing your first smart contract](https://helloworld.tonstudio.io/02-contract/)
 
 - [Challenge 1: Simple NFT deploy](https://github.com/romanovichim/TONQuest1/)
 - [Challenge 2: Chatbot contract](https://github.com/romanovichim/TONQuest2/)
@@ -63,16 +87,36 @@ Below, you can find additional materials shared by community experts:
 - [Challenge 5: Create UI to interact with the contract in 5 minutes](https://github.com/romanovichim/TONQuest5/)
 - [Challenge 6: Analyzing NFT sales on the Getgems marketplace](https://github.com/romanovichim/TONQuest6/)
 
-- [FunC lessons](https://github.com/romanovichim/TonFunClessons_Eng/) ([RU version](https://github.com/romanovichim/TonFunClessons_ru/)) by _@romanovichim_
-- [FunC quiz](https://t.me/toncontests/60/) ([RU version](https://t.me/toncontests/58?comment=14888/)) by _Vadim_. It is good for self-checking and will take 10–15 minutes. The questions are mainly about FunС, with a few general questions about TON.
+- [FunC & Blueprint](https://www.youtube.com/watch?v=7omBDfSqGfA&list=PLtUBO1QNEKwtO_zSyLj-axPzc9O9rkmYa/) - _@MarcoDaTr0p0je_
+- [TON hello world: step-by-step guide for writing your first smart contract](https://ton-community.github.io/tutorials/02-contract/)
+- [TON hello world: step-by-step guide for testing your first smart contract](https://ton-community.github.io/tutorials/04-testing/)
+- [10 FunC lessons](https://github.com/romanovichim/TonFunClessons_Eng/) - _@romanovichim_, using Blueprint
+- [10 FunC lessons (RU)](https://github.com/romanovichim/TonFunClessons_ru/) - _@romanovichim_, using Blueprint
+- [FunC quiz](https://t.me/toncontests/60/) - _Vadim_. It is good for self-checking and will take 10–15 minutes. The questions are mainly about FunC, with a few general questions about TON.
+- [FunC quiz (RU)](https://t.me/toncontests/58?comment=14888/) - _Vadim_
+
+## Contests
+
+Joining [contests](https://t.me/toncontests/) is a great way to learn FunC.
+You can also review past competitions to learn more.
+
+#### Legacy contests
+
+| Contest           | Tasks                                                     | Solutions                                                                                     |
+| ----------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| TSC #5 (Dec 2023) | [Tasks](https://github.com/ton-community/tsc5/)           |                                                                                               |
+| TSC #4 (Sep 2023) | [Tasks](https://github.com/ton-community/tsc4/)           | [Solutions](/v3/documentation/smart-contracts/contracts-specs/examples#ton-smart-challenge-4) |
+| TSC #3 (Dec 2022) | [Tasks](https://github.com/ton-blockchain/func-contest3/) | [Solutions](https://github.com/nns2009/TON-FunC-contest-3/)                                   |
+| TSC #2 (Jul 2022) | [Tasks](https://github.com/ton-blockchain/func-contest2/) | [Solutions](https://github.com/ton-blockchain/func-contest2-solutions/)                       |
+| TSC #1 (Mar 2022) | [Tasks](https://github.com/ton-blockchain/func-contest1/) | [Solutions](https://github.com/ton-blockchain/func-contest1-solutions/)                       |
 
 ## Smart contract examples
 
 Follow [this link](/v3/documentation/smart-contracts/contracts-specs/examples/) to find various standard smart contracts,
-such as wallets, electors that manage validation on TON, multi-signature wallets, etc. These can serve as helpful learning references.
+such as wallets, the Elector contract that manages validator elections on TON, multi-signature wallets, etc. These can serve as helpful learning references.
 
 ## Changelog
 
-[Blockchain changelog](https://github.com/ton-blockchain/ton/blob/master/Changelog.md)
+[History of FunC](/v3/documentation/smart-contracts/func/changelog/)
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-func-overview.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/func/overview.mdx`

Related issues (from issues.normalized.md):
- [ ] **1901. Add missing semicolon in import**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/overview.mdx?plain=1#L1-L3

Ensure consistent import style by adding a semicolon to line 3: import Button from '@site/src/components/button';

---

- [ ] **1902. Fix FunC code block highlighting**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/overview.mdx?plain=1#L11

Change the code fence language from ```func to ```c (or ```cpp) so blocks render with syntax highlighting until FunC Prism support is added.

---

- [ ] **1903. Clarify bytecode sentence pronouns**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/overview.mdx?plain=1#L25

Rewrite to remove ambiguity: “Developers can use this bytecode, which is structured as a tree of cells like all data in the TON Blockchain, to deploy smart contracts or run this bytecode on a local instance of the TVM.”

---

- [ ] **1904. Rename “Compile with original binaries” heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/overview.mdx?plain=1#L46

Replace the ambiguous heading with “Use precompiled binaries” to align with the linked precompiled-binaries page.

---

- [ ] **1905. Fix wording about using FunC locally**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/overview.mdx?plain=1#L48

Change “use the native FunC language locally” to “use the FunC compiler locally” and in the info note replace “create binaries from source code” with “build binaries from source code.”

---

- [ ] **1906. Use “from source” phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/overview.mdx?plain=1#L56

Change “Read how to compile it from sources.” to “Read how to compile it from source.”

---

- [ ] **1907. Capitalize FunC in “Func & Blueprint”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/overview.mdx?plain=1#L91

Update the link text to “FunC & Blueprint” for consistent capitalization.

---

- [ ] **1908. Capitalize Blueprint as proper noun**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/overview.mdx?plain=1#L94-L95

Replace “using a blueprint” with “using Blueprint” (or “using the Blueprint framework”) to reflect the proper name.

---

- [ ] **1909. Replace Cyrillic “С” with Latin “C” in “FunC”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/overview.mdx?plain=1#L96

Fix the visually deceptive “FunС” by replacing the Cyrillic “С” (U+0421) with the Latin “C” to read “FunC.”

---

- [ ] **1910. Rename “Contests legacy” heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/overview.mdx?plain=1#L104

Improve readability by changing the subsection heading to “Legacy contests.”

---

- [ ] **1911. Use singular “Elector contract”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/overview.mdx?plain=1#L117

Replace “electors that manage validation on TON” with “the Elector contract that manages validator elections on TON.”

---

- [ ] **4514. Internal message example omits required tail bits**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/overview.mdx?plain=1

The example builds only flags, destination, and coins then calls send_raw_message(msg, 64), but it must also zero the header fee/timestamp fields and include init/body Maybe bits; add .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1) before .end_cell() and include a body slice if needed.

---

- [ ] **4515. Use recommended message mode or explain 64**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/overview.mdx?plain=1

Replace send_raw_message(msg, 64) with mode 3 for simple sends (pay fees separately, ignore action errors) or add an inline comment linking to Message modes to justify using 64.

---

- [ ] **4516. Use 'FunC' casing in 'FunC & Blueprint'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/overview.mdx?plain=1

Change the label "Func & Blueprint" to "FunC & Blueprint" to match the glossary naming.

---

- [ ] **4517. Replace Cyrillic 'С' with Latin 'C' in 'FunC'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/overview.mdx?plain=1

In the FunC quiz description, correct "FunС" (Cyrillic С) to "FunC" (Latin C) to avoid search/copy issues.

---

- [ ] **4518. Update 'TON Hello World' links and title case**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/overview.mdx?plain=1

Replace ton-community.github.io tutorial links with https://helloworld.tonstudio.io/02-contract/ and https://helloworld.tonstudio.io/04-testing/ and use the title case "TON Hello World: …" consistently.

---

- [ ] **4519. Say 'Linux' instead of 'Ubuntu' for binaries**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/overview.mdx?plain=1

Change "Windows, macOS (Intel/M1), and Ubuntu" to "Windows, macOS (Intel/Apple Silicon), and Linux" to match the Precompiled binaries page.

---

- [ ] **4520. Match link text to 'Precompiled binaries' page title**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/overview.mdx?plain=1

Change the link text "Environment setup page" to "Precompiled binaries" while keeping the same URL.

---

- [ ] **4521. Clarify 'use the native FunC language locally'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/overview.mdx?plain=1

Reword to "If you want to use the FunC compiler locally, set up the TON compiler binaries on your machine" to refer to the compiler rather than the language.

---

- [ ] **4522. Call Blueprint a development environment**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/overview.mdx?plain=1

Replace "framework" with "development environment" when referring to Blueprint to match its description.

---

- [ ] **4523. Rename course buttons to 'Chinese' and 'Russian'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/overview.mdx?plain=1

Change button labels "CHN" and "RU" to "Chinese" and "Russian" for consistency with the smart contracts introduction.

---

- [ ] **4524. Remove unsupported 'Module 4' reference**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/overview.mdx?plain=1

Delete the specific "Module 4" mention in the course description since module numbering/content is external and not corroborated in these docs.

---

- [ ] **4525. Capitalize 'Blueprint' in tutorial bullets**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/func/overview.mdx?plain=1

In the two tutorial bullets, change "using a blueprint" to "using Blueprint" to correctly capitalize the product name.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.