### PR TITLE
Split: update docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx
+++ b/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx
@@ -28,9 +28,9 @@ Let's dive in!
 
 There are three types of messages:
 
-- **External** - messages sent from outside the blockchain to a smart contract inside the blockchain. Smart contracts should explicitly accept such messages during the so-called `credit_gas`. The node should not accept the message into a block or relay it to other nodes if it is not accepted.
+- **External** - messages sent from outside the blockchain to a smart contract inside the blockchain. Smart contracts should explicitly accept such messages during the gas credit. If not accepted with `accept_message()`, the message is discarded without a recorded transaction.
 - **Internal** - messages sent from one blockchain entity to another. In contrast to external messages, such messages may carry some TON and pay for themselves. Thus, smart contracts that receive such messages may not accept them. In this case, gas will be deducted from the message value.
-- **Logs** - messages sent from a blockchain entity to the outer world. Generally, there is no mechanism for sending such messages out of the blockchain. While all nodes in the network have a consensus on whether a message was created, there are no rules for processing them. Logs may be directly sent to `/dev/null`, logged to disk, saved in an indexed database, or even sent by non-blockchain means (email/telegram/sms); these are at the sole discretion of the given node.
+- **Logs** - messages sent from a blockchain entity to the outside world. Generally, there is no mechanism for sending such messages out of the blockchain. While all nodes in the network have a consensus on whether a message was created, there are no rules for processing them. Logs may be directly sent to `/dev/null`, logged to disk, saved in an indexed database, or even sent by non-blockchain means (email/telegram/sms); these are at the sole discretion of the given node.
 
 ## Message layout
 
@@ -56,7 +56,7 @@ Let's put it into words: The serialization of any message consists of three fiel
 - When we have the field `body:(Either X ^X)`, it means that when we (de)serialize some type `X`, we first put one `either` bit, which is `0` if `X` is serialized to the same cell, or `1` if it is serialized to the separate cell.
 - When we have the field `init:(Maybe (Either StateInit ^StateInit))`, we first put `0` or `1` depending on whether this field is empty. If it is not empty, we serialize `Either StateInit ^StateInit` (again, put one `either` bit, which is `0` if `StateInit` is serialized to the same cell or `1` if it is serialized to a separate cell).
 
-Let's focus on one particular `CommonMsgInforRelaxed` type, the internal message definition declared with the `int_msg_info$0` constructor.
+Let's focus on one particular `CommonMsgInfoRelaxed` type, the internal message definition declared with the `int_msg_info$0` constructor.
 
 ```tlb
 int_msg_info$0 ihr_disabled:Bool bounce:Bool bounced:Bool
@@ -69,7 +69,7 @@ It starts with the 1-bit prefix `0`.
 
 Then, there are three 1-bit flags:
 
-- Whether Instant Hypercube Routing is disabled (currently always true)
+- Whether Instant Hypercube Routing is disabled (currently always true) (IHR is not implemented; see [current status of IHR](/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm#current-status-of-ihr))
 - Whether a message should be bounced if there are errors during its processing
 - Whether the message itself is the result of a bounce.
 
@@ -77,7 +77,7 @@ Then, source and destination addresses are serialized, followed by the message v
 
 If a message is sent from the smart contract, some fields will be rewritten to the correct values. In particular, the validator will rewrite `bounced`, `src`, `ihr_fee`, `fwd_fee`, `created_lt`, and `created_at`. That means two things: first, another smart contract while handling the message may trust those fields (sender may not forge source address, `bounced` flag, etc.), and second, during serialization, we may put to those fields any valid values because those values will be overwritten anyway.
 
-Straight-forward serialization of the message would be as follows:
+Straightforward serialization of the message would be as follows:
 
 ```func
  var msg = begin_cell()
@@ -92,15 +92,15 @@ Straight-forward serialization of the message would be as follows:
  .store_dict(extra_currencies)
  .store_coins(0) ;; ihr_fee
  .store_coins(fwd_value) ;; fwd_fee
