### PR TITLE
Split: update docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx
@@ -2,7 +2,7 @@ import Feedback from '@site/src/components/Feedback';
 
 # Universal createMessage
 
-In FunC, you had to compose message cells manually and regularly face code like:
+In FunC, you had to compose message cells manually and would regularly face code like this:
 
 ```func
 cell m = begin_cell()
@@ -17,7 +17,7 @@ cell m = begin_cell()
 send_raw_message(m, 0);
 ```
 
-In Tolk, you use a high-level function — and it's even more gas-effective:
+In Tolk, you use a high-level function — and it's even more gas-efficient:
 
 ```tolk
 val reply = createMessage({
@@ -33,10 +33,10 @@ reply.send(SEND_MODE_REGULAR);
 
 1. Supports extra currencies
 2. Supports `stateInit` (code+data) with automatic address computation
-3. Supports different WorkChains
-4. Supports sharding (formerly splitDepth)
+3. Supports different workchains
+4. Supports sharding (formerly split depth)
 5. Integrated with auto-serialization of `body`
-6. Automatically detects **body ref or not**
+6. Automatically decides whether to inline the body or store it by reference
 7. More efficient than handwritten code
 
 ## The concept is based on union types
@@ -47,9 +47,9 @@ There is a huge variety of interacting between contracts. When you explore FunC 
 - ... but sometimes, you "build the address (builder) manually"
 - sometimes, you compose `StateInit` from code+data
 - ... but sometimes, you already have `StateInit` as a ready cell
-- sometimes, you send a message to basechain
+- sometimes, you send a message to BaseChain
 - ... but sometimes, you have the `MY_WORKCHAIN` constant and use it everywhere
-- sometimes, you just attach tons (**msg value**)
+- sometimes, you just attach Toncoin (**msg value**)
 - ... but sometimes, you also need extra currencies
 - etc.
 
@@ -59,13 +59,13 @@ Let's start exploring this idea by looking at how extra currencies are supported
 
 ## Extra currencies: union
 
-When you don't need them, you just attach **msg value** as tons:
+When you don't need them, you just attach **msg value** as Toncoin:
 
 ```tolk
 value: someTonAmount
 ```
 
-When you need them, you attach tons AND extra currencies dict:
+When you need them, you attach Toncoin AND an extra currencies dict:
 
 ```tolk
 value: (someTonAmount, extraDict)
