### PR TITLE
Split: update docs/v3/documentation/smart-contracts/tolk/changelog.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/tolk/changelog.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/changelog.mdx
@@ -9,7 +9,7 @@ Once new versions are released, they will be announced on this page.
 1. The magic `lazy` keyword — lazy loading, partial loading, partial updating
 2. Auto-detect and inline functions at the compiler level
 3. Various peephole optimizations for gas efficiency
-4. `onInternalMessage` and `onBouncedMessage`, TVM 11 support
+4. `onInternalMessage` and `onBouncedMessage`, TVM‑11 support (new instructions; see [Tolk vs FunC: in detail](/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail))
 5. Custom pack/unpack serializers for custom types
 
 
@@ -17,21 +17,21 @@ Once new versions are released, they will be announced on this page.
 
 1. Universal `createMessage`
 2. Universal `createExternalLogMessage`
-3. Sharding — calculate addresses "close to another contract"
+3. Sharding — calculate addresses 'close to' another contract.
 
 
 ## v0.13
 
 1. Auto-packing to/from cells/builders/slices
 2. Type `address`
-3. Lateinit variables
+3. `lateinit` variables
 4. Defaults for parameters
 
 
 ## v0.12
 
 1. Structures `struct A { ... }`
-2. Generics `struct<T>` and `type<T>`
+2. Generics `struct<T>`
 3. Methods `fun Point.getX(self)`
 4. Rename stdlib functions to short methods
 
