### PR TITLE
Split: update docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/lazy-loading.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/lazy-loading.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/lazy-loading.mdx
@@ -4,11 +4,11 @@ title: "The magic lazy"
 
 import Feedback from '@site/src/components/Feedback';
 
-# Lazy loading, partial loading, partial updating
+# The magic lazy
 
 One magic keyword — `lazy` — to rule them all.
 
-## Lazy loading, partial loading
+## Lazy loading
 
 Suppose you have a `Storage` struct in a wallet:
 
@@ -155,8 +155,8 @@ match (msg) {
 }
 ```
 
-Without an explicit `else`, unpacking throws `error 63` by default,
-which is controlled by the `throwIfOpcodeDoesNotMatch` option in fromCell/fromSlice.
+Without an explicit `else`, unpacking throws exit code 63 by default,
+which is controlled by the `throwIfOpcodeDoesNotMatch` option in `fromCell`/`fromSlice`.
 Adding `else` allows you to override this behavior.
 
 Note that `else` in `match` by type is only allowed with `lazy` because it matches on prefixes.
@@ -180,7 +180,7 @@ contract.setData(storage.toCell());   // <-- magic
 ```
 
 The compiler is smart: when calling `toCell()`, it **does not save all fields of the storage** since only `seqno` was modified.
-Instead, during loading, after loading `seqno`, it saved an _immutable tail_ and reuses it when writing back:
+Instead, during loading, after loading `seqno`, it saved an _immutable tail_ and reuses it on write back:
 
 ```tolk
 val storage = lazy Storage.load();
@@ -197,10 +197,10 @@ storage.toCell();
 ```
 
 No more manual optimizations using intermediate slices—the compiler handles everything for you.
-It can even group unmodified fields in the middle, load them as a slice, and preserve that slice on write-back.
+It can even group unmodified fields in the middle, load them as a slice, and preserve that slice on write back.
 
 This optimization is only effective when the compiler can statically resolve control flow within a local function scope.
-If you use globals, split logic into non-inlined functions, this optimization will break, and `lazy` will fall back to regular loading.
+If you use globals or split logic into non-inlined functions, this optimization breaks and `lazy` falls back to regular loading.
 
 
 ## Q: What are the disadvantages of lazy?
@@ -209,10 +209,10 @@ In terms of gas usage, `lazy fromSlice` is always equal to or cheaper than regul
 
 However, there is another difference unrelated to gas consumption:
 
-- When you do `T.fromSlice(s)`, it unpacks all fields of `T` and then inserts`s.assertEnd()`, which can be turned off using an option. So, if the slice is corrupted or contains extra data, `fromSlice` will throw an error.
+- When you do `T.fromSlice(s)`, it unpacks all fields of `T` and then inserts `s.assertEnd()`, which can be turned off using an option. So, if the slice is corrupted or contains extra data, `fromSlice` will throw an error.
 
 - The `lazy` keyword, of course, selectively _picks_ only the requested fields and handles partially invalid input gracefully. For example, given:
-```
+```tolk
 struct Point { x: int8, y: int8 }
 ```
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-tolk-tolk-vs-func-lazy-loading.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/lazy-loading.mdx`

Related issues (from issues.normalized.md):
- [ ] **2277. Fix undefined validUntil in example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/lazy-loading.mdx?plain=1

In “Partial updating”, the code asserts storage.validUntil but the earlier Storage struct lacks this field; either add validUntil: uint32 to the Storage example or remove/replace the assertion to use an existing field.

---

- [ ] **2278. Add missing semicolon in assert**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/lazy-loading.mdx?plain=1

In the “Lazy matching and else” example, add a semicolon to the else-branch line: assert (msgBody.isEmpty()) throw 0xFFFF;.

---

- [ ] **2279. Add tolk language tag to Point code block**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/lazy-loading.mdx?plain=1

The fenced code block showing struct Point { x: int8, y: int8 } lacks a language tag; mark it as ```tolk for correct syntax highlighting.

---

- [ ] **2280. Add missing space before inline code**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/lazy-loading.mdx?plain=1

Fix the typography “inserts`s.assertEnd()`” by inserting a space: “inserts `s.assertEnd()`”.

---

- [ ] **2281. Close braces in lazy match example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/lazy-loading.mdx?plain=1

The “Lazy matching” snippet opens match (msg) { and a branch body but does not close them; add the missing closing } (or an ellipsis) to keep the example balanced.

---

- [ ] **2282. Code-format fromCell/fromSlice identifiers**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/lazy-loading.mdx?plain=1

Format the identifiers in “fromCell/fromSlice” as code: “in `fromCell`/`fromSlice`”.

---

- [ ] **2283. Fix comma splice in optimization caveat**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/lazy-loading.mdx?plain=1

Rewrite “If you use globals, split logic into non-inlined functions, this optimization will break...” to “If you use globals or split logic into non-inlined functions, this optimization breaks and `lazy` falls back to regular loading.”

---

- [ ] **2284. Standardize “write back” hyphenation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/lazy-loading.mdx?plain=1

Use “write back” (no hyphen) consistently instead of mixing “write-back” and “writing back.”

---

- [ ] **2285. Align H1 with frontmatter title**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/lazy-loading.mdx?plain=1

Change the visible H1 to “The magic lazy” to match the frontmatter title for consistent navigation.

---

- [ ] **2286. Rename redundant H2 heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/lazy-loading.mdx?plain=1

Rename the H2 “Lazy loading, partial loading” to “Lazy loading” (or merge under the H1) to avoid duplicating the H1 wording.

---

- [ ] **2287. Fix comment: skip ref before commonKey**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/lazy-loading.mdx?plain=1

Update the comment when accessing CollectionContent.commonKey to “skip ref, skip 32 bits, preload uint256” to reflect the metadata reference followed by minIndex bits.

---

- [ ] **2288. Relabel “FunC-style” snippet**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/lazy-loading.mdx?plain=1

Change the label “FunC-style” to a neutral “Legacy pre-check pattern” (or convert the code to true FunC syntax) to avoid mismatching syntax and label.

---

- [ ] **2289. Use “exit code 9” terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/lazy-loading.mdx?plain=1

Replace “excno 9” with “exit code 9” to align with TVM exit code terminology.

---

- [ ] **2290. Use “exit code 63” terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/lazy-loading.mdx?plain=1

Change “throws error 63 by default” to “throws exit code 63 by default” for consistent exit-code phrasing.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.