### PR TITLE
Split: update docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx
@@ -3,10 +3,10 @@ import Feedback from '@site/src/components/Feedback';
 # Tolk vs FunC: standard library
 
 FunC has a rich [standard library](/v3/documentation/smart-contracts/func/docs/stdlib),
-known as *"stdlib.fc"* file. It's quite low-level and contains many `asm` functions
+known as the "stdlib.fc" file. It's quite low-level and contains many `asm` functions
 closely related to [TVM instructions](/v3/documentation/tvm/instructions/).
 
-Tolk also has a standard library based on a FunC one. Three main differences:
+Tolk also has a standard library based on the FunC one. Three main differences:
 1. It's split into multiple files: `common.tolk`, `tvm-dicts.tolk`, and others. Functions from `common.tolk` are always available. Functions from other files are available after import:
 ```tolk
 import "@stdlib/tvm-dicts"
@@ -14,14 +14,14 @@ import "@stdlib/tvm-dicts"
 beginCell()          // available always
 createEmptyDict()    // available due to import
 ```
-2. You don't need to download it from GitHub; it's a part of Tolk distribution. 
-3. Tolk has functions and methods (called via dot), lots of global FunC functions became methods of builder/slice/etc. (and can't be called as functions)
+2. You don't need to download it from GitHub; it's part of the Tolk distribution. 
+3. Tolk has functions and methods (called via the dot operator). Many global FunC functions became methods of builders/slices/etc. and can no longer be called as functions.
 
 
 ## Functions vs methods
 
-In FunC, there are no methods, actually. All functions are global-scoped.  
-You just call any function via dot:
+In FunC, there are no methods, actually. All functions are globally scoped.  
+You can call any function using the dot operator:
 ```func
 ;; FunC
 cell config_param(int x) asm "CONFIGOPTPARAM";
@@ -31,7 +31,7 @@ config_param(16);   ;; ok
 ```
 
 So, when you call `b.end_cell()`, you actually call a global function `end_cell`. 
-Since all functions are global-scoped, there are no "short methods."
+Since all functions are globally scoped, there are no "short methods."
 ```func
 someTuple.tuple_size();
 ;; why not someTuple.size()? because it's a global function:
@@ -39,8 +39,8 @@ someTuple.tuple_size();
 ```
 
 **Tolk separates functions and methods** like it's done in most languages:
-1) functions can NOT be called via dot, only methods can
-2) methods can have short names, they don't conflict
+1) functions can NOT be called via dot, only methods can.
+2) methods can have short names, they don't conflict.
 
 ```tolk
 // FunC
@@ -61,6 +61,8 @@ Note that some functions were deleted because they either can be expressed synta
 or they were very uncommon in practice.
 
 The table is "sorted" in a way how functions are declared in stdlib.fc:
+
+Note: FunC uses snake_case names (for example, `begin_cell`), while Tolk methods use camelCase (for example, `beginCell`).
 
 | FunC name                         | Tolk name                          | Required import |
 |-----------------------------------|------------------------------------|-----------------|
@@ -249,6 +251,11 @@ The table is "sorted" in a way how functions are declared in stdlib.fc:
 | pfxdict_delete?                   | prefixDictDelete                   | tvm-dicts       |
 
 
+See also for `accept_message` → `acceptExternalMessage`:
+- Effects and nuances: /v3/documentation/smart-contracts/transaction-fees/accept-message-effects.
+- FunC stdlib reference: /v3/documentation/smart-contracts/func/docs/stdlib#accept_message.
+
+
 ## A list of added functions
 
 Tolk standard library has some functions missing in FunC but is pretty typical for everyday tasks.
@@ -315,4 +322,3 @@ If you use blueprint, it automatically installs tolk-js; therefore, folder `node
 Inside are `common.tolk`, `tvm-dicts.tolk`, and others. 
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-tolk-tolk-vs-func-stdlib.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx`

Related issues (from issues.normalized.md):
- [ ] **2333. Fix article usage for “stdlib.fc”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#L5-L7

Change “known as "stdlib.fc" file” to “known as the "stdlib.fc" file” (and avoid italics for quoted filenames).

---

- [ ] **2334. Verify TVM instructions link target**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#L7

Confirm that the link to “/v3/documentation/tvm/instructions/” resolves on the deployed site; if not, add the missing page or a redirect to the correct TVM instructions page (do not replace with the TVM overview).

---

- [ ] **2335. Use “the” in “based on the FunC one”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#L9

Change “based on a FunC one” to “based on the FunC one” (or “based on FunC’s standard library”).

---

- [ ] **2336. Fix distribution phrasing (“part of the Tolk distribution”)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#L17

Change “it's a part of Tolk distribution” to “it's part of the Tolk distribution.”

---

- [ ] **2337. Fix run-on and pluralization in point 3**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#L18

Split the sentence and pluralize: “Tolk has functions and methods (called via the dot operator). Many global FunC functions became methods of builders/slices/etc. and can no longer be called as functions.”

---

- [ ] **2338. Replace “global-scoped” with “globally scoped”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#L23,L33

Use “globally scoped” instead of “global-scoped.”

---

- [ ] **2339. Clarify FunC dot/tilde method syntax**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#L24

Reword to avoid implying member methods; e.g., “In FunC, functions are global and can be called using dot (.) or tilde (~) method syntax; these are call-syntax sugar, not members,” and prefer “using the dot operator” over “via dot.”

---

- [ ] **2340. Clarify “short methods” wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#L34-L39

Replace “there are no ‘short methods.’” with a clearer statement, e.g., “there are no short method names.”

---

- [ ] **2341. Fix comma splice in methods sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#L41-L43

Use a semicolon or split: “Methods can have short names; they don't conflict.”

---

- [ ] **2342. Split mixed-language code block and fix fences**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#L45-L53

Separate the mixed FunC and Tolk examples into two fenced blocks (first fenced as “func”, second as “tolk”) or use a neutral fence to avoid incorrect highlighting.

---

- [ ] **2343. Fix table ordering sentence grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#L63

Change “The table is ‘sorted’ in a way how functions are declared in stdlib.fc:” to “The table is ordered similarly to how functions are declared in stdlib.fc:”.

---

- [ ] **2344. Correct compute_data_size? rows to show function and dot forms**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#L100-L103

Replace “c.compute_data_size?() or dot” with “compute_data_size?(c) or dot c.compute_data_size?()” and “slice_compute_data_size?() or dot” with “slice_compute_data_size?(s) or dot s.compute_data_size?()”.

---

- [ ] **2345. Add parentheses to dictIsEmpty method**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#L191

Change “d.dictIsEmpty” to “d.dictIsEmpty()” for consistency with method style.

---

- [ ] **2346. Reword sentence about added functions**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#L254

Change “Tolk standard library has some functions missing in FunC but is pretty typical for everyday tasks.” to “Tolk’s standard library includes some functions missing in FunC that are typical for everyday tasks.”

---

- [ ] **2347. Rephrase evolving stdlib note and constants sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#L256-L258

Replace “Since Tolk is actively developed, and its standard library changes, it better considers the `tolk-stdlib/` folder in sources ... Besides functions, there some constants were added:” with “Since Tolk is actively developed and its standard library evolves, refer to the `tolk-stdlib/` folder in the sources … Some constants have also been added:”.

---

- [ ] **2348. Use “wrappers around” instead of “over”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#L262-L263

Change “wrappers over the TVM assembler” to “wrappers around the TVM assembler.”

---

- [ ] **2349. Correct “tilda” to “tilde”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#L291

Replace “`~` tilda” with “`~` tilde.”

---

- [ ] **2350. Change “As told above” to “As mentioned above”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#L301

Use “As mentioned above” for natural phrasing.

---

- [ ] **2351. Change “It works the following way.” to “It works as follows.”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#L304

Use the standard phrasing “It works as follows.”

---

- [ ] **2352. Fix missing subject in “locate stdlib” sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#L306-L308

Reword to “For example, if you launch the Tolk compiler from a package installation (e.g., `/usr/bin/tolk`), it locates the stdlib folder in `/usr/share/ton/smartcont`.”

---

- [ ] **2353. Use “environment variable” instead of “env variable”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#L308

Change “env variable” to “environment variable.”

---

- [ ] **2354. Capitalize Blueprint and improve phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#L311

Change “when you take tolk-js or blueprint” to “when you use tolk-js or Blueprint.”

---

- [ ] **2355. Add missing article before “folder”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#L314-L315

Change “therefore, folder `node_modules/@ton/tolk-js/` exists ...” to “therefore, the folder `node_modules/@ton/tolk-js/` exists ...”.

---

- [ ] **2356. Replace JSX inline code with fenced blocks in table**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#some-functions-became-mutating-not-returning-a-copy

Use fenced code blocks with language tags (e.g., ```func) instead of JSX strings like {'int flags = cs~load_uint(32);'} for consistent rendering and highlighting.

