### PR TITLE
Split: update docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx
+++ b/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx
@@ -3,30 +3,27 @@ import Feedback from '@site/src/components/Feedback';
 # Low-level fees overview
 
 :::caution
-This section describes instructions and manuals for interacting with TON at a low level.
-Here you will find the **raw formulas** for calculating commissions and fees on TON.
-However, most of them are **already implemented through opcodes**!
-So, you **use them instead of manual calculations**.
+This section provides low-level instructions for interacting with TON; it includes raw formulas for calculating commissions and fees; however, most of these are already implemented as opcodes, so you should use those instead of manual calculations.
 :::
 
 This document provides a general idea of transaction fees on TON and particularly computation fees for the FunC code. There is also a [detailed specification in the TVM whitepaper](https://ton.org/tvm.pdf).
 
 ## Transactions and phases
 
-As was described in the [TVM overview](/v3/documentation/tvm/tvm-overview), transaction execution consists of a few phases. During those phases, the corresponding fees may be deducted. There is a [high-level fees overview](/v3/documentation/smart-contracts/transaction-fees/fees).
+As described in the [TVM overview](/v3/documentation/tvm/tvm-overview), transaction execution consists of a few phases. During those phases, the corresponding fees may be deducted. There is a [high-level fees overview](/v3/documentation/smart-contracts/transaction-fees/fees).
 
 ## Storage fee
 
 TON validators collect storage fees from smart contracts.
 
-Storage fees are collected from the smart contract `balance` at the **Storage phase** of **any** transaction due to storage payments for the account state (including smart-contract code and data, if present) up to the present time. Even if a contract receives 1 nanoton, it will pay all the debt since the last payment. The smart contract may be frozen as a result. **Only unique hash cells are counted for storage and forward fees i.e. 3 identical hash cells are counted as one**. In particular, it [deduplicates](/v3/documentation/data-formats/tlb/library-cells) data: if there are several equivalent sub-cells referenced in different branches, their content is only stored once.
+Storage fees are collected from the smart contract `balance` at the **Storage phase** of **any** transaction due to storage payments for the account state (including smart-contract code and data, if present) up to the present time. Even if a contract receives 1 nanoton, it will pay all the debt since the last payment. The smart contract may be frozen as a result. Only unique cells (by hash) are counted for storage and forward fees, i.e., three identical hash cells are counted as one. In particular, it [deduplicates](/v3/documentation/data-formats/tlb/library-cells) data: if there are several equivalent sub-cells referenced in different branches, their content is only stored once.
 
-It's important to keep in mind that on TON you pay for both the execution of a smart contract and for the **used storage** (check [@thedailyton article](https://telegra.ph/Commissions-on-TON-07-22)), `storage_fee` depends on your contract size: number of cells and sum of bits from that cells. It means you have to pay a storage fee for having TON Wallet (even if it's very-very small).
+On TON, you pay for both smart-contract execution and used storage (see the [@thedailyton article](https://telegra.ph/Commissions-on-TON-07-22)); the `storage_fee` depends on your contract size—the number of cells and the total number of bits across those cells—so you even pay a storage fee for having a TON wallet (even if it’s very small).
 
-If you have not used your TON Wallet for a significant period of time (1 year), _you will have to pay a significantly larger commission than usual because the wallet pays commission on sending and receiving transactions_.
+If you have not used your TON wallet for a long time, _you will pay a larger fee than usual because the wallet pays fees on both sending and receiving transactions_.
 
 :::info **Note**:
-When a message is bounced from the contract, the contract will pay its current `storage_fee`
+When a message is bounced from the contract, the contract will pay its current `storage_fee`.
 :::
 
 ### Formula
@@ -37,7 +34,7 @@ You can approximately calculate storage fees for smart contracts using this form
 storage_fee = ceil(
                   (account.bits * bit_price
                   + account.cells * cell_price)
-               * time_delta / 2 ^ 16)
+               * time_delta / 2^16)
 
 ```
 
@@ -68,7 +65,7 @@ Current values are:
 
 You can use this JS script to calculate storage price for 1 MB in the workchain for 1 year
 
-```js live
+```jsx live
 // Welcome to LIVE editor!
 // feel free to change any variables
 // Source code uses RoundUp for the fee amount, so does the calculator
@@ -81,7 +78,7 @@ function storageFeeCalculator() {
   const cell_price_ps = 500;
 
   const pricePerSec =
-    size * bit_price_ps + +Math.ceil(size / 1023) * cell_price_ps;
+    size * bit_price_ps + Math.ceil(size / 1023) * cell_price_ps;
 
   let fee = Math.ceil((pricePerSec * duration) / 2 ** 16) * 10 ** -9;
   let mb = (size / 1024 / 1024 / 8).toFixed(2);
@@ -91,15 +88,17 @@ function storageFeeCalculator() {
 
   return str;
 }
+
+<div>{storageFeeCalculator()}</div>
 ```
 
 ## Computation fees
 
 ### Gas
 
-All computation costs are nominated in gas units. The price of gas units is determined by this [chain config](/v3/documentation/network/configs/blockchain-configs#param-20-and-21) (Config 20 for masterchain and Config 21 for basechain) and may be changed only by consensus of validators. Note that unlike in other systems, the user cannot set his own gas price, and there is no fee market.
+All computation costs are denominated in gas units. The price of gas units is determined by this [chain config](/v3/documentation/network/configs/blockchain-configs#param-20-and-21) (Config 20 for MasterChain and Config 21 for BaseChain) and may be changed only by consensus of validators. Note that unlike in other systems, the user cannot set his own gas price, and there is no fee market.
 
-Current settings in basechain are as follows: 1 unit of gas costs 400 nanotons.
+Current settings in BaseChain are as follows: 1 unit of gas costs 400 nanotons.
 
 ### TVM instructions cost
 
@@ -113,17 +112,17 @@ Apart from those basic fees, the following fees appear:
 | Instruction             | GAS price | Description                                                                                                                                                                                   |
 | ----------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Creation of cell        | **500**   | Operation of transforming builder to cell.                                                                                                                                                    |
-| Parsing cell firstly    | **100**   | Operation of transforming cells into slices first time during current transaction.                                                                                                            |
-| Parsing cell repeatedly | **25**    | Operation of transforming cells into slices, which already has parsed during same transaction.                                                                                                |
+| Parsing a cell for the first time    | **100**   | Operation of transforming cells into slices for the first time during the same transaction.                                                                                                  |
+| Parsing a cell repeatedly | **25**    | Operation of transforming cells into slices, already parsed during the same transaction.                                                                                                      |
 | Throwing exception      | **50**    |                                                                                                                                                                                               |
 | Operation with tuple    | **1**     | This price will multiply by the quantity of tuple's elements.                                                                                                                                 |
 | Implicit Jump           | **10**    | It is paid when all instructions in the current continuation cell are executed. However, there are references in that continuation cell, and the execution flow jumps to the first reference. |
 | Implicit Back Jump      | **5**     | It is paid when all instructions in the current continuation are executed and execution flow jumps back to the continuation from which the just finished continuation was called.             |
-| Moving stack elements   | **1**     | Price for moving stack elements between continuations. It will charge correspond gas price for every element. However, the first 32 elements moving is free.                                  |
+| Moving stack elements   | **1**     | Charges the corresponding gas price per element; the first 32 elements moved are free.                                                                                                        |
 
-### FunC constructions gas fees
+### FunC constructs gas fees
 
-Almost all FunC functions used in this article are defined in [stablecoin stdlib.fc contract](https://github.com/ton-blockchain/stablecoin-contract) (actually, stdlib.fc with new opcodes is currently **under development** and **not yet presented on the mainnet repos**, but you can use `stdlib.fc` from [stablecoin](https://github.com/ton-blockchain/ton) source code as reference) which maps FunC functions to Fift assembler instructions. In turn, Fift assembler instructions are mapped to bit-sequence instructions in [asm.fif](https://github.com/ton-blockchain/ton/blob/master/crypto/fift/lib/Asm.fif). So if you want to understand how much exactly the instruction call will cost you, you need to find `asm` representation in `stdlib.fc`, then find bit-sequence in `asm.fif` and calculate instruction length in bits.
+Almost all FunC functions used in this article are defined in [stablecoin stdlib.fc contract](https://github.com/ton-blockchain/stablecoin-contract) (actually, stdlib.fc with new opcodes is currently **under development** and **not yet presented on the main repositories**, but you can use `stdlib.fc` from the TON source code as a reference) which maps FunC functions to Fift assembler instructions. In turn, Fift assembler instructions are mapped to bit-sequence instructions in [asm.fif](https://github.com/ton-blockchain/ton/blob/master/crypto/fift/lib/Asm.fif). So if you want to understand how much exactly the instruction call will cost you, you need to find `asm` representation in `stdlib.fc`, then find bit-sequence in `asm.fif` and calculate instruction length in bits.
 
 However, generally, fees related to bit-lengths are minor in comparison with fees related to cell parsing and creation, as well as jumps and just number of executed instructions.
 
@@ -151,7 +150,7 @@ slice payload_encoding(int a, int b, int c) {
     .store_slice(destination)
     .store_coins(0)
     .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1) ;; default message headers (see sending messages page)
-    .store_uint(0x33bbff77, 32) ;; op-code (see smart-contract guidelines)
+    .store_uint(0x33bbff77, 32) ;; opcode (see smart-contract guidelines)
     .store_uint(cur_lt(), 64)  ;; query_id (see smart-contract guidelines)
     .store_slice(payload)
   .end_cell();
@@ -159,7 +158,7 @@ slice payload_encoding(int a, int b, int c) {
 }
 ```
 
-What is the problem with this code? `payload_encoding` to generate a slice bit-string, first create a cell via `end_cell()` (+500 gas units). Then parse it `begin_parse()` (+100 gas units). The same code can be written without those unnecessary operations by changing some commonly used types:
+What is the problem with this code? To generate a slice bit-string, `payload_encoding` first creates a cell via `end_cell()` (+500 gas units), then parses it with `begin_parse()` (+100 gas units); the same logic can be implemented without these operations by changing some commonly used types:
 
 ```cpp
 ;; we add asm for function which stores one builder to the another, which is absent from stdlib
@@ -179,7 +178,7 @@ builder payload_encoding(int a, int b, int c) {
     .store_slice(destination)
     .store_coins(0)
     .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1) ;; default message headers (see sending messages page)
-    .store_uint(0x33bbff77, 32) ;; op-code (see smart-contract guidelines)
+    .store_uint(0x33bbff77, 32) ;; opcode (see smart-contract guidelines)
     .store_uint(cur_lt(), 64)  ;; query_id (see smart-contract guidelines)
     .store_builder(payload)
   .end_cell();
@@ -187,19 +186,19 @@ builder payload_encoding(int a, int b, int c) {
 }
 ```
 
-By passing bit-string in the another form (builder instead of slice) we substantially decrease computation cost by very slight change in code.
+By passing the bit-string in another form (a builder instead of a slice), we substantially decrease computation cost with a very small code change.
 
 ### Inline and inline_refs
 
-By default, when you have a FunC function, it gets its own `id`, stored in a separate leaf of id->function dictionary, and when you call it somewhere in the program, a search of the function in dictionary and subsequent jump occur. Such behavior is justified if your function is called from many places in the code and thus jumps allow to decrease the code size (by storing a function body once). However, if the function is only used once or twice, it is often much cheaper to declare this function as `inline` or `inline_ref`. `inline` modificator places the body of the function right into the code of the parent function, while `inline_ref` places the function code into the reference (jumping to the reference is still much cheaper than searching and jumping to the dictionary entry).
+By default, when you have a FunC function, it gets its own `id`, stored in a separate leaf of id->function dictionary, and when you call it somewhere in the program, a search of the function in dictionary and subsequent jump occur. Such behavior is justified if your function is called from many places in the code and thus jumps allow to decrease the code size (by storing a function body once). However, if the function is only used once or twice, it is often much cheaper to declare this function as `inline` or `inline_ref`. `inline` modifier places the body of the function into the caller, while `inline_ref` places it into a reference (which is still cheaper than a dictionary lookup).
 
 ### Dictionaries
 
 Dictionaries on TON are introduced as trees (DAGs to be precise) of cells. That means that if you search, read, or write to the dictionary, you need to parse all cells of the corresponding branch of the tree. That means that
 
-- a) dicts operations are not fixed in gas costs (since the size and number of nodes in the branch depend on the given dictionary and key)
+- a) dictionary operations are not fixed in gas costs (since the size and number of nodes in the branch depend on the given dictionary and key)
 - b) it is expedient to optimize dict usage by using special instructions like `replace` instead of `delete` and `add`
-- c) developer should be aware of iteration operations (like next and prev) as well `min_key`/`max_key` operations to avoid unnecessary iteration through the whole dict
+- c) developer should be aware of iteration operations (like `next` and `prev`), as well as `min_key`/`max_key` operations to avoid unnecessary iteration through the whole dict
 
 ### Stack operations
 
@@ -210,18 +209,18 @@ Note that FunC manipulates stack entries under the hood. That means that the cod
 return (c, b, a);
 ```
 
-will be translated into a few instructions which changes the order of elements on the stack.
+will be translated into a few instructions which change the order of elements on the stack.
 
-When the number of stack entries is substantial (10+), and they are actively used in different orders, stack operations fees may become non-negligible.
+When the number of stack entries is substantial (10+), and they are actively used in different orders, stack operation fees may become non-negligible.
 
 ## Forward fees
 
-Internal messages define an `ihr_fee` in Toncoins, which is subtracted from the value attached to the message and awarded to the validators of the destination shardchain if they include the message through the IHR mechanism. The `fwd_fee` is the original total forwarding fee paid for using the HR mechanism; it is automatically computed from the [24 and 25 configuration parameters](/v3/documentation/network/configs/blockchain-configs#param-24-and-25) and the size of the message at the time the message is generated. Note that the total value carried by a newly created internal outbound message equals the sum of the value, `ihr_fee`, and `fwd_fee`. This sum is deducted from the balance of the source account. Of these components, only the `ihr_fee` value is credited to the destination account upon message delivery. The `fwd_fee` is collected by the validators on the HR path from the source to the destination, and the `ihr_fee` is either collected by the validators of the destination shardchain (if the message is delivered via IHR) or credited to the destination account.
+Internal messages define an `ihr_fee` in nanotons, which is subtracted from the value attached to the message and awarded to the validators of the destination ShardChain if they include the message through the IHR mechanism. The `fwd_fee` is the original total forwarding fee paid for using the HR mechanism; it is automatically computed from the [24 and 25 configuration parameters](/v3/documentation/network/configs/blockchain-configs#param-24-and-25) and the size of the message at the time the message is generated. Note that the total value carried by a newly created internal outbound message equals the sum of the value, `ihr_fee`, and `fwd_fee`. This sum is deducted from the balance of the source account. Of these components, only the `ihr_fee` value is credited to the destination account upon message delivery. The `fwd_fee` is collected by the validators on the HR path from the source to the destination, and the `ihr_fee` is either collected by the validators of the destination ShardChain (if the message is delivered via IHR) or credited to the destination account.
 
 ### IHR
 
 :::info What is IHR?
-[**Instant Hypercube Routing (IHR)**](/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm#messages-and-instant-hypercube-routing-instant-hypercube-routing) is an alternative mechanism for message delivery without intermediate hops between shards. To understand why IHR is not currently relevant:
+[**Instant Hypercube Routing (IHR)**](/v3/documentation/smart-contracts/shards/infinity-sharding-paradigm#messages-and-instant-hypercube-routing-ihr) is an alternative mechanism for message delivery without intermediate hops between shards. To understand why IHR is not currently relevant:
 
 - **IHR is not implemented** and is not yet fully specified
 - **IHR would only be relevant** when the network has more than 16 shards and not all shards are neighbors to each other
@@ -253,7 +252,7 @@ total_fwd_fees = msg_fwd_fees + ihr_fwd_fees; // ihr_fwd_fees - is 0 for externa
 :::info IMPORTANT
 Please note that `msg_fwd_fees` above includes `action_fee` below. For a basic message this fee = lump_price = 400000 nanotons, action_fee = (400000 \* 21845) / 65536 = 133331. Or approximately a third of the `msg_fwd_fees`.
 
-`fwd_fee` = `msg_fwd_fees` - `action_fee` = 266669 nanotons = 0,000266669 TON
+`fwd_fee` = `msg_fwd_fees` - `action_fee` = 266669 nanotons = 0.000266669 TON
 :::
 
 ## Action fee
@@ -287,9 +286,9 @@ max_cells = floor(remaining_balance / fine_per_cell)
 action_fine = fine_per_cell * min(max_cells, cells_in_msg);
 ```
 
-## Fee's config file
+## Fees config file
 
-All fees are nominated in nanotons or nanotons multiplied by 2^16 to [maintain accuracy while using integer](/v3/documentation/smart-contracts/transaction-fees/fees-low-level#forward-fees) and may be changed. The config file represents the current fee cost.
+All fees are denominated in nanotons, or in nanotons multiplied by 2^16 to [maintain accuracy while using integers](/v3/documentation/smart-contracts/transaction-fees/fees-low-level#forward-fees) and may be changed. The config file represents the current fee cost.
 
 - storage_fees = [p18](https://tonviewer.com/config#18)
 - in_fwd_fees = [p24](https://tonviewer.com/config#24), [p25](https://tonviewer.com/config#25)
@@ -314,4 +313,3 @@ For educational purposes [example of the old one](https://explorer.toncoin.org/c
 - [Fees calculation](/v3/guidelines/smart-contracts/fee-calculation)
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-transaction-fees-fees-low-level.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx`

Related issues (from issues.normalized.md):
- [ ] **2376. Improve caution block phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1#L5-L10

Rewrite the caution to: “This section provides low-level instructions for interacting with TON; it includes raw formulas for calculating commissions and fees; however, most of these are already implemented as opcodes, so you should use those instead of manual calculations.”

---

- [ ] **2377. Replace “As was described” with direct phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1#L16

Change “As was described …” to “As described in the TVM overview, …”.

---

- [ ] **2378. Fix punctuation and numerals in deduplication sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1#L22

Replace “Only unique hash cells are counted for storage and forward fees i.e. 3 identical hash cells are counted as one” with “Only unique cells (by hash) are counted for storage and forward fees, i.e., three identical hash cells are counted as one.”

---

- [ ] **2379. Rewrite storage paragraph for clarity and grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1#L24

Rewrite the paragraph as: “On TON, you pay for both smart-contract execution and used storage (see the @thedailyton article); the storage_fee depends on your contract size—the number of cells and the total number of bits across those cells—so you even pay a storage fee for having a TON wallet (even if it’s very small).”

---

- [ ] **2380. Rephrase wallet inactivity sentence and remove unsupported duration**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1#L26

Rephrase to avoid the specific “1 year” claim and use consistent casing/plurals, e.g., “If you have not used your TON wallet for a long time, you will pay a larger fee than usual because the wallet pays fees on both sending and receiving transactions.”

---

- [ ] **2381. Add missing period in bounce note**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1#L29

Add a period at the end: “When a message is bounced from the contract, the contract will pay its current storage_fee.”

---

- [ ] **2382. Use correct exponent notation in formula**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1#L36-L41

Replace “2 ^ 16” with “2^16” (no spaces) to avoid implying XOR; if code-like, prefer “(1 << 16)”.

---

- [ ] **2383. Fix live calculator block tag and stray unary plus**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1#L71-L94

Change the fence to “jsx live” and render a visible element, and remove the redundant unary plus: size * bit_price_ps + Math.ceil(size / 1023) * cell_price_ps.

---

- [ ] **2384. Capitalize chain names consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1#L100-L102

Replace “masterchain/basechain” with “MasterChain/BaseChain”.

---

- [ ] **2385. Improve wording in TVM instruction cost table**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1#L113-L122

Update labels to: “Parsing a cell for the first time,” “Parsing a cell repeatedly (already parsed during the same transaction),” “Operations on tuples — price multiplied by the number of tuple elements,” and clarify that moving stack elements “charges the corresponding gas price per element; the first 32 elements moved are free.”

---

- [ ] **2386. Fix stdlib reference text and repo wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1#L124-L127

Change the sentence to “… you can use stdlib.fc from the TON source code as a reference …” and replace “mainnet repos” with “main repositories.”

---

- [ ] **2387. Clarify example paragraph and use “opcode”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1#L162-L163

Rewrite to: “To generate a slice bit-string, payload_encoding first creates a cell via end_cell (+500 gas units), then parses it with begin_parse (+100 gas units); the same logic can be implemented without these operations by changing some commonly used types,” and replace “op-code” with “opcode.”

---

- [ ] **2388. Clarify sentence after optimized example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1#L190

Replace with: “By passing the bit-string in another form (a builder instead of a slice), we substantially decrease computation cost with a very small code change.”

---

- [ ] **2389. Use “modifier” and clarify inline vs inline_ref**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1#L192-L195

Replace “modificator” with “modifier” and clarify that inline places the function body into the caller while inline_ref places it into a reference (which is still cheaper than a dictionary lookup).

---

- [ ] **2390. Fix grammar in dictionaries bullets**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1#L198-L202

Use “dictionary operations,” say “as well as min_key/max_key,” and wrap operation names like next/prev/min_key/max_key in backticks.

---

- [ ] **2391. Fix subject–verb agreement in stack operations**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1#L213

Change “a few instructions which changes” to “a few instructions which change,” and prefer “stack operation fees” (also adjust at L215).

---

- [ ] **2392. Use nanotons for fee fields**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1#L219

Replace “Toncoins” with “nanotons” (or “Toncoin, measured in nanotons”) for ihr_fee and related fields.

---

- [ ] **2393. Fix IHR cross-reference anchor**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1#L223-L233

Update the link to /v3/documentation/smart-contracts/shards/infinity-sharding-paradigm#messages-and-instant-hypercube-routing-ihr.

---

- [ ] **2394. Use dot as decimal separator**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1#L256

Replace “0,000266669 TON” with “0.000266669 TON.”

---

- [ ] **2395. Correct section title to “Fees config file”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1#L290

Change “Fee’s config file” to “Fees config file.”

---

- [ ] **2396. Use “denominated” and clarify integer arithmetic**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1#L292

Replace “nominated” with “denominated” and rephrase as “All fees are denominated in nanotons, or in nanotons multiplied by 2^16 to maintain accuracy while using integers.”

---

- [ ] **2397. Use “denominated” for gas units**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1

Change “nominated in gas units” to “denominated in gas units,” matching fees.mdx wording.

---

- [ ] **2398. Capitalize “ShardChain”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1

Capitalize “ShardChain” wherever used (e.g., “destination ShardChain”).

---

- [ ] **2399. Use canonical “Compute phase” naming**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1

Replace “Computing phase” with “Compute phase” to match canonical phase names.

---

- [ ] **2400. Standardize heading: “FunC constructs gas fees”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx?plain=1

Change the heading “FunC constructions gas fees” to “FunC constructs gas fees.”

---

- [ ] **2416. Soften storage‑cost precision**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx?plain=1#cost-of-saving-data-in-ton

Change “will cost 6.01 TON” to “will cost approximately 6.01 TON” and link to the method in docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx#calculator-example.

---

- [ ] **2748. Remove unsupported numeric storage fee claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/payments-processing.mdx?plain=1#send-payments

Replace “Storage fees are typically less than 1 Toncoin per year” with a non-numeric statement linking to fees docs (e.g., “Keep the wallet funded to cover storage fees”: docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx#storage-fee).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.