### PR TITLE
Split: update docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx
@@ -2,7 +2,7 @@ import Feedback from '@site/src/components/Feedback';
 
 # Tolk vs FunC: in detail
 
-A huge list is below. Will anyone have enough patience to read it up to the end?..
+This page provides a comprehensive, detailed comparison.
 
 :::tip There is a compact version
 Here: [Tolk vs FunC: in short](/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short)
@@ -49,7 +49,7 @@ Here: [Tolk vs FunC: in short](/v3/documentation/smart-contracts/tolk/tolk-vs-fu
   </tbody>
 </table>
 
-### 2+2 is 4, not an identifier. Identifiers can only be alpha-numeric
+### 2+2 is 4, not an identifier. Identifiers can only be alphanumeric
 
 In FunC, almost any character can be a part of the identifier.
 For example, `2+2` (without a space) is an identifier.
@@ -82,10 +82,10 @@ In Tolk, spaces are not mandatory. `2+2` is 4, as expected. `3+~x` is `3 + (~ x)
   </tbody>
 </table>
 
-More precisely, an identifier can start from <code style={{display: 'inline-block'}}>{'[a-zA-Z$_]'}</code>
-and be continued with <code style={{display: 'inline-block'}}>{'[a-zA-Z0-9$_]'}</code>. Note that `?`, `:`, and others are not valid symbols, and `found?` and `op::increase` are invalid identifiers.
+More precisely, an identifier can start with <code style={{display: 'inline-block'}}>{'[a-zA-Z$_]'}</code>
+and be continued by <code style={{display: 'inline-block'}}>{'[a-zA-Z0-9$_]'}</code>. Note that `?`, `:`, and others are not valid symbols, and `found?` and `op::increase` are invalid identifiers.
 
-Note, that `cell`, `slice`, etc. are valid identifiers: `var cell = ...` or even `var cell: cell = ...` is okay. (like in TypeScript, `number` is a valid identifier)
+Note that `cell`, `slice`, etc. are valid identifiers: `var cell = ...` or even `var cell: cell = ...` is okay (like in TypeScript — `number` is a valid identifier).
 
 You can use backticks to surround an identifier, and then it can contain any symbols (similar to Kotlin and some other languages). This potential usage is to allow keywords to be used as identifiers in case of code generation by a scheme, for example.
 
@@ -114,11 +114,13 @@ You can use backticks to surround an identifier, and then it can contain any sym
 
     <tr>
       <td>
-        <code dangerouslySetInnerHTML={{__html: ';; even 2%&!2 is valid<br>int 2+2 = 5;'}} />
+        <code>{';; even 2%&!2 is valid'}</code><br/>
+        <code>{'int 2+2 = 5;'}</code>
       </td>
 
       <td>
-        <code dangerouslySetInnerHTML={{__html: '// don\'t do like this :)<br>var \`2+2\` = 5;'}} />
+        <code>{"// Avoid this pattern."}</code><br/>
+        <code>{'var `2+2` = 5;'}</code>
       </td>
     </tr>
   </tbody>
@@ -259,21 +261,23 @@ Modifiers `inline` and others — with annotations:
   <tbody>
     <tr>
       <td>
-        <code dangerouslySetInnerHTML={{__html: '<br>int f(cell s) inline {'}} />
+        <code>{'int f(cell s) inline {'}</code>
       </td>
 
       <td>
-        <code dangerouslySetInnerHTML={{__html: '@inline<br>fun f(s: cell): int {'}} />
+        <code>{'@inline'}</code><br/>
+        <code>{'fun f(s: cell): int {'}</code>
       </td>
     </tr>
 
     <tr>
       <td>
-        <code dangerouslySetInnerHTML={{__html: '<br>() load_data() impure inline_ref {'}} />
+        <code>{'() load_data() impure inline_ref {'}</code>
       </td>
 
       <td>
-        <code dangerouslySetInnerHTML={{__html: '@inline_ref<br>fun load_data() {'}} />
+        <code>{'@inline_ref'}</code><br/>
+        <code>{'fun load_data() {'}</code>
       </td>
     </tr>
 
@@ -312,7 +316,7 @@ Modifiers `inline` and others — with annotations:
       </td>
 
       <td>
-        <code dangerouslySetInnerHTML={{__html: 'fun cons&lt;X&gt;(head: X, tail: tuple): tuple'}} />
+        <code>{'fun cons<X>(head: X, tail: tuple): tuple'}</code>
       </td>
     </tr>
   </tbody>
@@ -336,7 +340,7 @@ fun mulDivFloor(x: int, y: int, z: int): int
 
 There is also a `@deprecated` attribute, not affecting compilation, but for a human and IDE.
 
-### get instead of method_id
+### `get` instead of `method_id`
 
 In FunC, `method_id` (without arguments) declared a get method. In Tolk, you use a straightforward syntax:
 
@@ -378,15 +382,18 @@ For `method_id(xxx)` (uncommon in practice, but valid), there is an attribute:
   <tbody>
     <tr>
       <td>
-        <code dangerouslySetInnerHTML={{__html: '<br>() after_code_upgrade(cont old_code) impure method_id(1666)'}} />
+        <code>{'() after_code_upgrade(cont old_code) impure method_id(1666)'}</code>
       </td>
 
       <td>
-        <code dangerouslySetInnerHTML={{__html: '@method_id(1666)<br>fun afterCodeUpgrade(oldCode: continuation)'}} />
+        <code>{'@method_id(1666)'}</code><br/>
+        <code>{'fun afterCodeUpgrade(oldCode: continuation)'}</code>
       </td>
     </tr>
   </tbody>
 </table>
+
+Note: FunC `cont` corresponds to Tolk `continuation`.
 
 ### It's essential to declare types of parameters (though optional for locals)
 
@@ -442,7 +449,7 @@ var a = 10;
 var (a, b) = (20, 30);  // error, releclaration of a
 ```
 
-Note, that it's not a problem for `loadUint()` and other methods. In FunC, they returned a modified object, so a pattern `var (cs, int value) = cs.load_int(32)` was quite common. In Tolk, such methods mutate an object: `var value = cs.loadInt(32)`, so redeclaration is unlikely to be needed.
+Note that it's not a problem for `loadUint()` and other methods. In FunC, they returned a modified object, so a pattern `var (cs, int value) = cs.load_int(32)` was quite common. In Tolk, such methods mutate an object: `var value = cs.loadInt(32)`, so redeclaration is unlikely to be needed.
 
 ```tolk
 fun send(msg: cell) {
@@ -600,7 +607,7 @@ var items = (
 ```
 
 Note that `(5)` is not a tensor. It's just the integer `5` in parentheses.
-With a trailing comma `(5,)` it's still `(5)`.
+With a trailing comma, `(5,)` denotes a one-element tensor.
 
 ### Optional semicolon for the last statement in a block
 
@@ -684,7 +691,7 @@ We have the following types:
 - union types `T1 | T2 | ...`, handled with pattern matching
 - `coins` and function `ton("0.05")`
 - `int32`, `uint64`, and other fixed-width integers (just int at TVM) [details](https://github.com/ton-blockchain/ton/pull/1559)
-- `bytesN` and `bitsN`, similar to `intN` (backed by slices at TVM)
+- `bytesN` and `bitsN`, similar to `intN` (backed by slices in TVM)
 - `address` (internal/external/none, still a slice at TVM)
 - `void` (more canonical to be named `unit`, but `void` is more reliable)
 - `self`, to make chainable methods, described below; actually it's not a type, it can only occur instead of return type of a function
@@ -745,7 +752,7 @@ valid + end;     // error
 8 & valid;       // error, int & bool not allowed
 ```
 
-Note, that logical operators `&& ||` (missed in FunC) use IF/ELSE asm representation always.
+Note that logical operators `&&` and `||` (absent in FunC) always compile to IF/ELSE.
 In the future, for optimization, they could be automatically replaced by `& |` when it's safe (example: `a > 0 && a < 10`).
 To manually optimize gas consumption, you can still use `& |` (allowed for bools), but remember, that they are not short-circuit.
 
@@ -782,7 +789,7 @@ duplicate([1, cs]);   // duplicate<[int, slice]>
 duplicate((1, 2));    // duplicate<(int, int)>
 ```
 
-Or even functions, it also works:
+Even functions work:
 
 ```tolk
 fun callAnyFn<TObj, TResult>(f: TObj -> TResult, arg: TObj) {
@@ -794,13 +801,13 @@ fun callAnyFn2<TObj, TCallback>(f: TCallback, arg: TObj) {
 }
 ```
 
-Note that while generic `T` is mostly detected from arguments, there are no such obvious corner cases when `T` does not depend on arguments:
+In corner cases, `T` does not depend on arguments:
 
 ```tolk
 fun tupleLast<T>(t: tuple): T
     asm "LAST"
 
-var last = tupleLast(t);    // error, can not deduce T
+var last = tupleLast(t);    // error, cannot deduce T
 ```
 
 To make this valid, `T` should be provided externally:
@@ -816,7 +823,7 @@ return tupleLast(t);       // ok if function specifies return type
 
 Also note that `T` for asm functions must occupy one stack slot, whereas for a user-defined function, `T` could be of any shape. Otherwise, asm body is unable to handle it properly.
 
-### #include → import. Strict imports
+### `#include` → `import`. Strict imports
 
 <table className="cmp-func-tolk-table">
   <thead>
@@ -847,7 +854,7 @@ In Tolk, you can not use a symbol from `a.tolk` without importing this file. In 
 
 All stdlib functions are available out of the box. Downloading stdlib and `#include "stdlib.fc"` is unnecessary. See below about embedded stdlib.
 
-There is still a global scope of naming. If `f` is declared in two different files, it's an error. We `import` a whole file with no per-file visibility, and the `export` keyword is now supported but probably will be in the future.
+There is still a global scope of naming. If `f` is declared in two different files, it's an error. We `import` a whole file with no per-file visibility. The `export` keyword is not currently supported and may be added in the future. You import whole files; per-file visibility is not implemented.
 
 ### #pragma → compiler options
 
@@ -857,17 +864,17 @@ In Tolk, all pragmas were removed. `allow-post-modification` and `compute-asm-lt
 
 As for now, there is one experimental option introduced — `remove-unused-functions`, which doesn't include unused symbols to Fift output.
 
-`#pragma version xxx` was replaced by `tolk xxx` (no >=, just a strict version). It's good practice to annotate the compiler version you are using. If it doesn't match, Tolk will show a warning.
+`#pragma version xxx` was replaced by a standalone directive line: `tolk xxx` (no >=, just a strict version). It's good practice to annotate the compiler version you are using. If it doesn't match, Tolk will show a warning.
 
 ```tolk
 tolk 0.12
 ```
 
-### Late symbols resolving. AST representation
+### Late Symbol Resolution. AST representation
 
-In FunC, like in С, you can not access a function declared below:
+In FunC, like in C, you cannot access a function declared below:
 
-```func
+```text
 int b() { a(); }   ;; error
 int a() { ... }    ;; since it's declared below
 ```
@@ -878,7 +885,7 @@ Tolk compiler separates these two steps. At first, it does parsing, and then it 
 
 It sounds simple, but internally, it's a very huge job. To make this available, I've introduced an intermediate AST representation, which was completely missed in FunC. That's an essential point for future modifications and performing semantic code analysis.
 
-### null keyword
+### `null` keyword
 
 Creating null values and checking variables on null looks very pretty now.
 
@@ -1022,7 +1029,7 @@ If FunC has `throw()`, `throw_if()`, `throw_arg_if()`, and the same for unless, 
   </tbody>
 </table>
 
-Note, that `!condition` is possible since logical NOT is available, see below.
+Note that `!condition` is possible since logical NOT is available, see below.
 
 There is a long (verbose) syntax of `assert(condition, excNo)`:
 
@@ -1127,7 +1134,7 @@ Also, Tolk swaps `catch` arguments: it's `catch (excNo, arg)`, both optional (si
   </tbody>
 </table>
 
-Note, that `!condition` is possible since logical NOT is available, see below.
+Note that `!condition` is possible since logical NOT is available, see below.
 
 ### Operator precedence became identical to C++ / JavaScript
 
@@ -1144,7 +1151,7 @@ if (flags & 0xFF != 0)
 will lead to a compilation error (similar to gcc/clang):
 
 ```
-& has lower precedence than ==, probably this code won't work as you expected.  Use parenthesis: either (... & ...) to evaluate it first, or (... == ...) to suppress this error.
+& has lower precedence than ==, probably this code won't work as you expected.  Use parentheses: either (... & ...) to evaluate it first, or (... == ...) to suppress this error.
 ```
 
 Hence, you should rewrite the code:
@@ -1161,7 +1168,7 @@ I've also added a diagnostic for a common mistake in bitshift operators: `a << 8
 ```
 int result = a << 8 + low_mask;
 
-error: << has lower precedence than +, probably this code won't work as you expected.  Use parenthesis: either (... << ...) to evaluate it first, or (... + ...) to suppress this error.
+error: << has lower precedence than +, probably this code won't work as you expected.  Use parentheses: either (... << ...) to evaluate it first, or (... + ...) to suppress this error.
 ```
 
 Operators `~% ^% /% ~/= ^/= ~%= ^%= ~>>= ^>>=` no longer exist.
@@ -1197,7 +1204,7 @@ fun processOpIncrease(msgBody: slice) {
 processOpIncrease(msgBody);  // by value, not modified
 ```
 
-In Tolk, a function can declare `mutate` parameters. It's a generalization of FunC `~` tilda functions, read below.
+In Tolk, a function can declare `mutate` parameters. It's a generalization of FunC `~` tilde functions, read below.
 
 ### Deprecated command-line options removed
 
@@ -1288,7 +1295,7 @@ Mind the rule **import what you use**, it's applied to `@stdlib/...` files also 
 
 JetBrains IDE plugin automatically discovers stdlib folder and inserts necessary imports as you type.
 
-### Logical operators && ||, logical not !
+### Logical operators `&&` `||`, logical not `!`
 
 In FunC, there are only bitwise operators `~ & | ^`. Developers making first steps, thinking "okay, no logical, I'll use bitwise in the same manner", often do errors, since operator behavior is completely different:
 
@@ -1301,7 +1308,7 @@ In FunC, there are only bitwise operators `~ & | ^`. Developers making first ste
   </thead>
 
   <tbody>
-    <tr><td colSpan={2}>sometimes, identical:</td></tr>
+    <tr><td colSpan={2}>sometimes identical:</td></tr>
 
     <tr>
       <td>
@@ -1358,7 +1365,7 @@ In FunC, there are only bitwise operators `~ & | ^`. Developers making first ste
   </thead>
 
   <tbody>
-    <tr><td colSpan={2}>sometimes, identical:</td></tr>
+    <tr><td colSpan={2}>sometimes identical:</td></tr>
 
     <tr>
       <td>
@@ -1505,7 +1512,7 @@ Tolk supports logical operators. They behave exactly as you get used to (right c
 
 Keywords `ifnot` and `elseifnot` were removed, since now we have logical not (for optimization, Tolk compiler generates `IFNOTJMP`, btw). The `elseif` keyword  was replaced by the traditional `else if`.
 
-Remember that a boolean `true`, transformed `as int`, is -1, not 1. It's a TVM representation.
+Remember: `true as int` is -1 (TVM representation), not 1. This cast inserts no runtime instructions.
 
 ### Indexed access tensorVar.0 and tupleVar.0
 
@@ -1604,7 +1611,7 @@ var s = b.endCell().beginParse();
 return s as address;   // `slice` as `address`
 ```
 
-A reversed cast also is valid: `someAddr as slice` (why would you need it, is an open question, though).
+The reverse cast is also valid: `someAddr as slice`.
 
 **Different types of addresses**
 
@@ -1787,7 +1794,7 @@ var v = 0;
 // prints a warning
 if (v == null) {
     // v is `never`
-    v + 10;   // error, can not apply `+` `never` and `int`
+    v + 10;   // error, cannot apply `+` `never` and `int`
 }
 // v is `int` again
 ```
@@ -2155,7 +2162,7 @@ fun builder.storeInt32(mutate self, v: int32): self {
 ```
 
 Methods for generic structs created seamlessly.
-Note, that no extra `<T>` is required: while parsing the receiver type, compiler treats unknown symbols as generic arguments.
+Note that no extra `<T>` is required: while parsing the receiver type, compiler treats unknown symbols as generic arguments.
 
 ```tolk
 struct Container<T> {
@@ -2326,7 +2333,7 @@ A function will NOT be inlined (even marked as `@inline`) if:
 3) It's used as a non-call. For example, you take a reference to it like `val callback = f.`
 
 
-### No tilda \~ methods, mutate keyword instead
+### No tilde \~ methods, mutate keyword instead
 
 If FunC has `.methods()` and `~methods()`, Tolk has only a dot, and the only way to call a method is `.method()`. Basically, Tolk just works as expected:
 
@@ -2339,7 +2346,7 @@ Continue reading on a separate page: [Mutability in Tolk](/v3/documentation/smar
 
 ### Auto-packing to/from cells/builders/slices
 
-Having any struct, you can unpack in from a cell or pack and object to a cell:
+Having any struct, you can unpack it from a cell or pack an object (into a cell, where relevant):
 
 ```tolk
 struct Point {


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-tolk-tolk-vs-func-in-detail.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx`

Related issues (from issues.normalized.md):
- [ ] **2228. Neutralize informal opening tone**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1#L5

Rewrite the opening to a neutral, professional tone, e.g., “This page provides a comprehensive, detailed comparison.”

---

- [ ] **2229. Use “Note that” (no comma)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1#L88, L445, L748, L1025, L1130, L2158

Replace “Note, that …” with “Note that …” in all occurrences.

---

- [ ] **2230. Remove emoji and contraction in comment**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1#L121

Change “// don’t do like this :)” to “// Do not do this.” or “// Avoid this pattern.”

---

- [ ] **2231. Wrap identifiers in headings with backticks**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1#L339

Use code formatting for identifiers in headings, e.g., “### get instead of method_id” → “### `get` instead of `method_id`”; apply similarly for `null`, `import`, etc.

---

- [ ] **2232. Fix typo “releclaration” → “redeclaration”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1#L442

Correct the misspelling in the comment: “error, redeclaration of a …”.

---

- [ ] **2233. Fix typo “intruduce” → “introduce”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1#L451

Correct the comment to “introduce a new variable”.

---

- [ ] **2234. Prefer “in TVM” preposition**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1#L687

Change “backed by slices at TVM” to “backed by slices in TVM”.

---

- [ ] **2235. Prefer “cannot” in prose (keep literal outputs)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1#L714–L716, L803, L846, L868, L1582, L1790

Replace “can not”/“Can not” with “cannot” in explanatory text; retain exact wording inside quoted compiler output or error snippets.

---

- [ ] **2236. Improve phrasing: “Or even functions, it also works”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1#L785

Rewrite to “Even functions work:” or “It also works with functions:”.

---

- [ ] **2237. Clarify corner-case wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1#L797

Replace “There are no such obvious corner cases when …” with a clear alternative, e.g., “In corner cases, `T` does not depend on arguments:”.

---

- [ ] **2238. Clarify `export` support status**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1#L850

Replace the contradictory sentence with: “The `export` keyword is not currently supported and may be added in the future. You import whole files; per-file visibility is not implemented.”

---

- [ ] **2239. Verify FunC code block language tag**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1#L870

Ensure Prism recognizes the “```func” fence; if not, switch to a supported tag (e.g., “```text”) to avoid broken highlighting.

---

- [ ] **2240. Rephrase “very huge job”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1#L879

Change to a neutral phrasing: “It sounds simple, but internally it was a very large change.”

---

- [ ] **2241. Use plural “parentheses” in diagnostics**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1#L1147, L1164

Use “parentheses” (plural), e.g., “Use parentheses: either (… & …) … or (… == …) …”.

---

- [ ] **2242. Replace “tilda” with “tilde”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1#L1200, L2329

Use the correct term “tilde” for the “~” character, e.g., “FunC `~` tilde functions”.

---

- [ ] **2243. Use “The former ‘stdlib.fc’ …”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1#L1239

Change “A former ‘stdlib.fc’ was split …” to “The former ‘stdlib.fc’ was split …”.

---

- [ ] **2244. Fix stdlib embedding grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1#L1273

Replace “In Tolk, stdlib a part of distribution.” with “In Tolk, the stdlib is part of the distribution.”

---

- [ ] **2245. Neutralize address cast aside; fix reverse-cast phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1#L1607

Remove the aside (“… an open question, though”) and change “A reversed cast also is valid” to “The reverse cast is also valid.”

---

- [ ] **2246. Replace double colon with single colon**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1#L1680

Fix “nullable::” to “nullable:”.

---

- [ ] **2247. Clarify logical operators sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1

Replace “Note, that logical operators `&& ||` (missed in FunC) use IF/ELSE asm representation always.” with “Note that logical operators `&&` and `||` (absent in FunC) always compile to IF/ELSE.”

---

- [ ] **2248. Tighten identifier rules wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1

- “alpha-numeric” → “alphanumeric” (identifiers heading). - “can start from” → “can start with”; “be continued with” → “be continued by”. - In the TypeScript analogy, prefer a dash: “like in TypeScript — `number` is a valid identifier.”

---

- [ ] **2249. Close brace in `send` example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1

The `send(msg: cell)` snippet opens a function but never closes it; add a closing “}” before the fence ends.

---

- [ ] **2250. Clarify boolean truthiness note**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1

Tighten to “Remember: `true as int` is -1 (TVM representation), not 1.” and note this cast inserts no runtime instructions.

---

- [ ] **2251. Update operator-precedence heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1

Change “Operator precedence became identical to C++ / JavaScript” to “Operator Precedence Matches C++/JavaScript.”

---

- [ ] **2252. Fix “Late symbols resolving” heading and Cyrillic “C”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1

Use “Late Symbol Resolution. AST representation” and ensure “like in C” uses a Latin “C” (not Cyrillic).

---

- [ ] **2253. Clarify single-input-file constraint**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1

Make explicit: “Only one input file can be passed to the compiler; others must be imported.”

---

- [ ] **2254. Prefer “camelCase naming”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1

Replace “camelCase style” with “camelCase naming.”

---

- [ ] **2255. Fix auto-packing typos**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1

Change “unpack in from a cell” → “unpack it from a cell” and “pack and object” → “pack an object (into a cell, where relevant)”.

---

- [ ] **2256. Make `tolk 0.12` directive standalone**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1

Clarify that the version annotation is a standalone directive line: `tolk 0.12`; if it doesn’t match, Tolk shows a warning.

---

- [ ] **2257. Clarify `cont` → `continuation` mapping**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1

After the method ID example, add that FunC `cont` corresponds to Tolk `continuation` to avoid confusion.

---

- [ ] **2258. Address TL‑B description grammar/terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1

Fix minor issues: “just an address of a smart contract”; and prefer “length (9 bits) + length bits” for clarity and consistency with TL‑B references.

---

- [ ] **2259. Prefer MDX-safe code over dangerouslySetInnerHTML**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1

Replace inline `<code dangerouslySetInnerHTML={{__html: '...'}} />` with MDX-safe markup to avoid escaping issues across translations.

---

- [ ] **2260. Add code font around “.tolk” in import comment**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1

In the stdlib import snippet comment, wrap the file extension with code font: “// ‘.tolk’ optional”.

---

- [ ] **2261. Use code font in “Modern onInternalMessage” heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1

Change the section title to “Modern `onInternalMessage`” for consistency with other identifiers.

---

- [ ] **2262. Clarify tuple trailing-comma semantics**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1

Explicitly state whether `(5,)` denotes a one-element tuple or just parentheses; current text “With a trailing comma `(5,)` it’s still `(5)`” is ambiguous and needs correction.

---

- [ ] **2263. Use code font for types in prose/headings**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1

Ensure types and identifiers like `address`, `coins`, `tuple`, `tensor`, `method_id`, `get`, `import`, `export`, `lazy`, and `continuation` are consistently wrapped in backticks when referenced as syntax.

---

- [ ] **2264. Remove comma in “sometimes identical”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx?plain=1

In logical-operator comparison notes, change “sometimes, identical:” to “sometimes identical:” (or “in some cases identical:”).

---

- [ ] **2268. Clarify impure by default sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx?plain=1#L25

Rephrase to: "No `impure` needed; functions are impure by default, and the Tolk compiler won't drop user function calls" for clarity and correctness (docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx#impure-by-default-compiler-wont-drop-user-function-calls).

---

- [ ] **2741. Add note/link for 267‑bit internal address when using 363‑bit threshold**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/nfts.mdx?plain=1

Add parenthetical “(internal addresses are 267 bits)” with a reference to docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx#L1613 to justify 32+64+267 = 363 bits.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.