### PR TITLE
Split: update docs/v3/documentation/smart-contracts/message-management/internal-messages.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/message-management/internal-messages.mdx
+++ b/docs/v3/documentation/smart-contracts/message-management/internal-messages.mdx
@@ -12,9 +12,9 @@ In particular, the processing transaction can create one or several outbound int
 
 This approach requires distinguishing whether an internal message is a:
 
-1. **Query** - initiating an action/request
-2. **Response** - replying to a query
-3. **Simple transfer** - requiring no processing (like basic value transfers)
+1. **Query**—initiating an action/request
+2. **Response**—replying to a query
+3. **Simple transfer**—requiring no processing (like basic value transfers)
 
 Additionally, when receiving responses, there must be a clear way to match them to their original queries.
 
@@ -40,15 +40,13 @@ The message body typically begins with the following fields:
 
 ### Simple message with a comment
 
-If `op` is zero, the message is a "simple transfer message with the comment". The comment is contained in the remainder of the message body (without any `query_id` field, i.e., starting from the fifth byte). If it does not begin with the byte `0xff`, the comment is a text one; it can be displayed "as is" to the end user of a wallet (after filtering out invalid and control characters and checking that it is a valid UTF-8 string).
+If `op` is zero, the message is a "simple transfer message with a comment". The comment is contained in the remainder of the message body (without any `query_id` field, i.e., starting from the fifth byte). If it does not begin with the byte `0xff`, the comment is a text one; it can be displayed "as is" to the end user of a wallet (after filtering out invalid and control characters and checking that it is a valid UTF-8 string).
 
 When a comment is long enough that it doesn’t fit in a cell, the non-fitting end of the line is put to the first reference of the cell. This process continues recursively to describe comments that don’t fit in two or more cells:
 
 ```
-root_cell("0x00000000" - 32 bit, "string" up to 123 bytes)
- ↳1st_ref("string continuation" up to 127 bytes)
- ↳1st_ref("string continuation" up to 127 bytes)
- ↳....
+root_cell("0x00000000" - 32-bit, "string" up to 123 bytes)
+ ↳1st_ref("string continuation" up to 127 bytes → 1st_ref → 1st_ref → ...)
 ```
 
 The same format is used for comments for NFT and [jetton](https://github.com/ton-blockchain/TEPs/blob/master/text/0074-jettons-standard.md#forward_payload-format) transfers.
@@ -59,7 +57,7 @@ Most smart contracts should not perform non-trivial actions or reject the inboun
 
 ### Messages with encrypted comments
 
-If `op` is `0x2167da4b`, then the message is a transfer message with the encrypted comment. This message is serialized as follows:
+If `op` is `0x2167da4b`, then the message is a transfer message with an encrypted comment. This message is serialized as follows:
 
 Input:
 
@@ -70,7 +68,7 @@ Input:
 #### Encryption algorithm
 
 1. Calculate `shared_secret` using `priv_1` and `pub_2`.
-2. Let `salt` be the [bas64url representation](/v3/documentation/smart-contracts/addresses/address-formats) of the sender wallet address with `isBounceable=1` and `isTestnetOnly=0`.
+2. Let `salt` be the [base64url representation](/v3/documentation/smart-contracts/addresses/address-formats) of the sender’s user-friendly address (`isBounceable=1`, `isTestnetOnly=0`).
 3. Select byte string `prefix` of length between 16 and 31 such that `len(prefix+msg)` is divisible by 16. The first byte of `prefix` equals `len(prefix)`, and the other bytes are random. Let `data = prefix + msg`.
 4. Let `msg_key` be the first 16 bytes of `hmac_sha512(salt, data)`.
 5. Calculate `x = hmac_sha512(shared_secret, msg_key)`. Let `key=x[0:32]` and `iv=x[32:48]`.
@@ -82,20 +80,20 @@ Input:
 8. The body of the message starts with the 4-byte tag `0x2167da4b`. Then, this encrypted comment is stored:
    1. The byte string is divided into segments and is stored in a chain of cells `c_1,...,c_k` (`c_1` is the root of the body). Each cell (except for the last one) has a reference to the next.
    2. `c_1` contains up to 35 bytes (not including the 4-byte tag); all other cells contain up to 127 bytes.
-   3. This format has limitations: `k <= 16`, max string length is 1024.
+   3. This format has limitations: `k <= 16`, max string length is 1024 bytes.
 
 Comments for NFT and jetton transfers follow the same format. Note that the public key of the sender and receiver addresses (not jetton-wallet addresses) should be used.
 
-:::info  
+:::info
 Learn from examples of the message encryption algorithm:
 
 - [encryption.js](https://github.com/toncenter/ton-wallet/blob/master/src/js/util/encryption.js)
 - [SimpleEncryption.cpp](https://github.com/ton-blockchain/ton/blob/master/tonlib/tonlib/keys/SimpleEncryption.cpp)
-  :::
+:::
 
 ### Simple transfer messages without comments
 
-A simple transfer message without comment has an empty body even without an `op` field.
+A simple transfer message without a comment has an empty body even without an `op` field.
 The above considerations apply to such messages as well. Note that such messages should have their bodies embedded into the message cell.
 
 ### Distinction between query and response messages
@@ -111,24 +109,19 @@ There are some "standard" response messages with the `op` equal to `0xffffffff` 
 
 Notice that unknown "responses" (with an `op` in the range `2^31 .. 2^32-1`) should be ignored (in particular, no response with an `op` equal to `0xffffffff` should be generated in response to them), just as unexpected bounced messages (with the "bounced" flag set).
 
-## Known op codes
+## Known opcodes
 
-:::info
-Also op-code, op::code and operational code
-:::
-
-| Contract type | Hex code   | OP::code                                                                                                                               |
-| ------------- | ---------- |----------------------------------------------------------------------------------------------------------------------------------------|
+| Contract type | Hex code   | Operation                                                                                                                              |
+| ------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | Global        | 0x00000000 | Text comment                                                                                                                           |
-| Global        | 0xffffffff | Bounce                                                                                                                                 |
 | Global        | 0x2167da4b | [Encrypted comment](/v3/documentation/smart-contracts/message-management/internal-messages#messages-with-encrypted-comments)           |
 | Global        | 0xd53276db | Excesses                                                                                                                               |
 | Elector       | 0x4e73744b | New stake                                                                                                                              |
 | Elector       | 0xf374484c | New stake confirmation                                                                                                                 |
 | Elector       | 0x47657424 | Recover stake request                                                                                                                  |
-| Elector       | 0x47657424 | Recover stake response                                                                                                                 |
+| Elector       | 0xC7657424 | Recover stake response                                                                                                                 |
 | Wallet        | 0x0f8a7ea5 | Jetton transfer                                                                                                                        |
-| Wallet        | 0x235caf52 | [Jetton call to](https://testnet.tonviewer.com/transaction/1567b14ad43be6416e37de56af198ced5b1201bb652f02bc302911174e826ef7)           |
+| Wallet        | 0x235caf52 | [Jetton call (example transaction)](https://testnet.tonviewer.com/transaction/1567b14ad43be6416e37de56af198ced5b1201bb652f02bc302911174e826ef7)           |
 | Jetton        | 0x178d4519 | Jetton internal transfer                                                                                                               |
 | Jetton        | 0x7362d09c | Jetton notify                                                                                                                          |
 | Jetton        | 0x595f07bc | Jetton burn                                                                                                                            |
@@ -145,21 +138,21 @@ Also op-code, op::code and operational code
 | Vesting       | 0xf258a69b | Add whitelist response                                                                                                                 |
 | Vesting       | 0xa7733acd | Send                                                                                                                                   |
 | Vesting       | 0xf7733acd | Send response                                                                                                                          |
-| Dedust        | 0x9c610de3 | Dedust swap extout                                                                                                                     |
-| Dedust        | 0xe3a0d482 | Dedust swap jetton                                                                                                                     |
-| Dedust        | 0xea06185d | Dedust swap internal                                                                                                                   |
-| Dedust        | 0x61ee542d | Swap external                                                                                                                          |
-| Dedust        | 0x72aca8aa | Swap peer                                                                                                                              |
-| Dedust        | 0xd55e4686 | Deposit liquidity internal                                                                                                             |
-| Dedust        | 0x40e108d6 | Deposit liquidity jetton                                                                                                               |
-| Dedust        | 0xb56b9598 | Deposit liquidity all                                                                                                                  |
-| Dedust        | 0xad4eb6f5 | Pay out from pool                                                                                                                      |
-| Dedust        | 0x474а86са | Payout                                                                                                                                 |
-| Dedust        | 0xb544f4a4 | Deposit                                                                                                                                |
-| Dedust        | 0x3aa870a6 | Withdrawal                                                                                                                             |
-| Dedust        | 0x21cfe02b | Create vault                                                                                                                           |
-| Dedust        | 0x97d51f2f | Create volatile Pool                                                                                                                   |
-| Dedust        | 0x166cedee | Cancel deposit                                                                                                                         |
+| DeDust        | 0x9c610de3 | DeDust swap extout                                                                                                                     |
+| DeDust        | 0xe3a0d482 | DeDust swap jetton                                                                                                                     |
+| DeDust        | 0xea06185d | DeDust swap internal                                                                                                                   |
+| DeDust        | 0x61ee542d | Swap external                                                                                                                          |
+| DeDust        | 0x72aca8aa | Swap peer                                                                                                                              |
+| DeDust        | 0xd55e4686 | Deposit liquidity internal                                                                                                             |
+| DeDust        | 0x40e108d6 | Deposit liquidity jetton                                                                                                               |
+| DeDust        | 0xb56b9598 | Deposit liquidity all                                                                                                                  |
+| DeDust        | 0xad4eb6f5 | Pay out from pool                                                                                                                      |
+| DeDust        | 0x474a86ca | Payout                                                                                                                                 |
+| DeDust        | 0xb544f4a4 | Deposit                                                                                                                                |
+| DeDust        | 0x3aa870a6 | Withdrawal                                                                                                                             |
+| DeDust        | 0x21cfe02b | Create vault                                                                                                                           |
+| DeDust        | 0x97d51f2f | Create volatile pool                                                                                                                   |
+| DeDust        | 0x166cedee | Cancel deposit                                                                                                                         |
 | StonFi        | 0x25938561 | Swap internal                                                                                                                          |
 | StonFi        | 0xf93bb43f | Payment request                                                                                                                        |
 | StonFi        | 0xfcf9e58f | Provide liquidity                                                                                                                      |
@@ -177,4 +170,3 @@ Also op-code, op::code and operational code
 
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-message-management-internal-messages.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/message-management/internal-messages.mdx`

Related issues (from issues.normalized.md):
- [ ] **1977. Use em dash instead of spaced hyphen**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/internal-messages.mdx?plain=1#L21-L22

Replace the spaced hyphen with an em dash: "restrictions—these are purely advisory" (or use parentheses).

---

- [ ] **1978. Use 'a comment' article**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/internal-messages.mdx?plain=1#L43

Change "with the comment" to "with a comment".

---

- [ ] **1979. Clarify repeated 1st_ref diagram**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/internal-messages.mdx?plain=1#L47-L52

Revise the diagram to show a single first-reference chain by nesting subsequent 1st_ref under the previous one or by using a continuation arrow (→ 1st_ref → 1st_ref) to avoid implying multiple first references.

---

- [ ] **1980. Hyphenate '32-bit'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/internal-messages.mdx?plain=1#L48

Change "32 bit" to "32-bit".

---

- [ ] **1981. Use 'an encrypted comment'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/internal-messages.mdx?plain=1#L62

Change "with the encrypted comment" to "with an encrypted comment".

---

- [ ] **1982. Fix 'base64url' typo and clarify address type**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/internal-messages.mdx?plain=1#L73

Change "bas64url" to "base64url" and rephrase to "sender’s user-friendly address" (flags isBounceable=1, isTestnetOnly=0 remain as specified).

---

- [ ] **1983. Specify units for max string length**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/internal-messages.mdx?plain=1#L85

Change "max string length is 1024" to "max string length is 1024 bytes".

---

- [ ] **1984. Normalize admonition fences**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/internal-messages.mdx?plain=1#L89,L94

Remove extra spaces so admonitions use ":::info" and ":::” on their own lines without trailing/leading spaces.

---

- [ ] **1985. Use 'without a comment'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/internal-messages.mdx?plain=1#L98

Change "without comment" to "without a comment".

---

- [ ] **1986. Align 0xffffffff meaning; remove 'Bounce' from opcode table**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/internal-messages.mdx?plain=1#L107-L112,L122-L125

Set 0xffffffff to "Operation not supported" and remove/move "Bounce" (a message flag) out of the opcode table.

---

- [ ] **1987. Use 'opcode' consistently; fix section and table headers**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/internal-messages.mdx?plain=1#L116-L118,L120-L121

Change the section title to "Known opcodes", remove the callout listing alternate forms, and rename the table column header "OP::code" to "Operation" to match its contents.

---

- [ ] **1988. Correct Elector response opcode to high-bit range**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/internal-messages.mdx?plain=1#L128-L129

Do not reuse 0x47657424 for both request and response; assign the response an opcode with the high-order bit set (2^31..2^32−1) or document a justified deviation.

---

- [ ] **1989. Standardize brand casing to "DeDust"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/internal-messages.mdx?plain=1#L148-L166,L170

Change all occurrences of "Dedust" to "DeDust" in the table and related references.

---

- [ ] **1990. Fix non-ASCII hex literal in DeDust row**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/internal-messages.mdx?plain=1#L157

Replace Cyrillic letters with ASCII to make a valid hex literal (intended value appears to be 0x474a86ca; verify and correct).

---

- [ ] **1991. Use sentence case: "Create volatile pool"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/internal-messages.mdx?plain=1#L161

Change "Create volatile Pool" to "Create volatile pool" (or apply consistent casing across all entries).

---

- [ ] **1992. Clarify "Jetton call" link label**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/internal-messages.mdx?plain=1#known-op-codes

Change the link label "Jetton call to" to "Jetton call (example transaction)" or replace it with a canonical documentation reference.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.