### PR TITLE
Split: update docs/v3/documentation/smart-contracts/tolk/environment-setup.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/tolk/environment-setup.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/environment-setup.mdx
@@ -12,26 +12,34 @@ We recommend using **Blueprint**, a tool for writing, testing, and deploying sma
 
 ## Create a new TON project
 
-> **Prerequisite:** Node.js v16 or higher
+> **Prerequisite:** Node.js 18+ (22+ recommended)
 
 1. Create a new TON project:
    ```bash
    npm create ton@latest
    ```
-2. Enter any project name and select **"A simple counter contract (Tolk)"** when prompted by Blueprint.
+2. Enter any project name and select the simple counter contract template in Tolk when prompted by Blueprint.
+3. Change into the project directory:
+   ```bash
+   cd ./<project-name>
+   ```
+4. Install dependencies:
+   ```bash
+   npm install
+   ```
 
 ## Project structure
 
 Here's a quick look at the typical project layout:
 
-   ```
-   my-first-contract/
-   ├── build/             # Compiled smart contract bytecode
-   ├── contracts/         # Smart contract sources (e.g., counter.tolk)
-   ├── scripts/           # TypeScript deployment scripts
-   ├── tests/             # TypeScript tests
-   ├── wrappers/          # TypeScript wrappers for contracts
-   ```
+```text
+my-first-contract/
+├── build/             # Compiled smart contract bytecode
+├── contracts/         # Smart contract sources (e.g., counter.tolk)
+├── scripts/           # TypeScript deployment scripts
+├── tests/             # TypeScript tests
+├── wrappers/          # TypeScript wrappers for contracts
+```
 
 ## Build the project
 
@@ -58,7 +66,9 @@ npx blueprint run
 # or
 yarn blueprint run
 ```
-Use this command to deploy your contract to Mainnet, Testnet, or MyLocalTon.
+Use this command to deploy your contract to Mainnet or Testnet.
+
+Note: To target a local node, configure a local network endpoint in `blueprint.config.ts`.
 
 ## IDE support
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-tolk-environment-setup.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/tolk/environment-setup.mdx`

Related issues (from issues.normalized.md):
- [ ] **2154. Update Node.js prerequisite**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/environment-setup.mdx?plain=1#L15

Change “Node.js v16 or higher” to “Node.js 18+ (22+ recommended)” to align with site standards and avoid confusion.

---

- [ ] **2155. Rephrase template selection text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/environment-setup.mdx?plain=1#L21

Replace the quoted, bold option with generic, style-compliant wording: write “select the simple counter contract template in Tolk” (no quotes/bold) instead of referencing the exact prompt string.

---

- [ ] **2156. Fix project structure code block formatting**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/environment-setup.mdx?plain=1#L27-L34

Move the code fences to column 0, add a language hint “```text”, and remove shared left padding while preserving the tree’s internal indentation.

---

- [ ] **2157. Add steps to enter project and install dependencies**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/environment-setup.mdx?plain=1

After scaffolding with “npm create ton@latest”, insert “cd ./<project-name>” and “npm install” before build/test commands to prevent failures.

---

- [ ] **2158. Clarify MyLocalTon deployment configuration**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/environment-setup.mdx?plain=1

Remove “or MyLocalTon” from the deploy sentence and add a note that targeting a local node requires configuring a local network endpoint in blueprint.config.ts.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.