### PR TITLE
Split: update docs/v3/documentation/smart-contracts/message-management/ecosystem-messages-layout.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/message-management/ecosystem-messages-layout.mdx
+++ b/docs/v3/documentation/smart-contracts/message-management/ecosystem-messages-layout.mdx
@@ -1,11 +1,10 @@
 import Feedback from '@site/src/components/Feedback';
 
-import ConceptImage from "@site/src/components/conceptImage";
 import ThemedImage from "@theme/ThemedImage";
 
 # Ecosystem messages layout
 
-## Sending messages
+## Send messages
 
 <div class="text--center">
   <ThemedImage
@@ -18,7 +17,7 @@ import ThemedImage from "@theme/ThemedImage";
   />
 </div>
 
-## Deploying a contract
+## Deploy a contract
 
 <div class="text--center">
   <ThemedImage
@@ -31,12 +30,12 @@ import ThemedImage from "@theme/ThemedImage";
   />
 </div>
 
-## Burn jettons
+## Burn Jettons
 
 - Implementation: [modern_jetton](https://github.com/EmelyanenkoK/modern_jetton/blob/master/contracts/op-codes.func) smart contract
   <div class="text--center">
     <ThemedImage
-      alt="Diagram of jetton burning process"
+      alt="Diagram of Jetton burning process"
       sources={{
         light:
           "/img/docs/ecosystem-messages-layout/ecosystem_messages_layout_3.svg?raw=true",
@@ -45,7 +44,7 @@ import ThemedImage from "@theme/ThemedImage";
     />
   </div>
 
-## Request jetton wallet address
+## Request a Jetton wallet address
 
 - Implementation: [modern_jetton](https://github.com/EmelyanenkoK/modern_jetton/blob/master/contracts/op-codes.func) smart contract
   <div class="text--center">
@@ -59,12 +58,12 @@ import ThemedImage from "@theme/ThemedImage";
     />
   </div>
 
-## Transfer jettons
+## Transfer Jettons
 
 - Implementation: [modern_jetton](https://github.com/EmelyanenkoK/modern_jetton/blob/master/contracts/op-codes.func) smart contract
   <div class="text--center">
     <ThemedImage
-      alt="Diagram of jetton transfer process"
+      alt="Diagram of Jetton transfer process"
       sources={{
         light:
           "/img/docs/ecosystem-messages-layout/ecosystem_messages_layout_5.svg?raw=true",
@@ -73,23 +72,23 @@ import ThemedImage from "@theme/ThemedImage";
     />
   </div>
 
-## Mint jettons
+## Mint Jettons
 
-- Implementation: [minter-contract](https://github.com/ton-blockchain/minter-contract/blob/main/contracts/imports/op-codes.fc) smart contract
+- Implementation: [minter-contract](https://github.com/ton-blockchain/token-contract) smart contract
   <div class="text--center">
     <ThemedImage
-      alt="Diagram of jetton minting process"
+      alt="Diagram of Jetton minting process"
       sources={{
         light:
-          "/img/docs/ecosystem-messages-layout/ecosystem_messages_layout_6.png?raw=true",
-        dark: "/img/docs/ecosystem-messages-layout/ecosystem_messages_layout_6_dark.png?raw=true",
+          "/img/docs/ecosystem-messages-layout/ecosystem_messages_layout_6.svg?raw=true",
+        dark: "/img/docs/ecosystem-messages-layout/ecosystem_messages_layout_6_dark.svg?raw=true",
       }}
     />
   </div>
 
-## Prove SBT ownership to contract
+## Prove SBT ownership to a contract
 
-- Implementation: [nft_contract](https://github.com/getgems-io/nft-contracts/blob/main/packages/contracts/sources/op-codes.fc) smart contract
+- Implementation: [nft-contracts](https://github.com/getgems-io/nft-contracts/blob/main/packages/contracts/sources/op-codes.fc) smart contract
   <div class="text--center">
     <ThemedImage
       alt="Diagram of SBT ownership verification"
@@ -103,7 +102,7 @@ import ThemedImage from "@theme/ThemedImage";
 
 ## Transfer NFT
 
-- Implementation: [nft_contract](https://github.com/getgems-io/nft-contracts/blob/main/packages/contracts/sources/op-codes.fc) smart contract
+- Implementation: [nft-contracts](https://github.com/getgems-io/nft-contracts/blob/main/packages/contracts/sources/op-codes.fc) smart contract
   <div class="text--center">
     <ThemedImage
       alt="Diagram of NFT transfer process"
@@ -118,7 +117,7 @@ import ThemedImage from "@theme/ThemedImage";
 ## Mint NFT
 
 :::info
-Not specified by NFT standard in /ton-blockchain/token-contract
+Not specified by the NFT standard in [ton-blockchain/token-contract](https://github.com/ton-blockchain/token-contract).
 :::
 
 <div class="text--center">
@@ -135,7 +134,7 @@ Not specified by NFT standard in /ton-blockchain/token-contract
 ## Batch mint NFT
 
 :::info
-Not specified by NFT standard in /ton-blockchain/token-contract
+Not specified by the NFT standard in [ton-blockchain/token-contract](https://github.com/ton-blockchain/token-contract).
 :::
 
 <div class="text--center">
@@ -149,9 +148,9 @@ Not specified by NFT standard in /ton-blockchain/token-contract
   />
 </div>
 
-## Destroy SBT by user
+## Destroy an SBT by the user
 
-- Implementation: [nft_contracts](https://github.com/getgems-io/nft-contracts/blob/main/packages/contracts/sources/op-codes.fc) smart contract
+- Implementation: [nft-contracts](https://github.com/getgems-io/nft-contracts/blob/main/packages/contracts/sources/op-codes.fc) smart contract
   <div class="text--center">
     <ThemedImage
       alt="Diagram of user-initiated SBT destruction"
@@ -163,9 +162,9 @@ Not specified by NFT standard in /ton-blockchain/token-contract
     />
   </div>
 
-## Destroy SBT by admin
+## Destroy an SBT by the admin
 
-- Implementation: [nft_contracts](https://github.com/getgems-io/nft-contracts/blob/main/packages/contracts/sources/op-codes.fc) smart contract
+- Implementation: [nft-contracts](https://github.com/getgems-io/nft-contracts/blob/main/packages/contracts/sources/op-codes.fc) smart contract
   <div class="text--center">
     <ThemedImage
       alt="Diagram of admin-initiated SBT destruction"
@@ -178,4 +177,3 @@ Not specified by NFT standard in /ton-blockchain/token-contract
   </div>
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-message-management-ecosystem-messages-layout.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/message-management/ecosystem-messages-layout.mdx`

Related issues (from issues.normalized.md):
- [ ] **1961. Remove unused ConceptImage import**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/ecosystem-messages-layout.mdx?plain=1#L3

ConceptImage is imported but never used; remove the import at line 3 to avoid lint errors and dead code.

---

- [ ] **1962. Standardize heading style to imperative**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/ecosystem-messages-layout.mdx?plain=1#L21

Headings mix styles; use the imperative form across the page (e.g., “Deploy a Contract”) and include articles for parallelism in SBT destruction headings (“by the user”/“by the admin”).

---

- [ ] **1963. Capitalize Jetton(s) in headings and alt text; fix article**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/ecosystem-messages-layout.mdx?plain=1#L34, L48, L62, L76

Capitalize “Jetton/Jettons” in these headings and related image alt text for consistency, and change line 48 to “Request a Jetton wallet address.”

---

- [ ] **1964. Use SVG images in Mint Jettons section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/ecosystem-messages-layout.mdx?plain=1#L83-L86

Replace the PNG sources with the SVG files /img/docs/ecosystem-messages-layout/ecosystem_messages_layout_6.svg and /img/docs/ecosystem-messages-layout/ecosystem_messages_layout_6_dark.svg using ?raw=true.

---

- [ ] **1965. Fix article in “Prove SBT ownership to contract”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/ecosystem-messages-layout.mdx?plain=1#L90

Change the heading to “Prove SBT ownership to a contract” for natural English.

---

- [ ] **1966. Unify Getgems repo link text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/ecosystem-messages-layout.mdx?plain=1#L92-L106, L154, L168

Use a consistent label “nft-contracts” for all Getgems implementation links, keeping the URLs unchanged.

---

- [ ] **1967. Link and rephrase NFT standard note**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/ecosystem-messages-layout.mdx?plain=1#L121, L138

Replace the plain path with a proper link and clearer phrasing: “Not specified by the NFT standard in [ton-blockchain/token-contract](https://github.com/ton-blockchain/token-contract).”

---

- [ ] **1968. Update jetton minter reference to canonical repo**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/ecosystem-messages-layout.mdx?plain=1

Update the “Mint jettons” implementation link to the canonical minter in https://github.com/ton-blockchain/token-contract (instead of ton-blockchain/minter-contract) to align with the standard.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.