@@ -50,7 +50,7 @@ Once new versions are released, they will be announced on this page.
 
 1. Fixed-width integers: `int32`, `uint64`, etc. [Details](https://github.com/ton-blockchain/ton/pull/1559)
 2. Type `coins` and function `ton("0.05")`
-3. `bytesN` and `bitsN` types (backed by slices at TVM level)
+3. `bytesN` and `bitsN` types (backed by slices at the TVM level)
 4. Replace `"..."c` postfixes with `stringCrc32("...")` functions
 5. Support `0b...` number literals along with `0x...`
 6. Trailing comma support
@@ -83,7 +83,7 @@ Once new versions are released, they will be announced on this page.
 
 ## v0.6
 
-The first public release. Here are some notes about its origin: 
+The first public release.
 
 
 ## A brief history of Tolk
@@ -95,7 +95,7 @@ FunC gave complete control over the TVM — and if you mastered it, it gave you 
 But its Lisp-like syntax and functional style made onboarding difficult for many.
 
 Tolk began as an experiment: to maintain efficiency while changing the interface.
-There are no parentheses and no prefix notation, just clean types, structs, pattern matching, and a modern toolchain.
+No Lisp-style prefix notation; familiar C-style syntax, with clean types, structs, pattern matching, and a modern toolchain.
 
 Since then, Tolk has grown far beyond just being **easier FunC**. It now offers:
 - a powerful type system,
@@ -103,19 +103,19 @@ Since then, Tolk has grown far beyond just being **easier FunC**. It now offers:
 - idiomatic message composition,
 - and better performance — not despite abstraction, but thanks to it.
 
-Today, Tolk is not an experiment — it's a production-ready replacement for FunC.
+Today, Tolk is not an experiment — it's a production-ready replacement for FunC (see [Is Tolk production-ready?](/v3/documentation/smart-contracts/tolk/overview#is-tolk-production-ready)).
 
 ## How Tolk was born
 
 In June 2024, I submitted a pull request: [FunC v0.5.0](https://github.com/ton-blockchain/ton/pull/1026) — along with a roadmap for how FunC could be improved, syntactically and semantically.
 
 But instead of merging it, we made a decision: **To fork**.
-To leave FunC untouched. As it is. As it always was. And to create a new language driven by a fresh and new name.
+To leave FunC untouched. As it is. As it always was. And to create a new language driven by a new name.
 
 Over the next several months, I worked on Tolk privately, implementing not just syntax changes,
 but a fully redesigned architecture — including an internal AST representation that FunC never had.
 
-On the TON Gateway in Dubai in November 2024, I gave a speech presenting Tolk to the public.
+At TON Gateway in Dubai in November 2024, I gave a speech presenting Tolk to the public.
 The video is available [on YouTube](https://www.youtube.com/watch?v=Frq-HUYGdbI).
 
 The very first pull request: [Tolk Language: next-generation FunC](https://github.com/ton-blockchain/ton/pull/1345).
@@ -128,15 +128,14 @@ The first released version of Tolk was **v0.6** — a metaphor for the **FunC v0
 
 In English, it sounds like *talk*. And after all, what do we use a language for? To talk. To talk to computers. 
 
-In all Slavic languages, the root *tolk* and the phrase *"to have tolk"* means "to make sense"; "to have deep internals".
+In many Slavic languages, the root *tolk* and the phrase "to have tolk" mean "to make sense"; "to have deep internals".
 
 But actually, **TOLK** is an abbreviation.  
-You know, that TON is **The Open Network**.  
+You know that TON is **The Open Network**.  
 By analogy, TOLK is **The Open Language K**.   
 
-What is K, you might ask? Maybe, it's *kot* — the nickname of Nikolay Durov? Or Kolya? Kitten? Kernel? Kit? Knowledge?  
+What is K, you might ask? Maybe it's *kot* — the nickname of Nikolay Durov? Or Kolya? Kitten? Kernel? Kit? Knowledge?  
 The correct answer is none of these. The K stands for nothing. It's open.
 *The Open Letter K*
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-tolk-changelog.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/tolk/changelog.mdx`

Related issues (from issues.normalized.md):
- [ ] **2131. Fix 'lateinit' casing and reference**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/changelog.mdx?plain=1#L27

Change "Lateinit variables" to lowercase inline code and add a reference to its docs: use `lateinit` and link to a definition/usage page (or remove the mention if it isn’t documented).

---

- [ ] **2132. Replace escaped quotes in inline code**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/changelog.mdx?plain=1#L52-L55

Inline code shows backslash-escaped quotes; replace them with plain quotes: ton("0.05"), "...“c → "..."c, stringCrc32("...").

---

- [ ] **2133. Add 'the' before 'TVM level'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/changelog.mdx?plain=1#L53

Change "backed by slices at TVM level" to "backed by slices at the TVM level."

---

- [ ] **2134. Fix 'Smart casts' phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/changelog.mdx?plain=1#L63

Change "Smart casts, like in TypeScript in Kotlin" to "Smart casts (similar to TypeScript and Kotlin)."

---

- [ ] **2135. Clarify parentheses claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/changelog.mdx?plain=1#L98

Replace "There are no parentheses and no prefix notation" with "No Lisp‑style prefix notation; familiar C‑style syntax."

---

- [ ] **2136. Remove redundancy in 'fresh and new'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/changelog.mdx?plain=1#L113-L114

Replace "a fresh and new name" with "a new name."

---

- [ ] **2137. Use 'At' for event preposition**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/changelog.mdx?plain=1#L118

Change "On the TON Gateway in Dubai" to "At TON Gateway in Dubai."

---

- [ ] **2138. Fix subject–verb agreement ('mean')**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/changelog.mdx?plain=1#L131

Change "the root … and the phrase … means" to "the root … and the phrase … mean."

---

- [ ] **2139. Soften 'all Slavic languages' claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/changelog.mdx?plain=1#L131

Change "In all Slavic languages" to "In many Slavic languages."

---

- [ ] **2140. Remove comma in 'You know that…'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/changelog.mdx?plain=1#L134

Remove the comma after "know": "You know that TON is The Open Network."

---

- [ ] **2141. Remove comma after 'Maybe'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/changelog.mdx?plain=1#L137

Change "Maybe, it's kot — …" to "Maybe it's kot — …".

---

- [ ] **2142. Standardize quotes in sharding phrase**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/changelog.mdx?plain=1

Change to: "Sharding — calculate addresses 'close to' another contract."

---

- [ ] **2143. Remove dangling lead‑in under v0.6**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/changelog.mdx?plain=1

Delete "Here are some notes about its origin:" so the line reads simply "The first public release."

---

- [ ] **2144. Explain 'TVM 11 support'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/changelog.mdx?plain=1

Add a brief clarifying note and link explaining what "TVM‑11" means and its impact.

---

- [ ] **2145. Remove unsupported 'type<T>' generics**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/changelog.mdx?plain=1

Remove "and `type<T>`" from "Generics `struct<T>` and `type<T>`" unless generic type aliases are documented elsewhere.

---

- [ ] **2146. Reconcile 'production‑ready' messaging**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/changelog.mdx?plain=1

Add a brief qualifier with a link to the "Is Tolk production‑ready?" section to align with pages that label Tolk "Under active development."

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.