### PR TITLE
Split: update docs/v3/documentation/smart-contracts/message-management/external-messages.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/message-management/external-messages.mdx
+++ b/docs/v3/documentation/smart-contracts/message-management/external-messages.mdx
@@ -2,17 +2,17 @@ import Feedback from '@site/src/components/Feedback';
 
 # External messages
 
-**External message** in TON is a message that originates *outside the blockchain* or is intended for actors *outside it*. These messages enable interaction between smart contracts and the external world. External messages (external inbound, ext_in) come in two types:
+**External message** in TON is a message that originates *outside the blockchain* or is intended for actors *outside it*. These messages enable interaction between smart contracts and the external world. External messages come in two types:
 
 - External incoming messages
 - External outgoing messages
 
 ## External incoming messages
 
-**External incoming messages (external inbound, ext_in)** are messages sent from outside to smart contracts on the TON Blockchain. They serve as the main entry point for external actors to interact with the blockchain.
+**External incoming messages (external inbound, ext_in)** are messages sent from outside to smart contracts on TON Blockchain. They serve as the main entry point for external actors to interact with the blockchain.
 
 **Key points**
-- Any account can receive external inbound (ext_in) messages, but handling depends on the contract’s logic.
+- Any account can receive external incoming messages, but handling depends on the contract’s logic.
 - Common sources include wallet users, validators, and DApp services.
 - Wallet contracts often receive external inbound (ext_in) messages and relay instructions internally through _internal messages_.
 

--- a/docs/v3/documentation/smart-contracts/message-management/external-messages.mdx
+++ b/docs/v3/documentation/smart-contracts/message-management/external-messages.mdx
@@ -14,7 +14,7 @@ import Feedback from '@site/src/components/Feedback';
 **Key points**
 - Any account can receive external incoming messages, but handling depends on the contract’s logic.
 - Common sources include wallet users, validators, and DApp services.
-- Wallet contracts often receive external inbound (ext_in) messages and relay instructions internally through _internal messages_.
+- Wallet contracts often receive and relay instructions internally through internal messages.
 
 
 ### External incoming message structure

--- a/docs/v3/documentation/smart-contracts/message-management/external-messages.mdx
+++ b/docs/v3/documentation/smart-contracts/message-management/external-messages.mdx
@@ -14,8 +14,7 @@ import Feedback from '@site/src/components/Feedback';
 **Key points**
 - Any account can receive external incoming messages, but handling depends on the contract’s logic.
 - Common sources include wallet users, validators, and DApp services.
-- Wallet contracts often receive and relay instructions internally through internal messages.
-
+- Wallet contracts often receive external incoming messages and relay instructions internally through _internal messages_.
 
 ### External incoming message structure
 

--- a/docs/v3/documentation/smart-contracts/message-management/external-messages.mdx
+++ b/docs/v3/documentation/smart-contracts/message-management/external-messages.mdx
@@ -2,19 +2,19 @@ import Feedback from '@site/src/components/Feedback';
 
 # External messages
 
-**External message** in TON is a message that originates *outside the blockchain* or is intended for actors *outside it*. These messages enable interaction between smart contracts and the external world. External messages come in two types:
+**External message** in TON is a message that originates *outside the blockchain* or is intended for actors *outside it*. These messages enable interaction between smart contracts and the external world. External messages (external inbound, ext_in) come in two types:
 
 - External incoming messages
 - External outgoing messages
 
 ## External incoming messages
 
-**External incoming messages (external-in)** are messages sent from outside TON Blockchain to smart contracts. They serve as the main entry point for external actors to interact with the blockchain.
+**External incoming messages (external inbound, ext_in)** are messages sent from outside to smart contracts on the TON Blockchain. They serve as the main entry point for external actors to interact with the blockchain.
 
 **Key points**
-- Any account can receive external-in messages, but handling depends on the contract’s logic.
+- Any account can receive external inbound (ext_in) messages, but handling depends on the contract’s logic.
 - Common sources include wallet users, validators, and DApp services.
-- Wallet contracts often receive external-in messages and relay instructions internally through _internal messages_.
+- Wallet contracts often receive external inbound (ext_in) messages and relay instructions internally through _internal messages_.
 
 
 ### External incoming message structure
@@ -96,21 +96,20 @@ created_lt:uint64 created_at:uint32 = CommonMsgInfo;
 ## Replay protection
 
 :::caution
-Stay vigilant and check replay protection in contracts for external-in messages.
+Ensure replay protection in contracts that process external inbound (ext_in) messages.
 :::
 
-Notice that all external messages must be protected against replay attacks. The validators normally remove an external message from the pool of suggested external messages (received from the network); however, in some situations another validator could process the same external message twice (thus creating a second transaction for the same external message, leading to the duplication of the original action). Even worse, a `malicious actor could extract` the external message from the block containing the processing transaction and re-send it later. This could force a wallet smart contract to repeat a payment.
+Notice that all external messages must be protected against replay attacks. The validators normally remove an external message from the pool of suggested external messages (received from the network); however, in some situations a validator could process the same external message twice, resulting in a duplicate transaction. Even worse, a malicious actor could extract the external message from the block containing the processing transaction and resend it later. This could force a wallet smart contract to repeat a payment.
 
