### PR TITLE
Split: update docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx
@@ -2,10 +2,10 @@ import Feedback from '@site/src/components/Feedback';
 
 # Tolk vs FunC: in short
 
-Tolk is much more similar to TypeScript and Kotlin than C and Lisp. 
-But it still gives you complete control over the TVM assembler since it has a FunC kernel inside.
+Tolk is much more similar to TypeScript and Kotlin than C and Lisp.
+But it still provides direct access to TVM assembler for low-level control.
 
-1. Functions are declared via `fun`, get methods via `get fun`, variables via `var`, immutable variables via `val`, putting types on the right; parameter types are mandatory; return type can be omitted (auto inferred), as well as for locals; specifiers `inline_ref` and others are `@` attributes
+1. Functions are declared via `fun`, get methods via `get fun`, variables via `var`, immutable variables via `val`, putting types on the right; parameter types are mandatory; the return type can be omitted (auto-inferred). Local variable types can also be omitted; attributes like `@inline_ref` use the `@` syntax
 ```tolk
 global storedV: int;
 
@@ -22,7 +22,7 @@ fun sum(a: int, b: int) {   // auto inferred int
 
 get fun currentCounter(): int { ... }
 ```
-2. No `impure`, it's by default, the Tolk compiler won't drop user function calls
+2. No `impure` needed; functions are impure by default, and the Tolk compiler won't drop user function calls
 3. Not `recv_internal` and `recv_external`, but `onInternalMessage` / `onExternalMessage` / `onBouncedMessage`
 4. `2+2` is 4, not an identifier; identifiers are alpha-numeric; use naming `const OP_INCREASE` instead of `const op::increase`; `cell` and `slice` are valid identifiers (not keywords)
 5. Logical operators AND `&&`, OR `||`, NOT `!` are supported
@@ -33,7 +33,7 @@ get fun currentCounter(): int { ... }
     - `~ found` → `!found` (for true/false only, obviously) (true is -1, like in FunC)
     - `v = null()` → `v = null`
     - `null?(v)` → `v == null`, same for `builder_null?` and others
-    - `~ null?(v)` → `c != null`
+    - `~ null?(v)` → `v != null`
     - `throw(excNo)` → `throw excNo`
     - `catch(_, _)` → `catch`
     - `catch(_, excNo)` → `catch(excNo)`
@@ -45,11 +45,11 @@ get fun currentCounter(): int { ... }
     - `ifnot (cond)` → `if (!cond)`
     - `"..."c` → `stringCrc32("...")` (and other postfixes also)
 7. A function can be called even if declared below; forward declarations not needed; the compiler at first does parsing, and then it does symbol resolving; there is now an AST representation of source code
-8. stdlib functions renamed to ~~verbose~~ clear names, camelCase style; it's now embedded, not downloaded from GitHub; it's split into several files; common functions available always, more specific available with `import "@stdlib/tvm-dicts"`, IDE will suggest you; here is [a mapping](/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib)
-9. No `~` tilda methods; `cs.loadInt(32)` modifies a slice and returns an integer; `b.storeInt(x, 32)` modifies a builder; `b = b.storeInt()` also works since it is not only modifies but returns; chained methods work identically to JS, they return `self`; everything works exactly as expected, similar to JS; no runtime overhead, exactly same Fift instructions; custom methods are created with ease; tilda `~` does not exist in Tolk at all; [more details here](/v3/documentation/smart-contracts/tolk/tolk-vs-func/mutability)
+8. stdlib functions renamed to ~~verbose~~ clear names, camelCase; it's now embedded, not downloaded from GitHub; it's split into several files; common functions available always, more specific available with `import "@stdlib/tvm-dicts"`, the IDE will suggest imports; here is [a mapping](/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib)
+9. No `~` tilda methods; `cs.loadInt(32)` modifies a slice and returns an integer; `b.storeInt(x, 32)` modifies a builder; `b = b.storeInt(x, 32)` also works since it not only modifies but returns; chained methods work identically to JS, they return `self`; everything works exactly as expected, similar to JS; no runtime overhead, exactly same Fift instructions; custom methods are created with ease; tilda `~` does not exist in Tolk at all; [more details here](/v3/documentation/smart-contracts/tolk/tolk-vs-func/mutability)
 10. Clear and readable error messages on type mismatch
 11. `bool` type support
-12. Indexed access `tensorVar.0` and `tupleVar.0` support
+12. Indexed access `tensorVar.0` and `tupleVar.0` is supported
 13. Nullable types `T?`, null safety, smart casts, operator `!`
 14. Union types and pattern matching (for types and for expressions, switch-like behavior)
 15. Type aliases are supported
@@ -58,7 +58,7 @@ get fun currentCounter(): int { ... }
 18. Methods (as extension functions) are supported
 19. Trailing comma is supported
 20. Semicolon after the last statement in a block is optional
-21. Fift output contains original .tolk lines as comments
+21. Fift output contains the original `.tolk` lines as comments
 22. [Auto-packing](/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells) to/from cells — for any types
 23. [Universal createMessage](/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message) to avoid manual cells composition
 24. Auto-detect and inline functions at the compiler level
