### PR TITLE
Split: update docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Auto packing to/from cells"
+title: "Auto-packing to/from cells"
 ---
 
 import Feedback from '@site/src/components/Feedback';
@@ -28,7 +28,7 @@ var p = Point.fromCell(c);
 - Allows you to specify serialization prefixes (particularly, opcodes)
 - Allows you to manage cell references and when to load them
 - Lets you control error codes and other behavior
-- Unpacks data from a cell or a slice, mutate it or not
+- Unpacks data from a cell or a slice, with or without mutating it
 - Packs data to a cell or a builder
 - Warns if data potentially exceeds 1023 bits
 - More efficient than manual serialization
@@ -41,7 +41,7 @@ For example, if you assign 256 to uint8, asm command "8 STU" will fail with code
 
 | Type                     | TL-B equivalent                          | Serialization notes                 |
 | ------------------------ | ---------------------------------------- | ----------------------------------- |
-| `int8`, `uint55`, etc.   | same as TL-B                             | `N STI` / `N STU`                   |
+| `int8`, `uint64`, etc.   | same as TL-B                             | `N STI` / `N STU`                   |
 | `coins`                  | VarUInteger 16                           | `STGRAMS`                           |
 | `varint16`, 32, etc.     | Var(U)Integer 16/32                      | `STVARINT16` / `STVARUINT32` / etc. |
 | `bits8`, `bits123`, etc. | just N bits                              | runtime check + `STSLICE` (1)       |
@@ -61,7 +61,7 @@ For example, if you assign 256 to uint8, asm command "8 STU" will fail with code
 | `(T1, T2, ...)`          | nested pairs = one by one                | pack T1 + pack T2 + ...             |
 | `SomeStruct`             | fields one by one                        | like a tensor                       |
 
-- (1) By analogy with `intN`, there is are `bytesN` types. It's just a `slice` under the hood: the type shows how to serialize this slice.
+- (1) By analogy with `intN`, there are `bitsN` types; it's just a `slice` under the hood—the type dictates how to serialize this slice.
   By default, before `STSLICE`, the compiler inserts runtime checks (get bits/refs count + compare with N + compare with 0).
   These checks ensure that serialized binary data will be correct, but they cost gas.
   However, if you guarantee that a slice is valid (for example, it comes from trusted sources), pass an option `skipBitsNValidation` to disable runtime checks.
@@ -78,7 +78,7 @@ However, if T1 and T2 are both structures with manual serialization prefixes, th
 
 - (4) To (un)pack a union, say, `Msg1 | Msg2 | Msg3`, we need serialization prefixes. For structures, you can specify them manually
 (or the compiler will generate them right here). For primitives, like `int32 | int64 | int128 | int256`, the compiler generates a prefix tree 
-(00/01/10/11 in this case). Read **auto-generating serialization prefixes** below.
+(00/01/10/11 in this case). Read **Auto-generating Prefixes for Unions** below.
 
 - (5) Using raw `builder` and `slice` for writing is supported but not recommended, as they do not reveal any information about their internal structure.
 Auto-generated TypeScript wrappers will be available in the future. However, for a raw `slice`, a wrapper cannot be generated, as there is no way to predict how to read such a field back.
