### PR TITLE
Split: update docs/v3/documentation/smart-contracts/tolk/language-guide.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/tolk/language-guide.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/language-guide.mdx
@@ -9,17 +9,17 @@ import Feedback from "@site/src/components/Feedback";
 ## Table of contents
 
 1. [Basic syntax](#basic-syntax)
-3. [Functions](#functions)
-4. [Variables and types](#variables-and-types)
-5. [Control flow](#control-flow)
-6. [Type system](#type-system)
-7. [Collections](#collections)
-8. [Error handling](#error-handling)
-9. [Structures](#structures)
-10. [Methods](#methods)
-11. [Imports and modules](#imports-and-modules)
-12. [Advanced features](#advanced-features)
-13. [Standard library](#standard-library)
+1. [Functions](#functions)
+1. [Variables and types](#variables-and-types)
+1. [Control flow](#control-flow)
+1. [Type system](#type-system)
+1. [Collections](#collections)
+1. [Error handling](#error-handling)
+1. [Structures](#structures)
+1. [Methods](#methods)
+1. [Imports and modules](#imports-and-modules)
+   - [Standard library](#standard-library)
+1. [Advanced features](#advanced-features)
 
 ## Basic syntax
 
@@ -88,7 +88,7 @@ fun increment(x: int, by: int = 1): int {
 }
 ```
 
-### GET methods
+### Get methods
 
 Contract getters use the `get fun` syntax:
 
@@ -176,7 +176,7 @@ repeat (10) {
 - `int` -  integer; fixed-width variants like `int32` and `uint64` are also supported
 - `bool` - boolean (`true`/`false`). **Note:** in TVM, `true` is represented as `-1`, **not** `1`
 - `cell` - a TVM cell
-- `slice` - a TVM slice; you can also use `bitsN`. (e.g. `bits512` for storing a signature)
+- `slice` - a TVM slice; you can also use `bitsN` (e.g., `bits512` for storing a signature)
 - `builder` - a TVM builder
 - `address` - blockchain address
 - `coins` - Toncoin or coin amounts
@@ -585,7 +585,7 @@ val reply = createMessage({
 reply.send(SEND_MODE_REGULAR);
 ```
 
-Deep dive: [Sending messages](/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx).
+Deep dive: [Sending messages](/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message).
 
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-tolk-language-guide.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/tolk/language-guide.mdx`

Related issues (from issues.normalized.md):
- [ ] **2159. Fix TOC numbering (use auto-numbering)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/language-guide.mdx?plain=1

The ordered list in the Table of contents is hard-coded as 1., 3., 4.; change every item marker to 1. so Markdown auto-numbers sequentially.

---

- [ ] **2160. Remove or add missing “Collections” TOC entry**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/language-guide.mdx?plain=1

The TOC links to #collections but no section exists; either add a “## Collections” section or remove the TOC entry to restore navigability.

---

- [ ] **2161. Add “Tensors” to TOC**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/language-guide.mdx?plain=1

There is a “## Tensors” section not listed in the TOC; add a “Tensors” entry linking to #tensors to keep the TOC consistent.

---

- [ ] **2162. Normalize heading case: “GET methods” -> “Get methods”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/language-guide.mdx?plain=1

Change the section title from “GET methods” to “Get methods” for sentence‑case consistency with other headings.

---

- [ ] **2163. Fix non-null assertion example (replace undefined variable)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/language-guide.mdx?plain=1

The snippet uses undefined hasCell; instead, check the parameter itself (e.g., if (maybeCell != null) { useCell(maybeCell!); }) and remove the undefined identifier.

---

- [ ] **2164. Remove .mdx from “Sending messages” link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/language-guide.mdx?plain=1

Update the link from /v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx to /v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message to match Docusaurus routing.

---

- [ ] **2165. Use camelCase: rename load_data to loadData**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/language-guide.mdx?plain=1

The attributes section uses fun load_data(); rename it to fun loadData() to follow the guide’s camelCase convention.

---

- [ ] **2166. Make union type example returns consistent**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/language-guide.mdx?plain=1

The is/!is example returns void in one branch and int in another; declare an explicit return type (e.g., int) and ensure both branches return that type.

---

- [ ] **2167. Consolidate tensor/tuple content and clarify “Tuples” subheading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/language-guide.mdx?plain=1

Reduce redundancy by keeping only a brief intro under “Type system” that links to a single dedicated “Tensors” section, and rename the later “Tuples” subsection to “Tuple indexed access,” removing duplicated examples.

---

- [ ] **2168. Replace unintroduced `tuple` type in assembler example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/language-guide.mdx?plain=1

The assembler example uses an unintroduced type name tuple; change to a concrete type like fun third<X>(t: (X, X, X)): X asm "THIRD".

---

- [ ] **2169. Fix punctuation in bitsN sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/language-guide.mdx?plain=1

Change “you can also use `bitsN`. (e.g. …)” to “you can also use `bitsN` (e.g., `bits512` …)” by removing the period before the parenthesis and adding a comma after “e.g.”.

---

- [ ] **2170. Reorder TOC item for “Standard library” to match section order**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/language-guide.mdx?plain=1

Move “Standard library” in the TOC (or nest it under “Imports and modules”) so its position mirrors where the section actually appears on the page.

---

- [ ] **2171. Align type alias example (`bits256?` vs `bytes32?`)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/language-guide.mdx?plain=1

This page uses type MaybeOwnerHash = bits256? while another guide shows bytes32?; choose one and update this page (and/or the referenced page) for consistency.

---

- [ ] **2172. Avoid undefined `sqrt` or reference its source**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/language-guide.mdx?plain=1

Point.distanceFromOrigin calls sqrt(...) without an import or reference; either cite the module providing sqrt or change the example to return the squared distance (x*x + y*y).

---

- [ ] **2173. Verify “Methods for any type” syntax or revise example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/language-guide.mdx?plain=1

If unconstrained extension syntax like fun T.copy(self): T is unsupported, replace it with a conventional generic function (e.g., fun copy<T>(value: T): T) or document and link the feature.

---

- [ ] **2266. Fix auto-inferred and locals sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx?plain=1#L8

Replace "parameter types are mandatory; return type can be omitted (auto inferred), as well as for locals" with "parameter types are mandatory; the return type can be omitted (auto-inferred). Local variable types can also be omitted" to match established phrasing (docs/v3/documentation/smart-contracts/tolk/language-guide.mdx#function-declaration, docs/v3/documentation/smart-contracts/tolk/language-guide.mdx#variable-declaration).

---

- [ ] **2267. Use 'attributes' with `@` terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx?plain=1#L8

Replace "specifiers `inline_ref` and others are `@` attributes" with "attributes like `@inline_ref` use the `@` syntax" to match Tolk terminology (docs/v3/documentation/smart-contracts/tolk/language-guide.mdx#function-attributes).

---

- [ ] **2271. Remove 'style' from camelCase**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx?plain=1#L48

Change "camelCase style" to "camelCase" for concise, consistent terminology (docs/v3/documentation/smart-contracts/tolk/language-guide.mdx#identifiers).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.