@@ -69,14 +69,14 @@ get fun currentCounter(): int { ... }
 - [JetBrains IDE plugin](https://github.com/ton-blockchain/intellij-ton)
 - [VS Code extension](https://github.com/ton-blockchain/ton-language-server)
 - [FunC-to-Tolk converter](https://github.com/ton-blockchain/convert-func-to-tolk)
-- [tolk-js](https://github.com/ton-blockchain/tolk-js) WASM wrapper for blueprint
+- [tolk-js](https://github.com/ton-blockchain/tolk-js) WASM wrapper for the Tolk compiler, integrated into Blueprint
 
 
 ### Tolk vs FunC gas benchmarks
 
 The [Tolk-bench repository](https://github.com/ton-blockchain/tolk-bench) contains several contracts migrated from FunC to Tolk, preserving all logic and passing the same tests.
 
-As you see, not only does the code become readable, but gas usage is noticeably reduced. And there are no tricks here—just clean, consistent logic — whether it's a Jetton or a Wallet.
+As you see, not only does the code become readable, but gas usage is noticeably reduced. And there are no tricks here—just clean, consistent logic—whether it's a Jetton or a Wallet.
 
 The rule is simple: **if you write code the way the language encourages — gas will take care of itself**.
 
@@ -85,4 +85,3 @@ The rule is simple: **if you write code the way the language encourages — gas 
 - [Tolk vs FunC: in detail](/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail)
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-tolk-tolk-vs-func-in-short.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx`

Related issues (from issues.normalized.md):
- [ ] **2265. Rephrase 'FunC kernel inside' claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx?plain=1#L6

Replace "it has a FunC kernel inside" with "But it still provides direct access to TVM assembler for low-level control" to avoid unsupported internals and align with the overview (docs/v3/documentation/smart-contracts/tolk/overview.mdx#why-choose-tolk).

---

- [ ] **2266. Fix auto-inferred and locals sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx?plain=1#L8

Replace "parameter types are mandatory; return type can be omitted (auto inferred), as well as for locals" with "parameter types are mandatory; the return type can be omitted (auto-inferred). Local variable types can also be omitted" to match established phrasing (docs/v3/documentation/smart-contracts/tolk/language-guide.mdx#function-declaration, docs/v3/documentation/smart-contracts/tolk/language-guide.mdx#variable-declaration).

---

- [ ] **2267. Use 'attributes' with `@` terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx?plain=1#L8

Replace "specifiers `inline_ref` and others are `@` attributes" with "attributes like `@inline_ref` use the `@` syntax" to match Tolk terminology (docs/v3/documentation/smart-contracts/tolk/language-guide.mdx#function-attributes).

---

- [ ] **2268. Clarify impure by default sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx?plain=1#L25

Rephrase to: "No `impure` needed; functions are impure by default, and the Tolk compiler won't drop user function calls" for clarity and correctness (docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx#impure-by-default-compiler-wont-drop-user-function-calls).

---

- [ ] **2269. Use consistent variable in null-check mapping**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx?plain=1#L36

Change "~ null?(v) → c != null" to "~ null?(v) → v != null" to keep the example consistent with the preceding "null?(v) → v == null".

---

- [ ] **2270. Clarify 'IDE will suggest you'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx?plain=1#L48

Change "IDE will suggest you" to "the IDE will suggest imports" to make the object explicit (see language guide Standard library section).

---

- [ ] **2271. Remove 'style' from camelCase**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx?plain=1#L48

Change "camelCase style" to "camelCase" for concise, consistent terminology (docs/v3/documentation/smart-contracts/tolk/language-guide.mdx#identifiers).

---

- [ ] **2272. Add missing arguments in storeInt example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx?plain=1#L49

Replace "b = b.storeInt()" with "b = b.storeInt(x, 32)" to include required parameters and match surrounding examples (docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/mutability.mdx#return-self-makes-a-method-chainable).

---

- [ ] **2273. Fix subject–verb for indexed access**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx?plain=1#L52

Change "Indexed access `tensorVar.0` and `tupleVar.0` support" to "Indexed access `tensorVar.0` and `tupleVar.0` is supported" to correct subject–verb agreement.

---

- [ ] **2274. Add article and code formatting for .tolk**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx?plain=1#L61

Change "Fift output contains original .tolk lines as comments" to "Fift output contains the original `.tolk` lines as comments" to improve readability.

---

- [ ] **2275. Capitalize and clarify tolk-js description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx?plain=1#L72

Replace "WASM wrapper for blueprint" with "WASM wrapper for the Tolk compiler, integrated into Blueprint" to capitalize Blueprint and clarify the description (docs/v3/documentation/smart-contracts/tolk/overview.mdx#tooling-around-tolk).

---

- [ ] **2276. Fix em-dash spacing in gas paragraph**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx?plain=1#L79-L81

Change "And there are no tricks here—just clean, consistent logic — whether it's a Jetton or a Wallet." to "And there are no tricks here—just clean, consistent logic—whether it's a Jetton or a Wallet." to normalize em-dash spacing.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.