### PR TITLE
Split: update docs/v3/documentation/smart-contracts/tolk/counter-smart-contract.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/tolk/counter-smart-contract.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/counter-smart-contract.mdx
@@ -57,7 +57,7 @@ Let’s explore what’s happening here.
 
 First, we declare the storage structure. It corresponds exactly to the format used when deploying from the TypeScript client `wrappers/Counter.ts`.
 ```tolk
-// In `Counter.ts`, the function `counterConfigToCell`
+// In `wrappers/Counter.ts`, the function `counterConfigToCell`
 // manually constructs two uint32 values — which correspond here:
 struct Storage {
     id: uint32
@@ -67,16 +67,16 @@ struct Storage {
 // Methods to load from and store to persistent storage
 
 fun Storage.load() {
-    return Storage.fromCell(contract.getData())
+    return Storage.fromCell(contract.getData());
 }
 fun Storage.save(self) {
-    contract.setData(self.toCell())
+    contract.setData(self.toCell());
 }
 ```
 
 ## Handling incoming messages
 
-When a client sends a message — for example, using the `sendIncrease` function in `wrappers/Counter.ts`— the contract processes it using this function:
+When a client sends a message — for example, using the `sendIncrease` function in `wrappers/Counter.ts` — the contract processes it using this function:
 
 ```tolk
 fun onInternalMessage(in: InMessage) {
@@ -110,9 +110,9 @@ struct (0x7e8764ef) IncreaseCounter {
 ## Sending messages
 
 This contract doesn’t send any messages.
-To learn how message construction works in Tolk, see the [Create message](/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx) article.
+To learn how message construction works in Tolk, see the [Universal createMessage](/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message) article.
 
-## Handling internal bounced messages
+## Handling bounced messages
 
 **Bounced messages** are messages that you _send_, but the receiver fails to process — so they are returned to you.
 
@@ -135,5 +135,7 @@ get fun currentCounter(): int {
 ```
 
 The `getCounter` function in `wrappers/Counter.ts` calls this exact getter from `counter.tolk`.
+
+Note: The initial scaffold also includes an `initialId()` getter that returns the storage `id`.
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-tolk-counter-smart-contract.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/tolk/counter-smart-contract.mdx`

Related issues (from issues.normalized.md):
- [ ] **2147. Fix snippet path to wrappers/Counter.ts**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/counter-smart-contract.mdx?plain=1#L58-L61

The snippet comment says “In `Counter.ts`” while the text references `wrappers/Counter.ts`; update the comment to “In `wrappers/Counter.ts`” for consistency.

---

- [ ] **2148. Add missing semicolons in data snippet**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/counter-smart-contract.mdx?plain=1#L69-L74

Add semicolons for consistency: change to “return Storage.fromCell(contract.getData());” and “contract.setData(self.toCell());”.

---

- [ ] **2149. Add space before second em dash**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/counter-smart-contract.mdx?plain=1#L79

In “When a client sends a message — for example, using the `sendIncrease` function in `wrappers/Counter.ts`— the contract…”, add a space before the second em dash: “`wrappers/Counter.ts` — the contract…”.

---

- [ ] **2150. Fix internal link text and path**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/counter-smart-contract.mdx?plain=1

Change “[Create message](/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx)” to “[Universal createMessage](/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message)” to use canonical title and extensionless URL.

---

- [ ] **2151. Change currentCounter() return type to uint32**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/counter-smart-contract.mdx?plain=1

Storage declares “counter: uint32” but the getter returns “int”; change the getter signature to return “uint32” to match the storage field type.

---

- [ ] **2152. Rename heading to 'Handling bounced messages'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/counter-smart-contract.mdx?plain=1

Replace the section title “Handling internal bounced messages” with “Handling bounced messages” to avoid redundancy and align with terminology used elsewhere.

---

- [ ] **2153. Add brief note explaining initialId getter**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/counter-smart-contract.mdx?plain=1

The initial scaffold includes an `initialId()` getter that is not explained; add a short note stating it returns the storage `id`.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.