### PR TITLE
Split: update docs/v3/documentation/smart-contracts/message-management/messages-and-transactions.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/message-management/messages-and-transactions.mdx
+++ b/docs/v3/documentation/smart-contracts/message-management/messages-and-transactions.mdx
@@ -27,10 +27,10 @@ Working with this type of communication is reminiscent of launching a satellite 
 
 ## What is a transaction?
 
-A transaction in TON is the **result** of a smart contract successfully processing an incoming message. It consists of:
+A transaction in TON is an account event. Most transactions are the **result** of a smart contract successfully processing an incoming message, but some system transactions (e.g., Storage or Tick‑tock) are not triggered by an incoming message. It consists of:
 
 * the **incoming message** that triggered the contract
-* the **state changes** performed by the contract during message processing (e.g. storage or balance updates)
+* the **state changes** performed by the contract during message processing (e.g., storage or balance updates)
 * any **outgoing messages** sent to other contracts (if applicable)
 
 > Technically, a contract can be triggered through special functions such as [Tick-tock](/v3/documentation/data-formats/tlb/transaction-layout#tick-tock). Still, this function is more used for internal TON Blockchain core contracts.
@@ -52,7 +52,7 @@ If we look at Ethereum or almost any other synchronous blockchain, each transact
 
 In an asynchronous system, you can't get a response from the destination smart contract in the same transaction. Depending on the length of the route between source and destination, a contract call may take a few blocks to process.
 
-Achieving the infinite sharding paradigm requires full parallelization, ensuring that each transaction executes independently of others. Therefore, instead of transactions that affect and change the state of many contracts simultaneously, each transaction in TON is only executed on a single smart contract, and smart contracts communicate through messages. That way, smart contracts can only interact with each other by calling their functions with special messages and getting a response to them via other messages later.
+Achieving the Infinity Sharding Paradigm (ISP) requires full parallelization, ensuring that each transaction executes independently of others. Therefore, instead of transactions that affect and change the state of many contracts simultaneously, each transaction in TON is only executed on a single smart contract, and smart contracts communicate through messages. That way, smart contracts can only interact with each other by calling their functions with special messages and getting a response to them via other messages later.
 
 :::info
 See [transaction layout](/v3/documentation/data-formats/tlb/transaction-layout) for complete transaction details.
@@ -60,29 +60,18 @@ See [transaction layout](/v3/documentation/data-formats/tlb/transaction-layout) 
 
 ### Transaction outcome
 
-There is a [TVM exit code](/v3/documentation/tvm/tvm-exit-codes) for a transaction that had a compute phase. If it is not 0 or 1, then there was an error.
-Also, TVM [compute phase may be skipped](/v3/documentation/tvm/tvm-overview#when-the-compute-phase-is-skipped) for reasons like lack of funds or state.
+There is a [TVM exit code](/v3/documentation/tvm/tvm-exit-codes) for a transaction that had a compute phase. Success requires a compute‑phase exit code of 0 or 1 and, if an action phase executed, an action result code of 0. Also, TVM [compute phase may be skipped](/v3/documentation/tvm/tvm-overview#when-the-compute-phase-is-skipped) for reasons like lack of funds or state.
 
 :::info for toncenter api v3
-One should use `tx.description.action` to determine a successful `transaction.success  && tx.description.compute_ph.success`:
+Use API v3 top‑level fields to determine success: check `description.aborted === false`, `compute_ph.success === true`, and, if present, `action.success === true`.
 :::
 
 ```json
-"transactions": [
-    {
-      "description": {
-        . . . . . . . .
-        "action": {
-          "valid": true,
-          "success": true,
-         . . . . . . . .
-          },
-. . . . . . . .
-        "destroyed": false,
-        "compute_ph": {
-          "mode": 0,
-          "type": "vm",
-          "success": true,
+{
+  "description": { "aborted": false },
+  "compute_ph": { "success": true },
+  "action": { "success": true }
+}
 ```
 
 The transaction may have one of three results:
@@ -92,7 +81,7 @@ The transaction may have one of three results:
 - Fail, [exit code](/v3/documentation/tvm/tvm-exit-codes), `aborted: true`
 
 :::info for toncenter api v3
-`aborted: true` is a TON Center field. Transaction has no such field.
+`aborted` is a TL‑B field of `TransactionDescr`, exposed as `description.aborted` in API v3; it is not a top‑level field of the Transaction cell.
 :::
 
 ## What is a logical time?
@@ -171,8 +160,8 @@ Consider three contracts - _A_, _B_, and _C_. When contract _A_ sends two intern
 
 While the sending order is preserved at the source, TON's decentralized sharded architecture means the receiving order can't be predetermined.
 
-For better clarity, suppose our contracts send back messages `msg1'` and `msg2'` after `msg1` and `msg2` executed by `B` and `C` contracts. As a result, it will apply `tx2'` and `tx1'` to contract `A`.
-We have two possible traces for these transactions,
+For better clarity, suppose our contracts send back messages `msg1'` and `msg2'` after `msg1` and `msg2` are executed by contracts `B` and `C`. As a result, it will apply `tx2'` and `tx1'` to contract `A`.
+We have two possible traces for these transactions:
 
 1. The first possible order is `tx1'_lt < tx2'_lt`:
 
@@ -259,4 +248,3 @@ There can be many scenarios of smart contract interactions, and in any scenario 
 The TON blockchain's asynchronous structure creates challenges for message delivery guarantees. Logical time helps to establish event and transaction order but doesn't guarantee message delivery order between multiple smart contracts due to varying routes in shard chains. Despite these complexities, TON ensures internal message delivery, maintaining network reliability. Developers must adapt to these nuances to harness TON's full potential in building innovative decentralized applications.
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-message-management-messages-and-transactions.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/message-management/messages-and-transactions.mdx`

Related issues (from issues.normalized.md):
- [ ] **2011. Broaden transaction definition**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/messages-and-transactions.mdx?plain=1#L30-L38

Define a transaction as an account event: most are triggered by an incoming message, but some system transactions (e.g., Storage, Tick‑tock) are not; update the wording accordingly.

---

- [ ] **2012. Add comma after “e.g.”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/messages-and-transactions.mdx?plain=1#L33

Insert a comma after “e.g.”: “(e.g., storage or balance updates)”.

---

- [ ] **2013. Use canonical name “Infinity Sharding Paradigm (ISP)”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/messages-and-transactions.mdx?plain=1#L55

Replace “infinite sharding paradigm” with “Infinity Sharding Paradigm (ISP)” to match the canonical concept page.

---

- [ ] **2014. Clarify success criteria: compute 0/1 and action 0**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/messages-and-transactions.mdx?plain=1#L63-L64

State that success requires a compute‑phase exit code of 0 or 1 and, if an action phase executed, an action result code of 0.

---

- [ ] **2015. Fix TON Center API v3 success logic and field paths**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/messages-and-transactions.mdx?plain=1#L66-L68

Remove `transaction.success` and `tx.description.*`; instruct to check `description.aborted === false`, `compute_ph.success === true`, and, if present, `action.success === true` using top‑level `tx.compute_ph` and `tx.action` per API v3.

---

- [ ] **2016. Replace invalid JSON and correct structure**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/messages-and-transactions.mdx?plain=1#L70-L86

Replace the ellipsis‑filled, misnested `json` block with valid JSON showing the correct v3 layout (e.g., `{ "description": {"aborted": false}, "compute_ph": {"success": true}, "action": {"success": true} }`) or relabel as `jsonc`/`text`.

---

- [ ] **2017. Correct statement about `aborted` field location**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/messages-and-transactions.mdx?plain=1#L94-L96

Clarify that `aborted` is a TL‑B field of `TransactionDescr` exposed as `description.aborted` in API v3; it is not a top‑level field of the Transaction cell.

---

- [ ] **2018. Add missing verb in multi‑contract sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/messages-and-transactions.mdx?plain=1#L174-L175

Change “after `msg1` and `msg2` executed by `B` and `C` contracts” to “after `msg1` and `msg2` are executed by contracts `B` and `C`”.

---

- [ ] **2019. Use a colon to introduce the list**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/messages-and-transactions.mdx?plain=1#L175

End the sentence with a colon: “We have two possible traces for these transactions:”.

---

- [ ] **2020. Clarify subject in return‑message sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/messages-and-transactions.mdx?plain=1#L174-L176

Replace “As a result, it will apply `tx2'` and `tx1'` to contract `A`.” with “As a result, contract `A` will apply transactions `tx2'` and `tx1'`.”

---

- [ ] **2021. Standardize “TON Blockchain” capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/messages-and-transactions.mdx?plain=1#L259

Use “TON Blockchain” consistently (e.g., change “TON blockchain’s” to “TON Blockchain’s”) to match usage across related pages.

---

- [ ] **2022. Use self‑closing <br /> tags**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/messages-and-transactions.mdx?plain=1

Replace all `<br></br>` with `<br />` for valid MDX/HTML.

---

- [ ] **2023. Title‑case admonitions: “TON Center API V3”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/messages-and-transactions.mdx?plain=1

Change custom admonition headings from “for toncenter api v3” to “TON Center API V3” in both notes.

---

- [ ] **2024. Add article before “TVM compute phase”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/messages-and-transactions.mdx?plain=1

Change “Also, TVM compute phase may be skipped…” to “Also, the TVM compute phase may be skipped…”, and prefer “for reasons like insufficient funds or missing/invalid state”.

---

- [ ] **2025. Use em dashes for parenthetical breaks**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/messages-and-transactions.mdx?plain=1

Replace hyphens used as sentence breaks with em dashes (e.g., “internal messages — the destination…”, “storage — this depends…”).

---

- [ ] **2026. Replace “issue about” with “issue of”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/messages-and-transactions.mdx?plain=1

Change “lt solves the issue about message delivery order” to “It solves the issue of message delivery order”.

---

- [ ] **2027. Spell out “two” in prose**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/messages-and-transactions.mdx?plain=1

Change “more than 2 contracts” to “more than two contracts”.

---

- [ ] **2028. Specify “all other shards” explicitly**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/messages-and-transactions.mdx?plain=1

Replace “the state of all the others” with “the state of all other shards”.

---

- [ ] **2029. Merge redundant delivery‑guarantee sentences**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/messages-and-transactions.mdx?plain=1

Combine the two consecutive sentences about reliable delivery of internal messages into one concise statement to avoid repetition.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.