### PR TITLE
Split: update docs/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm.mdx
+++ b/docs/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm.mdx
@@ -2,9 +2,9 @@ import Feedback from '@site/src/components/Feedback';
 
 # Infinite Sharding Paradigm
 
-## Understanding split-merge in the TON Blockchain
+## Understanding split-merge in TON Blockchain
 
-The TON (The Open Network) Blockchain introduces innovative mechanisms for scalability and efficiency. One of the key features is **split-merge**, a fundamental component of its architecture. This article outlines the core principles of split-merge within the Infinite Sharding Paradigm (ISP) framework.
+The TON (The Open Network) blockchain introduces innovative mechanisms for scalability and efficiency. One of the key features is **split-merge**, a fundamental component of its architecture. This article outlines the core principles of split-merge within the Infinite Sharding Paradigm (ISP) framework.
 
 #### ISP and its application
 
@@ -13,7 +13,8 @@ At the heart of TON's design is the ISP, which treats each account as its own **
 - **ShardState**: approximated as `Hashmap(n, AccountState)`, where `n` is the bit length of the `account_id`.
 - **ShardBlock**: approximated as `Hashmap(n, AccountBlock)`.
 
-Each ShardChain block is uniquely identified by `ShardIdent` (workchain + shard prefix) and `seq_no` (sequence number).
+Each ShardChain block is uniquely identified by a combination consisting of the `workchain_id` and a binary prefix `s` of the `account_id`.
+
 
 ## Algorithm for deciding whether to split or merge
 
@@ -30,7 +31,7 @@ Each block includes three core parameters that are used to assess load:
 
 1. **Block size estimate:** an estimated value computed during block collation (not the actual block size).
 2. **Gas consumption:** total gas consumed by all transactions in the block, excluding ticktock, mint, and recover transactions.
-3. **LT delta:** the difference between the block's starting and ending logical times.
+3. **lt delta:** the difference between the block's starting and ending logical times.
 
 ### 2. Block limits and classification
 
@@ -43,10 +44,11 @@ Each parameter has three thresholds: **underload**, **soft**, and **hard**:
 | --------------- | --------------------------------------- | ----------------------------------------- |
 | Block size      | 128 / 256 / 512 KiB (illustrative)      | N/A                                       |
 | Gas consumption | 2M / 10M / 20M (illustrative)           | 200K / 1M / 2.5M (illustrative)           |
-| LT delta        | 1000 / 5000 / 10000 (illustrative)      | Same as BaseChain                         |
+| lt delta        | 1000 / 5000 / 10000 (illustrative)      | Same as BaseChain                         |
 