@@ -83,7 +83,7 @@ struct CreateMessageOptions<TBody> {
     value: coins | (coins, ExtraCurrenciesDict)
 ```
 
-That's it! You just attach tons OR tons with extra, and the compiler takes care of composing this into a cell.
+That's it! You just attach Toncoin or Toncoin with extra, and the compiler takes care of composing this into a cell.
 
 ## Destination: union
 
@@ -94,7 +94,7 @@ dest: someAddress,
 dest: (workchain, hash)
 ```
 
-It's either an address, OR a OR (WorkChain + hash), OR ...:
+It's either an address, a builder, a pair (workchain, hash), or an AutoDeployAddress:
 
 ```tolk
 struct CreateMessageOptions<TBody> {
@@ -106,12 +106,12 @@ struct CreateMessageOptions<TBody> {
           AutoDeployAddress;    // ... or "send to stateInit" aka deploy (address auto-calculated)
 ```
 
-**That's indeed the TypeScript way** — but it works at compile-time!
+**That's indeed the TypeScript way** — but it works at compile time!
 
-## StateInit and WorkChains
+## StateInit and workchains
 
 Let's start from an example. From a jetton minter, you are deploying a jetton wallet.
-You know wallet's code and initial data:
+You know the wallet's code and initial data:
 
 ```tolk
 val walletInitialState: ContractState = {
@@ -120,10 +120,10 @@ val walletInitialState: ContractState = {
 };
 ```
 
-Now, from a minter, you want to send a message to a wallet. But since you are not sure whether the wallet already exists onchain, you attach its code+data:
+Now, from a minter, you want to send a message to a wallet. But since you are not sure whether the wallet already exists on-chain, you attach its code+data:
 if a wallet doesn't exist, it's immediately initialized with that code.
 So, where should you send a message to? What is **destination**? The answer is: **destination is the wallet's StateInit**.
-You need to send a message to a `walletInitialState` because, in TON, the address of a contract is — by definition — a hash of its initial state:
+You need to send a message to `walletInitialState` because, in TON, the address of a contract is — by definition — a hash of its initial state:
 
 ```tolk
 // address auto-calculated, code+data auto-attached
@@ -160,11 +160,11 @@ The `createMessage` interface also supports initializing contracts in specific s
 In other words, your intention is:
 
 - a jetton wallet must be **close to** the owner's wallet
-- this _closeness_ is determined by a shard depth (syn. _fixed prefix length_, syn. _split depth_)
+- this _closeness_ is determined by a shard depth (also known as _fixed prefix length_, also known as _split depth_)
 
 Let's illustrate it with numbers for `shard depth` = 8:
 
-| Title                | Addr hash (256 bits) | Comment                              |
+| Title                | Address hash (256 bits) | Comment                              |
 | -------------------- | -------------------- | ------------------------------------ |
 | closeTo (owner addr) | `01010101...xxx`     | owner's wallet                       |
 | shardPrefix          | `01010101`           | first 8 bits of closeTo              |
@@ -183,7 +183,7 @@ dest: {
 }
 ```
 
-Technically, **shard depth** must be a part of `StateInit` (besides code+data) — for correct initialization inside the blockchain.
+Technically, **shard depth** must be part of `StateInit` (besides code+data) — for correct initialization inside the blockchain.
 The compiler automatically embeds it.
 
 But semantically, **shard depth** alone makes no sense. That's why **shard depth + closeTo** is a single entity:
@@ -203,11 +203,11 @@ struct AddressShardingOptions {
 
 ## Body ref or not: compile-time calculation
 
-In TON Blockchain, according to the specification, a message is a cell (flags, dest address, stateInit, etc.),
+In the TON blockchain, according to the specification, a message is a cell (flags, dest address, stateInit, etc.),
 and its _body_ can be either inlined into the same cell or can be placed into its own cell (and be a ref).
 
 In FunC, you had to manually calculate whether it's safe to embed body (you did it _on paper_ or dynamically).\
-In Tolk, you just pass `body`, and the compiler does all calculations for you:
+In Tolk, you just pass `body`, and the compiler does all the calculations for you:
 
 ```tolk
 createMessage({
@@ -218,8 +218,8 @@ createMessage({
 
 The rules are the following:
 
-1. if `body` is small, it's embedded directly into a message cell
-2. if `body` is large or unpredictable, it's wrapped into a ref
+1. If `body` is small, it's embedded directly into a message cell
+2. If `body` is large or unpredictable, it's wrapped into a ref
 
 Why not make a ref always? Because creating cells is expensive. Avoiding cells for small bodies is crucial for gas consumption.
 
@@ -239,7 +239,7 @@ Hence, when you pass `body: RequestedInfo {...}`, then `TBody = RequestedInfo`, 
 
 - it's **small** if its maximum size is less than 500 bits and 2 refs — then **no ref**
 - it's **large** if >= 500 bits or >= 2 refs — then "ref"
-- it's **unpredictable** if contains `builder` or `slice` inside — then **ref**
+- it's **unpredictable** if it contains a `builder` or `slice` — then **ref**
 
 **Even if body is large/unpredictable, you can force it to be inlined** by wrapping into a special type:
 
@@ -259,7 +259,7 @@ createMessage({                         // so, you take the risks
 // here TBody = UnsafeBodyNoRef<ProbablyLarge>
 ```
 
-If `body` is already a cell, it will be left as a ref, without any surprise:
+If `body` is already a cell, it will be left as a ref, without any surprises:
 
 ```tolk
 createMessage({
@@ -268,7 +268,7 @@ createMessage({
 // here TBody = cell 
 ```
 
-That's why, don't pass `body: someObj.toCell()`, pass just `body: someObj`, let the compiler take care of everything.
+Don't pass `body: someObj.toCell()`; just pass `body: someObj` and let the compiler take care of everything.
 
 ## Body is not restricted to structures
 
@@ -300,7 +300,7 @@ val excessesMsg = createMessage({
 excessesMsg.send(SEND_MODE_IGNORE_ERRORS);
 ```
 
-Even this is okay, it is inferred as `createMessage<(int32, uint64)>(...)` and encoded correctly.
+Even this is okay; it is inferred as `createMessage<(int32, uint64)>(...)` and encoded correctly.
 
 The example above just illustrates the power of the type system, no more.
 
@@ -328,16 +328,16 @@ struct CreateMessageOptions<TBody = never> {
 }
 ```
 
-Hence, when we miss `body` in `createMessage`, it leads to the default `TBody = never`.
-And by convention, fields having `never` type are not required in a literal.
+Hence, when we omit `body` in `createMessage`, it leads to the default `TBody = never`.
+And by convention, fields of type `never` are not required in a literal.
 It's not that obvious, but it is definitely beautiful.
 
 ## Don't confuse StateInit and code+data, they are different
 
-It's incorrect to say that **StateInit is code+data**, because in TON, a full **StateInit** cell contents is richer (consider block.tlb):
+It's incorrect to say that **StateInit is code+data**, because in TON, the full **StateInit** cell contents are richer (consider block.tlb):
 
 - it also contains fixed_prefix_length (formerly split_depth),
-- it also contains ticktock info
+- it also contains tick/tock info
 - it also contains a library cell
 - code and data are actually optional
 
@@ -356,9 +356,9 @@ struct ContractState {
 And that's why a field `stateInit: ContractState | cell` is named **stateInit**,
 emphasizing that `StateInit` can be initialized automatically from `ContractState` (or can be a well-formed **rich** cell).
 
-## Why not send, but createMessage?
+## Why createMessage instead of send()?
 
-You might ask: "why do we follow the pattern `val msg = createMessage(...); msg.send(mode)` instead of just `send(... + mode)` ?"
+You might ask: "why do we follow the pattern `val msg = createMessage(...); msg.send(mode)` instead of just `send(... + mode)`?"
 
 Typically, yes — you send a message immediately after composing it.
 But there are also advanced use cases:
@@ -372,7 +372,7 @@ But there are also advanced use cases:
 So, composing a message cell and THEN doing some action with it is a more flexible pattern.
 
 Moreover, following this pattern requires you to give **a name** to a variable.
-Advice is not to name it "m" or "msg," but to give a descriptive name like "excessesMsg" or "transferMsg":
+Do not name it "m" or "msg"; use a descriptive name like "excessesMsg" or "transferMsg":
 
 ```tolk
 val excessesMsg = createMessage({
@@ -390,7 +390,7 @@ As opposed to a potential `send(...)` function, you have to dig into what body i
 
 You might also ask: why do we join `stateInit` as a **destination** for other use cases? Why not make a `deploy()` function that accepts code+data and drops stateInit from a **regular** createMessage?
 
-The answer lies in terminology. Yes, **attaching stateInit** is often referred to as **deployment**, but it's an inaccurate term. **TON Blockchain doesn't have a dedicated deployment mechanism.** You send a message to some _void_  — and if this _void_ doesn't exist, but you've attached a way to initialize it (code+data) — it's initialized immediately and accepts your message.
+The answer lies in terminology. Yes, **attaching stateInit** is often referred to as **deployment**, but it's an inaccurate term. **TON Blockchain doesn't have a dedicated deployment mechanism.** You send a message to some _void_ — and if this _void_ doesn't exist, but you've attached a way to initialize it (code+data) — it's initialized immediately and accepts your message.
 
 If you wish to emphasize the deployment, give it _a name_:
 
@@ -403,7 +403,7 @@ deployMsg.send(mode);
 
 ## Universal createExternalLogMessage
 
-The philosophy is similar to `createMessage`. But **external outs** don't have **bounce**; you don't attach tons, etc. So, options for creating are different.
+The philosophy is similar to `createMessage`. But **external outs** don't have **bounce**; you don't attach Toncoin, etc. So, options for creating are different.
 
 **Currently, external messages are used only for emitting logs (for viewing them in indexers).**
 But theoretically, they can be extended to **send messages to the offchain**.


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-tolk-tolk-vs-func-create-message.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx`

Related issues (from issues.normalized.md):
- [ ] **2185. Fix awkward phrase “regularly face code like”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Change “and regularly face code like:” to “and would regularly face code like this:”.

---

- [ ] **2186. Standardize efficiency wording; remove unsupported claims**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Use “gas-efficient” instead of “gas-effective” and remove or cite unsubstantiated efficiency claims (e.g., in the intro and feature 7); if kept, provide a benchmark reference.

---

- [ ] **2187. Correct destination union sentence and casing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1#destination-union

Replace “It’s either an address, OR a OR (WorkChain + hash), OR …:” with “It’s either an address, a builder, a pair (workchain, hash), or an AutoDeployAddress:”, and normalize “WorkChain” to “workchain”.

---

- [ ] **2188. Normalize split depth/fixed prefix length terms**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1#key-features-of-createmessage

Use “split depth” in prose (also known as fixed prefix length), and keep code identifiers as-is (`fixed_prefix_length`, `fixedPrefixLength`); e.g., change “Supports sharding (formerly splitDepth)” to “Supports sharding (formerly split depth)”.

---

- [ ] **2189. Capitalize sentence starting with “If”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Change “if a wallet doesn’t exist, it’s immediately initialized …” to “If a wallet doesn’t exist, it’s immediately initialized …”.

---

- [ ] **2190. Use article in “the wallet’s code”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Change “You know wallet’s code and initial data:” to “You know the wallet’s code and initial data:”.

---

- [ ] **2191. Remove article before walletInitialState**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Change “send a message to a `walletInitialState`” to “send a message to `walletInitialState`”.

---

- [ ] **2192. Expand “syn.” to “also known as”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Replace “syn.” with “also known as” wherever used for clarity.

---

- [ ] **2193. Use “compile time” vs “compile‑time” correctly**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Use “at compile time” as a noun phrase and “compile‑time” adjectivally (e.g., change “at compile-time” → “at compile time”).

---

- [ ] **2194. Use “the TON blockchain”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Change “In TON Blockchain” to “In the TON blockchain”.

---

- [ ] **2195. Add article in “all the calculations”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Change “the compiler does all calculations for you” to “the compiler does all the calculations for you”.

---

- [ ] **2196. Fix body-size rule phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Change “it’s unpredictable if contains `builder` or `slice` inside” to “it’s unpredictable if it contains a `builder` or `slice`”.

---

- [ ] **2197. Fix typo “potentially” in code comment**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1#body-ref-or-not-compile-time-calculation

Change “potentialy 620 bits” to “potentially 620 bits”.

---

- [ ] **2198. Use singular “risk”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Change “so, you take the risks” to “so you take the risk”.

---

- [ ] **2199. Use “without any surprises”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Change “left as a ref, without any surprise” to “left as a ref, without any surprises”.

---

- [ ] **2200. Fix comma splice in inference sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Change “Even this is okay, it is inferred as …” to “Even this is okay; it is inferred as …” (or “… and it is inferred as …”).

---

- [ ] **2201. Tighten guidance sentence with semicolon**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Change “That’s why, don’t pass `body: someObj.toCell()`, pass just `body: someObj`, let the compiler take care of everything.” to “Don’t pass `body: someObj.toCell()`; just pass `body: someObj` and let the compiler take care of everything.”

---

- [ ] **2202. Use “omit body” and “of type never”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Change “when we miss `body`” to “when we omit `body`” and “fields having `never` type” to “fields of type `never`”.

---

- [ ] **2203. Use plural verb with “contents”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Change “a full StateInit cell contents is richer” to “the full StateInit cell contents are richer”.

---

- [ ] **2204. Use “tick/tock” terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Change “ticktock info” to “tick/tock info” (or “tick/tock flags”).

---

- [ ] **2205. Remove space before question mark**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Change “send(... + mode) ?” to “send(... + mode)?”.

---

- [ ] **2206. Normalize “workchain” casing and “account ID”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Lowercase “workchain” in prose/comments and section titles (e.g., “StateInit and workchains”), and change “accountID” to “account ID”.

---

- [ ] **2207. Use “off‑chain” wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1#universal-createexternallogmessage

Change “send messages to the offchain” to “send messages to the off‑chain world” (or “to off‑chain systems”).

---

- [ ] **2208. Use “event ID” spacing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Change “eventID” to “event ID”.

---

- [ ] **2209. Prefer “outside world”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Change “outer world” to “outside world”.

---

- [ ] **2210. Replace “variety of interacting”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1#the-concept-is-based-on-union-types

Change “There is a huge variety of interacting between contracts.” to “There is a huge variety of interactions between contracts.”

---

- [ ] **2211. Hyphenate “on‑chain”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Use the hyphenated form “on‑chain” in prose.

---

- [ ] **2212. Capitalize numbered rule starts**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Start each numbered rule with a capital letter (e.g., “If `body` is small …”, “If `body` is large …”).

---

- [ ] **2213. Clarify table header “Address hash”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Change “Addr hash (256 bits)” to “Address hash (256 bits)”.

---

- [ ] **2214. Use “part of” instead of “a part of”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Change “must be a part of `StateInit`” to “must be part of `StateInit`”.

---

- [ ] **2215. Remove comma after “example” in comment**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Change “just an example, that even this would work” to “just an example that even this would work”.

---

- [ ] **2216. Avoid vague variable names**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Rephrase to “Do not name it ‘m’ or ‘msg’; use a descriptive name …” (or “It’s advisable not to name it …”).

---

- [ ] **2217. Fix em dash spacing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

In “You send a message to some _void_ — and if this _void_ …”, reduce the two spaces before the em dash to one consistent spacing.

---

- [ ] **2218. Capitalize “BaseChain”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Change lowercase “basechain” in prose/comments to “BaseChain” to match convention elsewhere.

---

- [ ] **2219. Replace undefined BASECHAIN constant**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1#stateinit-and-workchains

Replace `workchain: int8 = BASECHAIN;` with `workchain: int8 = 0; // BaseChain`, or link to the stdlib constant if it exists.

---

- [ ] **2220. Qualify or cite body inlining thresholds**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1#body-ref-or-not-compile-time-calculation

Either provide a citation for the exact limits (“< 500 bits and < 2 refs” vs “≥ 500 bits or ≥ 2 refs”), or qualify them as implementation‑defined.

---

- [ ] **2221. Close createMessage examples properly**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1#body-ref-or-not-compile-time-calculation

Add the missing `});` to the shown `createMessage({ ...` snippets so they are syntactically valid.

---

- [ ] **2222. Document or replace createAddressNone()**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1#universal-createexternallogmessage

Link to documentation for `createAddressNone()` if it’s a stdlib helper, or replace it with an explicit `addr_none` construction and note the mapping.

---

- [ ] **2223. Define or link ExtOutLogBucket**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1#universal-createexternallogmessage

Provide a definition or link for `ExtOutLogBucket`, or replace it with a documented construct for external logs.

---

- [ ] **2224. Document or generalize sendAndEstimateFee**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1#why-not-send-but-createmessage

Link to `sendAndEstimateFee` documentation if part of the stdlib, or rephrase to a general capability (e.g., “estimate fees before sending”) without naming an undefined API.

---

- [ ] **2225. Clarify heading about send vs createMessage**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1#why-not-send-but-createmessage

Change “Why not send, but createMessage?” to “Why createMessage instead of send()?”.

---

- [ ] **2226. Rephrase “body ref or not” feature**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1#key-features-of-createmessage

Change “Automatically detects body ref or not” to “Automatically decides whether to inline the body or store it by reference.”

---

- [ ] **2227. Use “Toncoin/TON” in prose**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx?plain=1

Prefer “Toncoin” (or “TON” as ticker) instead of lowercase “tons” in prose/comments; keep `coins` type unchanged in code.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.