### PR TITLE
Split: update docs/v3/documentation/smart-contracts/shards/shards-intro.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/shards/shards-intro.mdx
+++ b/docs/v3/documentation/smart-contracts/shards/shards-intro.mdx
@@ -2,16 +2,17 @@ import Feedback from '@site/src/components/Feedback';
 
 # Shards
 
-Sharding is a well-established concept that originated in [database design](https://en.wikipedia.org/wiki/Shard_\(database_architecture\)). It refers to splitting a single logical dataset into multiple independent databases that don’t share resources and can run across different servers.
-In simple terms, sharding enables horizontal scalability—breaking down data into smaller, manageable parts that can be processed in parallel. This technique has been crucial in the evolution from traditional data systems to [big data](https://en.wikipedia.org/wiki/Big_data).
-As datasets grow beyond the capacity of conventional systems, sharding becomes the only practical way to scale effectively.
+Sharding, a concept from [database design](https://en.wikipedia.org/wiki/Shard_\(database_architecture\)), splits a logical dataset into multiple independent databases that don’t share resources and can run on separate servers.
+
+It enables horizontal scalability—a necessity for large datasets—by dividing data into smaller parts processed in parallel.
+This technique has been crucial in the evolution from traditional data systems to [big data](https://en.wikipedia.org/wiki/Big_data). It becomes essential when datasets exceed the capacity of conventional systems.
 
 ## Sharding in TON Blockchain
 
 TON uses sharding to handle a high volume of transactions efficiently.
-The TON blockchain architecture includes one MasterChain and up to 2³² WorkChains. Each WorkChain functions as an independent blockchain with its own rules. Furthermore, each WorkChain can be divided into up to 2⁶⁰ ShardChains, each responsible for a portion of the WorkChain’s state.
+The TON blockchain architecture includes one MasterChain and up to 2<sup>32</sup> WorkChains. Each WorkChain functions as an independent blockchain with its own rules. Furthermore, each WorkChain can be divided into up to 2<sup>60</sup> ShardChains, each responsible for a portion of the WorkChain’s state.
 
-TON currently runs two WorkChains: the BaseChain (workchain 0) and the MasterChain (workchain −1).
+TON currently runs two WorkChains: the BaseChain (WorkChain 0) and the MasterChain (WorkChain −1).
 
 The core principle behind sharding in TON is parallelism:
 For example, if account A sends a message to account B and account C sends a message to account D, both transactions can be processed asynchronously and independently.
@@ -24,10 +25,10 @@ The MasterChain (`workchain = -1`) includes one ShardChain.
 The MasterChain is the main blockchain in the TON network. It stores the network configuration and the final state of all WorkChains and ShardChains, including hashes of the latest blocks. The MasterChain can be considered the core directory or the single source of truth for all shards and chains in the ecosystem.
 It contains essential protocol-level information, including:
 
-- The current network configuration.
-- The list of active validators and their stakes.
-- All active WorkChains and their corresponding ShardChains.
-- The most recent block hashes of every WorkChain and ShardChain.
+- the current network configuration
+- the list of active validators and their stakes
+- all active WorkChains and their corresponding ShardChains
+- the most recent block hashes of every WorkChain and ShardChain
 
 This data is key to maintaining consensus and ensuring all network parts are synchronized and operating securely.
 
@@ -41,7 +42,7 @@ Two key architectural decisions set the TON blockchain apart from other sharded 
 
 First, TON implements dynamic segmentation of the blockchain based on the network load. When the number of transactions reaches a critical threshold, the blockchain splits into two ShardChains. If the load on a shard continues to increase, it splits again—and this process continues recursively as needed. Conversely, when the transaction volume decreases, shards can merge back together. This adaptive sharding model enables the network to create as many shards as necessary at any given time.
 
-Second, TON employs a non-fixed shard count. The number of shards scales dynamically based on demand, with a theoretical upper limit of 2⁶⁰ shards per WorkChain.
+Second, TON employs a non-fixed shard count. The number of shards scales dynamically based on demand, with a theoretical upper limit of 2<sup>60</sup> shards per WorkChain.
 
 ![TON sharding scheme](/img/docs/blockchain-fundamentals/scheme.png)
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-shards-shards-intro.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/shards/shards-intro.mdx`

Related issues (from issues.normalized.md):
- [x] **2095. Remove extra space before link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/shards-intro.mdx?plain=1#L5

There is a double space before the “[database design]” link; remove the extra space so it reads “originated in [database design]”.

---

- [ ] **2096. Standardize em dash spacing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/shards-intro.mdx?plain=1#L6,L44

Use unspaced em dashes consistently; change the spaced em dash at line 44 to “scalability—a necessity” to match line 6.

---

- [x] **2097. Convert bold title to heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/shards-intro.mdx?plain=1#L9

“Sharding in TON Blockchain” is bold text; change it to a proper H2 heading: “## Sharding in TON Blockchain”.

---

- [ ] **2098. Normalize MasterChain list punctuation and casing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/shards-intro.mdx?plain=1#L27-L30

The bullets mix semicolons and a period and inconsistent capitalization; end each bullet with a period and use consistent casing (e.g., “WorkChains”, “ShardChains”, “validators”).

---

- [x] **2099. Correct WorkChain/MasterChain relationship**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/shards-intro.mdx?plain=1#L36

Replace “The MasterChain is divided into individual blockchains called WorkChains” with “WorkChains are separate blockchains operating in parallel; the MasterChain coordinates them and tracks their states.”

---

- [x] **2100. Add descriptive alt text to images**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/shards-intro.mdx?plain=1#L46,L58,L100

Replace empty alt text with descriptive text, for example: “TON sharding scheme”, “ShardChains split diagram”, and “ShardChains merge diagram”.

---

- [x] **2101. Simplify “hereinafter” phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/shards-intro.mdx?plain=1#L50

Replace “hereinafter simply as a ‘shard’” with “hereinafter referred to as ‘shard’.”

---

- [x] **2102. Fix MasterChain block grammar and finality**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/shards-intro.mdx?plain=1#L60

Change to: “A MasterChain block contains information about the state of all shards in its header. Once a shard block is included in the header, it is considered final and cannot be reverted.”

---

- [x] **2103. Unify example headings**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/shards-intro.mdx?plain=1#L62,L102

Use a consistent label; rename “Actual example” to “Real example”.

---

- [x] **2104. Capitalize MasterChain consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/shards-intro.mdx?plain=1#L104

Change “Masterchain” to “MasterChain” here and in any other occurrences on this page for consistency.

---

- [ ] **2105. Use Unicode superscripts for counts**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/shards-intro.mdx?plain=1

Replace HTML superscripts (e.g., “2<sup>32</sup>”, “2<sup>60</sup>”) with Unicode superscripts “2³²” and “2⁶⁰” for consistency and readability.

---

- [x] **2106. Remove ambiguous term “sub-shards”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/shards-intro.mdx?plain=1

Replace “ShardChains or sub-shards” with “ShardChains” to align with terminology used elsewhere.

---

- [x] **2107. Update active WorkChain count statement**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/shards-intro.mdx?plain=1

Replace “Currently, TON operates with only one WorkChain, known as the BaseChain.” with “TON currently runs two WorkChains: the BaseChain (workchain 0) and the MasterChain (workchain −1).”

---

- [x] **2108. Clarify binary value explanation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/shards-intro.mdx?plain=1

After “0x8000000000000000”, add “which in binary is one ‘1’ followed by 63 zeros” to aid understanding.

---

- [x] **2109. Expand MasterChain data scope wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/shards-intro.mdx?plain=1

Update wording to include ShardChains and latest hashes, e.g., “the final state of all WorkChains and ShardChains, including hashes of the latest blocks.”

---

- [x] **2110. Remove external comparison and hyperbole**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/shards-intro.mdx?plain=1

Delete the Ethereum 2.0 comparison and the claim about “assign[ing] over 100 million shards to every person on Earth”; retain the bound “theoretical upper limit of 2⁶⁰ shards per WorkChain.”

---

- [x] **2111. Improve splitting section style**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/shards-intro.mdx?plain=1

Remove unnecessary quotes around shard after its definition and rephrase to: “A shard stores and processes all transactions for its accounts; each AccountChain belongs to exactly one shard.”

---

- [x] **2112. Clarify shard ID prefix notation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/shards-intro.mdx?plain=1

Add a note that shard‑ID prefix examples are illustrative and omit trailing zeros while keeping the sentinel ‘1’, to avoid confusion about differing zero counts.

---

- [x] **2113. Align MasterChain shard count phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/shards/shards-intro.mdx?plain=1

Replace “always operates with exactly one shard” with “The MasterChain includes one ShardChain.”

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.