-Note: Thresholds are defined by [configuration parameters 22 and 23](/v3/documentation/network/configs/blockchain-configs#param-22-and-23) and the live network configuration.
-
+:::note
+All values are illustrative only. The thresholds are defined by [configuration parameters 22 and 23](/v3/documentation/network/config-params/overview#param-22-and-23) and the live network configuration.
+:::
 A **medium limit** is also defined as `(soft + hard) / 2`.
 
 Each parameter is classified as follows:
@@ -57,9 +59,9 @@ Each parameter is classified as follows:
 - `3` - medium limit is exceeded.
 - `4` - hard limit is exceeded.
 
-The block classification is the maximum of the three individual classifications (`Classification of size`, `Classification of gas`, `Classification of LT delta`).
+The block classification is the maximum of the three individual classifications (`Classification of size`, `Classification of gas`, `Classification of lt delta`).
 
-Example: size = 2, gas = 3, LT = 1 → block classification = 3.
+Example: size = 2, gas = 3, lt = 1 → block classification = 3.
 
 Based on classification:
 
@@ -102,9 +104,9 @@ Shards perform the split or merge after a protocol-defined delay from the decisi
 
 ## Messages and Instant Hypercube Routing (IHR)
 
-In the infinite sharding paradigm, each account or smart contract is treated as if it were a part of its own ShardChain.
+In Infinite Sharding Paradigm, each account or smart contract is treated as if it were a part of its own ShardChain.
 Interactions between accounts occur exclusively through message passing, following the **actor model**, where accounts act as actors.
-An efficient messaging system between ShardChains is essential for the operation of the TON blockchain. A proposed mechanism called **Instant Hypercube Routing** would enable direct message delivery across ShardChains without intermediate hops. For related fee parameters, see [configuration parameters 24 and 25](/v3/documentation/network/configs/blockchain-configs#param-24-and-25).
+An efficient messaging system between ShardChains is essential for the operation of the TON blockchain. A proposed mechanism called **Instant Hypercube Routing** would enable direct message delivery across ShardChains without intermediate hops. For related fee parameters, see [configuration parameters 24 and 25](/v3/documentation/network/config-params/overview#param-24-and-25).
 
 ### Current Status of IHR
 
@@ -137,7 +139,7 @@ In the diagram above:
 - For illustration, blocks 222, 223, and 224 correspond to MasterChain block `seqno = 102`. Block 222 belongs to one shard, while blocks 223 and 224 belong to another.
 - If a split or merge event occurs, the affected shards pause operations until the next MasterChain block is produced.
 
-In summary, **split-merge** in the TON Blockchain is a sophisticated yet efficient mechanism that enhances scalability and inter-shard communication. It exemplifies TON's approach to solving core blockchain challenges by prioritizing efficiency and global consistency.
+In summary, **split-merge** in TON Blockchain is a sophisticated yet efficient mechanism that enhances scalability and inter-shard communication. It exemplifies TON's approach to solving core blockchain challenges by prioritizing efficiency and global consistency.
 
 ## Sharding details
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-shards-infinity-sharding-paradigm.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm.mdx`

Related issues (from issues.normalized.md):
- [x] **2076. Use “Infinite Sharding Paradigm (ISP)” consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm.mdx?plain=1#L3,L107,L150

Unify terminology by changing the H1 to “# Infinite Sharding Paradigm,” capitalizing the term as “Infinite Sharding Paradigm (ISP)” throughout, and removing the incorrect “Independent State Part” expansion of ISP.

---

- [ ] **2077. Hyphenate and article-case subsection heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm.mdx?plain=1#L5

Change “## Understanding split merge in TON Blockchain” to “## Understanding split-merge in the TON Blockchain” for hyphenation and capitalization consistency.

---

- [ ] **2078. Standardize “TON Blockchain” capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm.mdx?plain=1#L7,L109

Capitalize Blockchain in these occurrences for consistency: “TON (The Open Network) Blockchain” and “TON Blockchain.”

---

- [x] **2079. Fix split/merge decision sentence grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm.mdx?plain=1#L25

Replace “Validators make split or merge decisions using these flags by configuration parameters.” with “Validators make split or merge decisions using these flags and configuration parameters.”

---

- [ ] **2080. Use consistent “LT” casing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm.mdx?plain=1#L58-L66,L60

Use LT (uppercase) consistently in headings and examples, e.g., “Classification of LT delta” and “LT = 1.”

---

- [x] **2081. Remove extra space before ≥ operator**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm.mdx?plain=1#L75

Delete the extra space before “≥” in “Message queue size is ≥ FORCE_SPLIT_QUEUE_SIZE = 4096, ...”.

---

- [x] **2082. Qualify hard-coded queue constants and define terms**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm.mdx?plain=1#L75

Avoid asserting exact constants (e.g., FORCE_SPLIT_QUEUE_SIZE, SPLIT_MAX_QUEUE_SIZE, MERGE_MAX_QUEUE_SIZE) without citation—label them as examples or link to the source—and replace or define “dispatch queue” using a canonical term.

---

- [ ] **2083. Resolve 64-bit mask vs. weighting details**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm.mdx?plain=1#L81-L89

State that overload/underload history are 64-bit masks of the last 64 blocks and remove or explicitly mark the 3/2/1 weighting as an example unless sourced, ensuring consistency with the 64-bit scope.

---

- [x] **2084. Deduplicate “final decision” text and capitalize WorkChain**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm.mdx?plain=1#L93-L96,L93

Remove the redundant first sentence, keep the second that introduces the bullet list, and use “WorkChain configuration parameters.”

---

- [x] **2085. Correct IHR heading and avoid implying current availability**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm.mdx?plain=1#L105,L107-L111

Use “## Messages and Instant Hypercube Routing (IHR)” and rephrase the paragraph to describe IHR conditionally (concept/proposal), avoiding claims of current operation; optionally link to Params 24–25.

---

- [x] **2086. Add descriptive alt text to diagram**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm.mdx?plain=1#L134

Provide alt text for accessibility, e.g., “![Shard splitting and merging over time](/img/docs/blockchain-fundamentals/shardchains.png)”.

---

- [x] **2087. Capitalize “ShardChain” in subheading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm.mdx?plain=1#L146

Change to “#### Split and non-split parts of ShardChain” for capitalization consistency.

---

- [x] **2088. Improve inbound/outbound message bullets**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm.mdx?plain=1#L165-L169

Remove backticks around “Hypercube Routing” and revise to “processed by a transaction in the block or forwarded in transit per Hypercube Routing”; for OutMsgDescr use “newly generated messages from transactions in the block” and “transit messages forwarded outside the current ShardChain (forwarded from InMsgDescr).”

---

- [x] **2089. Clarify block header bullets and shard prefix phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm.mdx?plain=1#L176-L178

Use a colon after “Block sequence number” and replace “Binary prefix of `account_ids`” with “Shard prefix (binary prefix over `account_id` values for the shard).”

---

- [x] **2090. Fix outbound queue sentence and identifier usage**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm.mdx?plain=1#L188-L189

Change to “Each outgoing message is initially placed in the outbound queue, where it remains until successfully delivered to its target,” and if referring to the TLB field, use the exact name out_msg_queue_info (no backticks for concept names).

---

- [x] **2091. Correct block identification definition**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm.mdx?plain=1

Replace “identified by workchain_id and a binary prefix s of the account_id” with “identified by ShardIdent (workchain + shard prefix) and seq_no (sequence number).”

---

- [ ] **2092. Mark threshold numbers as examples or cite config**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm.mdx?plain=1

In the “Threshold table,” label specific sizes/counts and LT deltas as illustrative or replace them with a note directing readers to network‑configurable Params 22 and 23 and live configuration.

---

- [x] **2093. Remove unverified split_merge_delay value**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm.mdx?plain=1

Replace “split_merge_delay = 100 seconds” with a non‑numeric description (e.g., “after a protocol‑defined delay”) or cite a source within the docs if a specific value is required.

---

- [ ] **2094. Mark sharding example numbers as illustrative**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm.mdx?plain=1

Preface specific block/seq_no values in the example (e.g., MasterChain seqno) as illustrative unless the image explicitly shows them, or add a citation.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.