-The simplest way to protect smart contracts from replay attacks related to external messages is to store a 32-bit counter `cur-seqno` in the persistent data of the smart contract, and to expect a `req-seqno` value in (the signed part of) any inbound external messages. Then an external message is accepted only if both the signature is valid and `req-seqno` equals `cur-seqno`. After successful processing, the `cur-seqno` value in the persistent data is increased by one, so the same external message will never be accepted again.
+The simplest way to protect smart contracts from replay attacks related to external messages is to store a 32-bit counter `seqno` in the persistent data of the smart contract, and to expect a `msg-seqno` value in (the signed part of) any inbound external messages. Then an external message is accepted only if both the signature is valid and `msg-seqno` equals `seqno`. After successful processing, the `seqno` value in the persistent data is increased by one, so the same external message will never be accepted again.
 
-And one could also include an `expire-at` field in the external message, and accept an external message only if the current Unix time is less than the value of this field. This approach can be used in conjunction with `seqno`; alternatively, the receiving smart contract could store the set of (the hashes of) all recent (not expired) accepted external messages in its persistent data, and reject a new external message if it is a duplicate of one of the stored messages. Some garbage collection of expired messages in this set should also be performed to avoid bloating the persistent data.
+Include a `valid-until` field (32-bit Unix time) in the external message and accept it only if the current Unix time is less than `valid-until`; this can be used together with the `seqno` mechanism. Alternatively, the receiving smart contract could store the set of (the hashes of) all recent (not expired) accepted external messages in its persistent data and reject a new external message if it is a duplicate of one of the stored messages. Some garbage collection of expired messages in this set should also be performed to avoid bloating the persistent data. See also: [Wallet v2 spec](/v3/documentation/smart-contracts/contracts-specs/wallet-contracts#wallet-v2), [Wallet replay protection](/v3/guidelines/smart-contracts/howto/wallet#replay-protection).
 
-:::note  
-In general, an external message begins with a 256-bit signature (if needed), a 32-bit `req-seqno` (if needed), a 32-bit `expire-at` (if needed), and possibly a 32-bit `op` and other required parameters depending on `op`. The layout of external messages does not need to be as standardized as that of internal messages because external messages are not used for interaction between different smart contracts (written by different developers and managed by different owners).  
+:::note
+In general, an external message begins with a 512-bit Ed25519 signature (if needed), a 32-bit `msg-seqno` (if needed), a 32-bit `valid-until` (if needed), and possibly a 32-bit `op` and other required parameters depending on `op`. The layout of external messages does not need to be as standardized as that of internal messages because external messages are not used for interaction between different smart contracts (written by different developers and managed by different owners).
 :::
 
 ### See also
 - [Message-driven execution](/v3/guidelines/dapps/transactions/message-driven-execution)
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-message-management-external-messages.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/message-management/external-messages.mdx`

Related issues (from issues.normalized.md):
- [x] **1969. Remove backticks from narrative phrases**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/external-messages.mdx?plain=1

Remove inline code formatting around the plain-text phrases "sent from the outside" (line 5) and "malicious actor could extract" (line 15); they are not code and should be regular text (or italics).

---

- [x] **1970. Use “on the TON Blockchain” instead of “residing in TON Blockchain”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/external-messages.mdx?plain=1

Change the clause at line 5 to "smart contracts on the TON Blockchain" for idiomatic wording and consistency with site style.

---

- [x] **1971. Standardize term and tighten caution: use “external inbound (ext_in)”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/external-messages.mdx?plain=1

At the caution near line 12, replace "external-in messages" with "external inbound (ext_in) messages" and reword to "Ensure replay protection in contracts that process external inbound (ext_in) messages"; at first mention of external messages, add the parenthetical "External messages (external inbound, ext_in)…" for alignment with other pages.

---

- [x] **1972. Clarify replay example and fix “re-send” to “resend”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/external-messages.mdx?plain=1

Around line 15, replace "re-send" with "resend" and rephrase "another validator could process the same external message twice" to an unambiguous form such as "a validator could process the same external message twice, resulting in a duplicate transaction."

---

- [x] **1973. Unify replay‑protection fields; use valid-until and standard seqno names**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/external-messages.mdx?plain=1

At line 19, rename "expire-at" to "valid-until" (32-bit Unix time) and "cur-seqno"/"req-seqno" to "seqno"/"msg-seqno"; rewrite the sentence to "Include a valid-until field in the external message and accept it only if the current Unix time is less than valid-until; this can be used together with the seqno mechanism," and add cross-references to wallet specs and replay protection (docs/v3/documentation/smart-contracts/contracts-specs/wallet-contracts.mdx#wallet-v2, docs/v3/guidelines/smart-contracts/howto/wallet.mdx#replay-protection).

---

- [x] **1974. Prefer accept_message over raw ACCEPT and add references**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/external-messages.mdx?plain=1

Replace "by running the TVM primitive `ACCEPT`" with "by calling accept_message (asm ACCEPT)" and link to docs/v3/documentation/smart-contracts/func/docs/stdlib.mdx#accept_message and docs/v3/documentation/smart-contracts/transaction-fees/accept-message-effects.mdx.

---

- [x] **1975. Fix admonition block syntax and trailing spaces**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/external-messages.mdx?plain=1

Update ":::note " (line 21) to ":::note" and remove the two trailing spaces at the end of the note content line (line 22) to avoid unintended hard line breaks.

---

- [x] **1976. Correct external message signature size**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/external-messages.mdx?plain=1

In the note at line 22, change "256-bit signature" to "512-bit Ed25519 signature" to match standard wallet message formats (64-byte signatures).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.