---

- [ ] **2357. Clarify exact import path for “tvm-lowlevel”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1

Where the “Required import” column lists “tvm-lowlevel,” specify the actual import path (e.g., `import "@stdlib/tvm-lowlevel"`) or adjust the label to match existing module names used elsewhere.

---

- [ ] **2358. Clarify module attribution for address parsing rows**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#a-list-of-renamed-functions

For rows like `load_msg_addr` → `loadAddress` and `parse_std_addr` → `parseStandardAddress`, note whether they come from the common stdlib (implicitly imported) or specify the module if needed.

---

- [ ] **2359. Add note on bitsHash byte-alignment behavior**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#a-list-of-renamed-functions

Clarify whether `s.bitsHash()` has the same byte-alignment constraint as FunC’s `string_hash(slice s)` (throws if bit length is not a multiple of 8); document accordingly.

---

- [ ] **2360. Mention casing conventions (snake_case vs camelCase)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#a-list-of-renamed-functions

Add a brief note that FunC uses snake_case (e.g., `begin_cell`) while Tolk methods use camelCase (e.g., `beginCell`), and optionally link to the overview section that explains this convention.

---

- [ ] **2361. Add cross-reference for acceptExternalMessage effects**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1#a-list-of-renamed-functions

For `accept_message` → `acceptExternalMessage`, add a “See also” link to the effects page and the FunC stdlib reference for context.

---

- [ ] **2362. Ensure punctuation consistency in lists and rules**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx?plain=1

End numbered list items and rule lists with periods and maintain consistent comma/semicolon usage for readability throughout the page.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.