- .store_uint(cur_lt(), 64) ;; lt of transaction
- .store_uint(now(), 32) ;; unixtime of transaction
+ .store_uint(cur_lt(), 64) ;; lt of the transaction
+ .store_uint(now(), 32) ;; Unix time of the transaction
  .store_uint(0,  1) ;; no init-field flag (Maybe)
  .store_uint(0,  1) ;; inplace message body flag (Either)
  .store_slice(msg_body)
  .end_cell();
 ```
 
-However, instead of serializing all fields step-by-step, developers usually use shortcuts. Thus, let's consider how messages can be sent from the smart contract using an example from [elector-code](https://github.com/ton-blockchain/ton/blob/master/crypto/smartcont/elector-code.fc#L153).
+However, instead of serializing all fields step-by-step, developers usually use shortcuts. Thus, let's consider how messages can be sent from the smart contract using an example from [elector-code](https://github.com/ton-blockchain/ton/blob/master/crypto/smartcont/elector-code.fc).
 
 ```func
 () send_message_back(addr, ans_tag, query_id, body, grams, mode) impure inline_ref {
@@ -142,16 +142,16 @@ currencies$_ grams:Grams other:ExtraCurrencyCollection
  = CurrencyCollection;
 ```
 
-This scheme means the message may carry the dictionary of additional _extra-currencies_ with the TON value. However, we may neglect it and assume that the message value is serialized as number of nanotons as variable integer and "`0` - empty dictionary bit".
+This scheme means the message may carry the dictionary of additional _extra-currencies_ with the TON value. However, we can ignore extra currencies and assume the value is serialized as a number of nanotons (a variable integer) plus a `0` bit indicating an empty dictionary.
 
 Indeed, in the elector code above, we serialize coins amounts via `.store_coins(toncoins)` but then just put a string of zeros with a length equal to `1 + 4 + 4 + 64 + 32 + 1 + 1`. What is it?
 
 - The first bit stands for empty extra-currencies dictionary.
-- Then we have two 4-bit long fields. They encode 0 as `VarUInteger 16`. Since `ihr_fee` and `fwd_fee` will be overwritten, we may as well put them as zeroes.
+- Then we have two 4-bit long fields. They encode 0 as `VarUInteger 16`. Since `ihr_fee` and `fwd_fee` will be overwritten, we may set them to zero.
 - Then we put zero to the `created_lt` and `created_at` fields. Those fields will also be overwritten; however, in contrast to fees, these fields have a fixed length and are thus encoded as 64- and 32-bit long strings.
   > _We had already serialized the message header and passed to init/body at that moment_
-- Next zero-bit means that there is no `init` field.
-- The last zero-bit means that msg_body will be serialized in-place.
+- The next zero bit means that there is no `init` field.
+- The last zero bit means that `msg_body` is serialized in place.
 - After that, the message body (with an arbitrary layout) is encoded.
 
 Instead of individual serialization of 14 parameters, we execute 4 serialization primitives.
@@ -181,19 +181,18 @@ For instance, `MsgAddress` may be represented by four constructors:
 
 With length from 2 bits for `addr_none` to 586 bits for `addr_var` in the largest form.
 
-The same stands for nanotons' amounts, which is serialized as `VarUInteger 16`.
-That means 4 bits indicating the byte length of the integer and then bytes for the integer itself.
+The same applies to nanoton amounts, which are serialized as `VarUInteger 16` — 4 bits indicating the byte length, followed by that many bytes.
 
 That way:
 
 - `0` nanotons serialized as `0b0000` (4 bits indicating zero-length byte string + no bytes)
 - `100000000000000000` nanotons (100,000,000 TON) serializes as:
   `0b10000000000101100011010001010111100001011101100010100000000000000000`
-  (where `0b1000` specifies 8 bytes length followed by the 8-byte value)
+  (where `0b1000` specifies an 8-byte length followed by the 8-byte value)
 
 :::info message size
 Note that the message has general size limits and cell count limits, too,
-e.g., the maximum message size must not exceed `max_msg_bits`, and the number of cells per message must not exceed `max_msg_cells`.
+e.g., the maximum message size must not exceed `max_msg_bits`, and the number of cells per message must not exceed `max_msg_cells` (see Param 43).
 
 More configuration parameters and their values can be found [here](/v3/documentation/network/configs/blockchain-configs#param-43).
 :::
@@ -224,10 +223,12 @@ When using the `send_raw_message` function, choosing the appropriate combination
 | `+16` | In the case of action failure, bounce the transaction. No effect if `+2` is used.       |
 | `+32` | Destroy the current account if its resulting balance is zero (often used with Mode 128) |
 
-:::info +16 Flag
+:::info Bounceable messages
 If a contract receives a bounceable message, it processes the `storage` phase **before** the `credit` phase. Otherwise, it processes the `credit` phase **before** the `storage` phase.
 
-For more details, check the [source code with checks for the `bounce-enable` flag](https://github.com/ton-blockchain/ton/blob/master/validator/impl/collator.cpp#L2810).
+This concerns the bounceable attribute of incoming messages and is distinct from the action-phase `+16` flag described below.
+
+For more details, check the [source code with checks for the `bounce-enable` flag](https://github.com/ton-blockchain/ton/blob/master/validator/impl/collator.cpp).
 :::
 
 :::warning
@@ -238,7 +239,8 @@ For more details, check the [source code with checks for the `bounce-enable` fla
 
 :::
 
-## Recommended approach: mode=3 \{#mode3}
+<a id="mode3" />
+## Recommended approach: mode=3
 
 ```func
 send_raw_message(msg, SEND_MODE_PAY_FEES_SEPARATELY | SEND_MODE_IGNORE_ERRORS); ;; stdlib.fc L833
@@ -277,7 +279,7 @@ As a result, unprocessed external messages can be replayed until they expire or 
 
 ### Error handling with +2 flag
 
-The `IGNORE ERRORS` flag (`+2`) suppresses these specific errors during the Action Phase:
+The `IGNORE_ERRORS` flag (`+2`) suppresses these specific errors during the action phase:
 
 #### Suppressed errors
 
@@ -308,10 +310,7 @@ The `IGNORE ERRORS` flag (`+2`) suppresses these specific errors during the Acti
 
 #### Current mitigations
 
-- Most wallet apps auto-include `IGNORE_ERRORS` in transactions
-- Wallet UIs often display transaction simulation results
-- V5 wallets enforce `IGNORE_ERRORS` usage
-- Validators limit message replays per block
+- V5 wallets enforce `IGNORE_ERRORS` usage (see [wallet exit code `0x89`](/v3/documentation/smart-contracts/contracts-specs/wallet-contracts#exit-codes))
 
 #### Potential risks
 
@@ -333,7 +332,7 @@ send_raw_message(msg, SEND_MODE_CARRY_ALL_REMAINING_MESSAGE_VALUE | SEND_MODE_BO
 save_data(status, balance, owner_address, jetton_master_address); }
 ```
 
-If a transfer using `mode=3` fails due to a suppressed error:
+If a transfer fails during the action phase:
 
 1. Transfer action is not executed
 2. Contract state updates persist (no rollback)
@@ -343,5 +342,6 @@ If a transfer using `mode=3` fails due to a suppressed error:
 
 Always pair `IGNORE_ERRORS` with robust client-side validations and real-time balance checks to prevent unintended state changes.
 
-<Feedback />
+Here, `msg` is a prebuilt message cell.
 
+<Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-message-management-sending-messages.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx`

Related issues (from issues.normalized.md):
- [ ] **2038. Fix intro link text/comma**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx?plain=1#L5

Replace “[transaction phases, and TVM]” with two clear links: “[TVM transaction phases](/v3/documentation/tvm/tvm-overview#transaction-phases) and [TVM](/v3/documentation/tvm/tvm-overview)”.

---

- [ ] **2039. Rename “Logs” message type to “External outgoing”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx?plain=1#L29-L33

Use the canonical terminology: internal, external incoming, and external outgoing (ext_out_msg_info); rename “Logs” to “External outgoing” and adjust its description accordingly.

---

- [ ] **2040. Replace undefined term `credit_gas`; clarify acceptance**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx?plain=1#L31

Replace “`credit_gas`” with “gas credit” and clarify that external messages must call `accept_message()` or they are discarded without a recorded transaction.

---

- [ ] **2041. Remove unverified relay claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx?plain=1#L31

Delete “or relay it to other nodes” from the external message description unless a citation is provided, retaining only the documented discard behavior without `accept_message()`.

---

- [ ] **2042. Use “outside world”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx?plain=1#L33

Change “the outer world” to “the outside world”.

---

- [ ] **2043. Fix typo: CommonMsgInfoRelaxed**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx?plain=1#L59

Correct the misspelled type name from “CommonMsgInforRelaxed” to “CommonMsgInfoRelaxed”.

---

- [ ] **2044. Cite IHR not implemented**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx?plain=1#L72

Append a citation explaining that IHR is not implemented (link: /v3/documentation/smart-contracts/shards/infinity-sharding-paradigm#current-status-of-ihr).

---

- [ ] **2045. Use “Straightforward”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx?plain=1#L80

Change “Straight-forward” to “Straightforward”.

---

- [ ] **2046. Capitalize “Unix time”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx?plain=1#L96-L104

Update comments to “Unix time of the transaction” for proper noun capitalization and clarity.

---

- [ ] **2047. Use permalinked GitHub links**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx?plain=1#L103,L230

Replace master-branch GitHub links with commit permalinks (or remove fragile line anchors and reference targets by name) to prevent drifting anchors.

---

- [ ] **2048. Use “zeros”; rephrase**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx?plain=1#L150

Change “as well put them as zeroes” to “set them to zero”.

---

- [ ] **2049. Clarify zero-bit phrasing; format code**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx?plain=1#L153-L155

Rephrase to “The next zero bit …” and “The last zero bit means that `msg_body` is serialized in place.”

---

- [ ] **2050. Clarify CurrencyCollection wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx?plain=1#L160-L168

Rewrite to “we can ignore extra currencies and assume the value is serialized as a number of nanotons (a variable integer) plus a ‘0’ bit indicating an empty dictionary.”

---

- [ ] **2051. Fix nanoton amounts sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx?plain=1#L184-L186

Use “The same applies to nanoton amounts, which are serialized as `VarUInteger 16` — 4 bits indicating the byte length, followed by that many bytes.”

---

- [ ] **2052. Use “8‑byte length”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx?plain=1#L192

Change “specifies 8 bytes length” to “specifies an 8‑byte length”.

---

- [ ] **2053. Reference Param 43 for size limits**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx?plain=1#L194-L199

Add “(see Param 43)” to the sentence mentioning `max_msg_bits` and `max_msg_cells` to point to /v3/documentation/network/configs/blockchain-configs#param-43.

---

- [ ] **2054. Standardize “action phase” lowercase**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx?plain=1#L223,L280

Use lowercase “action phase” consistently (to match “credit phase” and “storage phase”).

---

- [ ] **2055. Retitle bounceable callout; distinguish from +16**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx?plain=1#L227-L231

Change the info box title from “+16 Flag” to “Bounceable messages” (and, if needed, add a sentence clarifying this is distinct from the `+16` action-phase flag).

---

- [ ] **2056. Fix escaped mode3 anchor**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx?plain=1#L241

Remove the backslash in the custom heading ID so it reads “## Recommended approach: mode=3 {#mode3}” and generates the proper anchor.

---

- [ ] **2057. Standardize IGNORE_ERRORS naming**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx?plain=1#L258-L281

Use `IGNORE_ERRORS` (and `SEND_MODE_IGNORE_ERRORS` where relevant) consistently instead of “IGNORE ERRORS” with a space, in prose and headings.

---

- [ ] **2058. Remove unsupported bullets; keep V5 citation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx?plain=1#L309-L321

Delete unsubstantiated ecosystem claims (wallet UIs simulation, validator relay limits, auto-inclusion) and retain only the documented V5 wallets enforcement with a citation to wallet exit code `0x89`.

---

- [ ] **2059. Define `msg` in example or note it is prebuilt**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx?plain=1#L328-L334

Add a minimal snippet showing construction of the `msg` cell (or explicitly state it is a prebuilt cell) so the `send_raw_message(msg, …)` example is self-contained.

---

- [ ] **2060. Align Jetton example with mode=3**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx?plain=1#L328-L344

Either add `| SEND_MODE_IGNORE_ERRORS` to the example call to match the “mode=3” narrative or change the narrative to reflect the flags actually used.

---

- [ ] **3812. Explain send mode magic number**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig-js.mdx?plain=1

Annotate order1.addMessage(msg, 3) to clarify that 3 is the send mode (1 + 2) and link to docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx#mode3; adjust if a different mode is intended.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.