@@ -114,11 +114,11 @@ struct A {
 }
 ```
 
-## Serialization prefixes and opcodes
+## Serialization Prefixes and Opcodes
 
 Declaring a struct, there is a special syntax to provide pack prefixes.
 
-Typically, you'll use 32-bit prefixes for messages opcodes, or arbitrary prefixes is case you'd like to express TL-B multiple constructors.
+Typically, you'll use 32-bit prefixes for message opcodes, or arbitrary prefixes in case you'd like to express TL-B multiple constructors.
 
 ```tolk
 struct (0x7362d09c) TransferNotification {
@@ -127,16 +127,16 @@ struct (0x7362d09c) TransferNotification {
 }
 ```
 
-Prefixes **can be of any width**, they are not restricted to be 32 bit.
+Prefixes **can be of any width**, they are not restricted to 32 bits.
 
 - `0x000F` — 16-bit prefix
 - `0x0F` — 8-bit prefix
 - `0b010` — 3-bit prefix
 - `0b00001111` — 8-bit prefix
 
-Declaring messages with 32-bit opcodes does not differ from declaring any other structs. Say, you the following TL-B scheme:
+Declaring messages with 32-bit opcodes does not differ from declaring any other struct. Say, you have the following TL-B scheme:
 
-```tl-b
+```tlb
 asset_simple$001 workchain:int8 ptr:bits32 = Asset;
 asset_booking$1000 order_id:uint64 = Asset;
 ...
@@ -208,15 +208,15 @@ MyData.fromSlice(s)  // expected to be "1234..." (hex)
 data.toCell()        // "1234..."
 ```
 
-That's why, when you declare outgoing messages with 32-bit opcodes and just serialize them, that opcodes are included in binary data.
+That's why, when you declare outgoing messages with 32-bit opcodes and just serialize them, those opcodes are included in the binary data.
 
 ## What can NOT be serialized
 
 - `int` can't be serialized, it does not define binary width; use `int32`, `uint64`, etc.
 - `slice`, for the same reason; use `address` or `bitsN`
 - tuples, not implemented
-- `A | B` (and `A|B|C|...` in general) if A has manual serialization prefix, B not (because it seems like a bug in your code)
-- `int32 | A` (and `primitives|...|structs` in general) if A has manual serialization prefix (because it's not definite what prefixes to use for primitives)
+- `A | B` (and `A|B|C|...` in general) if A has a manual serialization prefix and B does not (because it seems like a bug in your code)
+- `int32 | A` (and `primitives|...|structs` in general) if A has a manual serialization prefix (because it's not definite what prefixes to use for primitives)
 
 Example of invalid:
 
@@ -263,7 +263,7 @@ hint: replace `int` with `int32` / `uint64` / `coins` / etc.
 
 Tolk gives you full control over how your data is placed in cells and how cells reference each other.
 When you declare fields in a struct, there is no compiler magic of reordering fields, making any implicit references, etc.
-As follows, whenever you need to place data in a ref, you do it manually. As well as you manually control, when contents of that ref is loaded.
+Accordingly, whenever you need to place data in a ref, you do it manually; you also manually control when the contents of that ref are loaded.
 
 There are two types of references: typed and untyped.
 
@@ -286,10 +286,10 @@ struct RoyaltyParams {
 When you call `NftCollectionStorage.fromSlice` (or fromCell), the process is as follows:
 
 1. read address (slice.loadAddress)
-2. read uint64 (slice.loadUint 64)
+2. read uint64 (slice.loadUint(64))
 3. read three refs (slice.loadRef); do not unpack them: we just have pointers to cells
 
-Note, that `royaltyParams` is `Cell<T>`, not `T` itself. You can NOT access `numerator`, etc. To load those fields, you should manually unpack that ref:
+Note that `royaltyParams` is `Cell<T>`, not `T` itself. You can NOT access `numerator`, etc. To load those fields, you should manually unpack that ref:
 
 ```tolk
 // error: field does not exist in type `Cell<RoyaltyParams>`
@@ -322,7 +322,7 @@ val c = p.toCell();  // Point to Cell<Point>
 val p2 = c.load();   // Cell<Point> to Point
 ```
 
-With types cells, you can express snake data:
+With typed cells, you can express snake cells:
 
 ```tolk
 struct Snake {
@@ -336,14 +336,14 @@ Note that `Cell<address>` or even `Cell<int32 | int64>` is also okay, you are no
 
 When it comes to untyped cells — just `cell` — they also denote references, but don't denote their inner contents, don't have the `.load()` method.
 
-It's just _some cell_, like code/data of a contract or an untyped nft content.
+It's just _some cell_, like code/data of a contract or untyped NFT content.
 
 ## Remaining data after reading
 
 Suppose you have struct Point (x int8, y int8), and read from a slice with contents "0102FF".
 Byte "01" for x, byte "02" for y, and the remaining "FF" — is it correct?
 
-**By default, this is incorrect**. By default, functions `fromCell` and `fromSlice` ensure the slice end after reading.
+**By default, this is incorrect**. By default, functions `fromCell` and `fromSlice` ensure the slice ends after reading.
 In this case, exception 9 ("cell underflow") is thrown.
 
 But you can override this behavior with an option:
@@ -389,7 +389,7 @@ fullDomain: Cell<VariadicString>
 
 The compiler inlines your functions every time packing/unpacking takes place.
 
-Method names `packToBuilder` and `unpackFromSlice` are reserved for this purpose, their prototype must be exactly as showed.
+Method names `packToBuilder` and `unpackFromSlice` are reserved for this purpose, their prototype must be exactly as shown.
 
 ## UnpackOptions and PackOptions
 
@@ -401,7 +401,7 @@ MyMsg.fromSlice(s, {
 })
 ```
 
-Serialization functions have the second optional parameter, actually:
+Deserialization functions have a second optional parameter:
 
 ```tolk
 fun T.fromSlice(rawSlice: slice, options: UnpackOptions = {}): T;
@@ -413,7 +413,7 @@ For deserialization (`fromCell` and similar), there are now two available option
 
 | Field of UnpackOptions      | Description                                                                                                                                                                                                                                                                                               |
 | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `assertEndAfterReading`     | after finished reading all fields from a cell/slice, call `slice.assertEnd` to ensure no remaining data left; it's the default behavior, it ensures that you've fully described data you're reading with a struct; for struct `Point`, input "0102" is ok, "0102FF" will throw excno 9; **default: true** |
+| `assertEndAfterReading`     | after finished reading all fields from a cell/slice, call `slice.assertEnd` to ensure no remaining data left; it's the default behavior, it ensures that you've fully described data you're reading with a struct; for struct `Point`, input "0102" is ok, "0102FF" will throw exit code 9 (Cell underflow); **default: true** |
 | `throwIfOpcodeDoesNotMatch` | this excNo is thrown if opcode doesn't match, e.g. for `struct (0x01) A` given input "88..."; similarly, for a union type, this is thrown when none of the opcodes match; **default: 63**                                                                                                                 |
 
 For serialization (`toCell` and similar), there is now one option:
@@ -438,7 +438,7 @@ Internally, a builder is created, all fields are serialized one by one, and a bu
 
 ```tolk
 var b = beginCell()
-       .storeUint(32)
+       .storeUint(32, 32)
        .storeAny(msgBody)  // T=MyMsg here
        .endCell();
 ```
@@ -461,7 +461,7 @@ Internally, a cell is unpacked to a slice, and that slice is parsed (c.beginPars
 var msg = CounterIncrement.fromSlice(cs);
 ```
 
-All fields are read from a slice immediately. If a slice is corrupted, an exception is thrown (most likely, excode 9 "cell underflow"). Note, that a passed slice is NOT mutated, its internal pointer is NOT shifted. If you need to mutate it, like `cs.loadInt()`, consider calling `cs.loadAny<Increment>()`.
+All fields are read from a slice immediately. If a slice is corrupted, an exception is thrown (most likely, exit code 9 (Cell underflow)). Note that a passed slice is NOT mutated, its internal pointer is NOT shifted. If you need to mutate it, like `cs.loadInt()`, consider calling `cs.loadAny<CounterIncrement>()`.
 
 3. `slice.loadAny<T>` — parse anything from a slice, shifting its internal pointer. Similar to `slice.loadUint()` and others, but allows loading structures. Example:
 
@@ -499,7 +499,7 @@ type RemainingBitsAndRefs = slice
 
 ## Auto-generating prefixes for unions
 
-We've mentioned multiple times, that `T1 | T2` is encoded as TL-B Either: bit '0' + T1 OR bit '1' + T2. But what about wider unions? Say,
+We've mentioned multiple times that `T1 | T2` is encoded as TL-B Either: bit '0' + T1 OR bit '1' + T2. But what about wider unions? Say,
 
 ```tolk
 struct WithUnion {
@@ -651,7 +651,7 @@ Since Tolk remains low-level whenever you need, it allows doing tricky things. S
 
 ```tolk
 var addrB = beginCell()
-           .storeUint(0b01)   // addr_extern
+           .storeUint(0b01, 2)   // addr_extern
            ...;
 ```
 
@@ -664,7 +664,7 @@ struct MyStorage {
 }
 
 var st: MyStorage;
-st.addr = addrB;   // error, can not assign `builder` to `address`
+st.addr = addrB;   // error, cannot assign `builder` to `address`
 ```
 
 Of course, you can do `addrB.endCell().beginParse() as address`, but creating a cell is expensive. How can you write `addrB` directly?


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-tolk-tolk-vs-func-pack-to-from-cells.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx`

Related issues (from issues.normalized.md):
- [ ] **2311. Standardize title hyphenation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx?plain=1

Make the frontmatter title and H1 use the same hyphenation; recommended: "Auto-packing to/from cells" in both.

---

- [ ] **2312. Fix summary list grammar (“mutate it or not”)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx?plain=1

Change "Unpacks data from a cell or a slice, mutate it or not" to "Unpacks data from a cell or a slice, with or without mutating it."

---

- [ ] **2313. Use standard width in types table**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx?plain=1

In the types list row, replace the confusing example "uint55" with a standard width like "uint64" to match earlier examples.

---

- [ ] **2314. Fix footnote: use “bitsN” and correct grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx?plain=1

Update the footnote to "By analogy with `intN`, there are `bitsN` types; it's just a `slice` under the hood—the type dictates how to serialize this slice."

---

- [ ] **2315. Align reference and header wording for prefixes section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx?plain=1

Change the reference to match the section title, e.g., "Auto-generating prefixes for unions."

---

- [ ] **2316. Fix grammar in prefixes/opcodes section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx?plain=1

Replace "messages opcodes" with "message opcodes", "is case" with "in case", "Say, you the following" with "Say, you have the following", "they are not restricted to be 32 bit" with "they are not restricted to 32 bits", and "any other structs" with "any other struct."

---

- [ ] **2317. Use correct TL‑B code fence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx?plain=1

Change code block fences from ```tl-b to ```tlb for proper TL‑B highlighting.

---

- [ ] **2318. Define variable in MyData example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx?plain=1

Replace the undefined `data.toCell()` with either `MyData{...}.toCell()` or define `val data: MyData = {...}; data.toCell()`.

---

- [ ] **2319. Use “those opcodes”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx?plain=1

Change "that opcodes are included in binary data" to "those opcodes are included in the binary data."

---

- [ ] **2320. Clarify union serialization bullet wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx?plain=1

Rewrite bullets to use clear phrasing, e.g., "if A has a manual serialization prefix, B does not" and for "`int32 | A` (and primitives vs. structs in general), use 'if A has a manual serialization prefix'."

---

- [ ] **2321. Clarify phrasing about refs**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx?plain=1

Replace "As follows, whenever you need to place data in a ref, you do it manually. As well as you manually control, when contents of that ref is loaded." with "Accordingly, whenever you need to place data in a ref, you do it manually; you also manually control when the contents of that ref are loaded."

---

- [ ] **2322. Add missing parentheses in method call**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx?plain=1

Change "slice.loadUint 64" to "slice.loadUint(64)" for consistency with method call syntax.

---

- [ ] **2323. Fix “Note, that” comma misuse**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx?plain=1

Change "Note, that ..." to "Note that ...".

---

- [ ] **2324. Fix grammar: ensure slice ends after reading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx?plain=1

Change "functions `fromCell` and `fromSlice` ensure the slice end after reading" to "functions `fromCell` and `fromSlice` ensure the slice ends after reading."

---

- [ ] **2325. Improve “typed cells” and “snake cells” wording; capitalize NFT**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx?plain=1

Change "With types cells, you can express snake data" to "With typed cells, you can express snake cells" and "an untyped nft content" to "untyped NFT content."

---

- [ ] **2326. Standardize exit code terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx?plain=1

Replace "excno 9" and "excode 9" with "exit code 9 (Cell underflow)" consistently throughout the page.

---

- [ ] **2327. Fix wording: “as showed” → “as shown”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx?plain=1

Change "as showed" to "as shown."

---

- [ ] **2328. Label deserialization functions correctly**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx?plain=1

Replace "Serialization functions have the second optional parameter" with "Deserialization functions have a second optional parameter."

---

- [ ] **2329. Add missing bit-length to storeUint examples**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx?plain=1

Add the length argument where missing, e.g., change ".storeUint(32)" to ".storeUint(32, 32)" and ".storeUint(0b01) // addr_extern" to ".storeUint(0b01, 2) // addr_extern".

---

- [ ] **2330. Use consistent type name in union load example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx?plain=1

Change `cs.loadAny<Increment>()` to `cs.loadAny<CounterIncrement>()` to match the earlier example.

---

- [ ] **2331. Remove extraneous comma after “multiple times”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx?plain=1

Change "We've mentioned multiple times, that ..." to "We've mentioned multiple times that ...".

---

- [ ] **2332. Use “cannot” instead of “can not”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx?plain=1

Replace "can not" with "cannot" in the comment.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.