### PR TITLE
Split: update docs/v3/documentation/smart-contracts/getting-started/testnet.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/getting-started/testnet.mdx
+++ b/docs/v3/documentation/smart-contracts/getting-started/testnet.mdx
@@ -21,7 +21,7 @@ Toncoin and other assets on Testnet have no value, and the network can be reset 
   Get Testnet Toncoin
 </Button>
 
-<Button href="https://t.me/testnetstatus" colorType={'secondary'} sizeType={'sm'}>
+<Button href="https://t.me/testnetstatus" colorType="secondary" sizeType="sm">
   Testnet status channel
 </Button>
 
@@ -35,7 +35,7 @@ Testnet mirrors the Mainnet infrastructure, including wallets, APIs, bridges, an
 |-----------------------|------|
 | Explorer            | [testnet.tonscan.org](https://testnet.tonscan.org) |
 | Web wallet          | [wallet.ton.org](https://wallet.ton.org/?testnet=true) |
-| Browser extension   | [install](https://chrome.google.com/webstore/detail/ton-wallet/nphplpgoakhhjchkkhmiggakijnkhfnd) and [switch to Testnet](https://github.com/toncenter/ton-wallet?tab=readme-ov-file#switch-between-mainnet-and-testnet) |
+| Browser extension   | [install](https://chrome.google.com/webstore/detail/ton-wallet/nphplpgoakhhjchkkhmiggakijnkhfnd) and [switch to Testnet](https://github.com/toncenter/ton-wallet/blob/master/readme.md#switch-between-mainnet-and-testnet) |
 | TON Center API      | [testnet.toncenter.com](https://testnet.toncenter.com) |
 | TON HTTP API        | [testnet.tonapi.io](https://testnet.tonapi.io/) |
 | Bridge              | [bridge.ton.org](https://bridge.ton.org/?testnet=true) |
@@ -46,14 +46,14 @@ Testnet mirrors the Mainnet infrastructure, including wallets, APIs, bridges, an
 
 - [Tonkeeper Testnet](https://tonkeeper.helpscoutdocs.com/article/100-how-switch-to-the-testnet)
 - [Crypto Testnet Bot](https://t.me/CryptoTestnetBot)
-- [TON Space Testnet](https://t.me/wallet/start?startapp=tonspace_settings)
+- [TON Space](https://t.me/wallet/start?startapp=tonspace_settings)
 - [Multisig wallet Testnet](https://multisig.ton.org/?testnet=true)
 
 ### Explorers
 
 - [Tonscan Testnet](https://testnet.tonscan.org)
 - [Tonviewer Testnet](https://testnet.tonviewer.com)
-- [Test explorer](https://test-explorer.toncoin.org)
+- [Test explorer](https://testnet.tonviewer.com)
 - [TON Explorer Testnet](https://tonsandbox.com/explorer)
 
 ### Other services
@@ -61,7 +61,6 @@ Testnet mirrors the Mainnet infrastructure, including wallets, APIs, bridges, an
 - [Minter Testnet](https://minter.ton.org/?testnet=true)
 - [DNS Testnet](https://dns.ton.org/?testnet=true)
 - [Vesting Testnet](https://vesting.ton.org/?testnet=true)
-- [Test staking](https://teststaking.xyz)
 - [Getgems Testnet](https://testnet.getgems.io)
 - [Hipo Testnet](https://app.hipo.finance/#/network=testnet/)
 - [Elections Testnet](https://testnet-elections.toncenter.com/getValidationCycles?limit=2&return_participants=true)


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-getting-started-testnet.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/getting-started/testnet.mdx`

Related issues (from issues.normalized.md):
- [ ] **1937. Use 'Testnet' as proper noun in callout**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/getting-started/testnet.mdx?plain=1#L11

Change “Coins in the test network have no value” to “Coins on the Testnet have no value” for consistent capitalization and usage across the docs.

---

- [ ] **1938. Standardize JSX string prop quoting**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/getting-started/testnet.mdx?plain=1#L16-L26

Use a single style for string props; switch to double-quoted strings throughout (e.g., sizeType="sm", colorType="primary"|"secondary").

---

- [ ] **1939. Fix README anchor to blob URL**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/getting-started/testnet.mdx?plain=1#L38

Replace the GitHub README link that uses ?tab=readme-ov-file with the blob URL to ensure the section anchor resolves: https://github.com/toncenter/ton-wallet/blob/master/readme.md#switch-between-mainnet-and-testnet.

---

- [ ] **1940. Replace broken Test Explorer URL**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/getting-started/testnet.mdx?plain=1#L56

Replace https://test-explorer.toncoin.org (HTTP 502) with a working Testnet explorer, e.g., https://testnet.tonviewer.com.

---

- [ ] **1941. Align tonsandbox explorer label to brand**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/getting-started/testnet.mdx?plain=1#L57

Change the link text from “TON Explorer Testnet” to “Ton Sandbox Explorer (Testnet)” to match the destination branding and avoid confusion with explorer.toncoin.org.

---

- [ ] **1942. Remove or replace dead 'Test staking' link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/getting-started/testnet.mdx?plain=1#L64

Delete the https://teststaking.xyz entry (no DNS) or update it to a confirmed, stable Testnet staking URL.

---

- [ ] **1943. Remove unsubstantiated 'reset at any time' claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/getting-started/testnet.mdx?plain=1

Delete the clause “and the network can be reset at any time.” from the callout unless an authoritative citation is provided.

---

- [ ] **1944. Rename 'TON HTTP API' to 'TonAPI (Testnet)'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/getting-started/testnet.mdx?plain=1

Update the label pointing to https://testnet.tonapi.io/ to “TonAPI (Testnet)” to match the service’s brand.

---

- [ ] **1945. Rename 'TON Center API' to 'TON Center (Testnet)'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/getting-started/testnet.mdx?plain=1

Change the label “TON Center API” to “TON Center (Testnet)” for brand consistency with the rest of the docs.

---

- [ ] **1946. Remove 'Testnet' suffix from wallet link texts**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/getting-started/testnet.mdx?plain=1

Rename “Tonkeeper Testnet” and “TON Space Testnet” to “Tonkeeper” and “TON Space” since the URLs are not testnet-specific.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.