### PR TITLE
Split: update docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx
+++ b/docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx
@@ -2,21 +2,21 @@ import Feedback from '@site/src/components/Feedback';
 
 # Transaction fees
 
-Every TON user should keep in mind that _fees depend on many factors_.
+Every Toncoin (TON) user should keep in mind that _fees depend on many factors_.
 
 ## Gas
 
-All [computation costs](/v3/documentation/smart-contracts/transaction-fees/fees-low-level#computation-fees) are denominated in gas units and fixed in a certain gas amount.
+All [computation](/v3/documentation/smart-contracts/transaction-fees/fees-low-level#computation-fees) is measured in gas units; each operation has a fixed gas cost.
 
-The price of gas units is determined by the [chain configuration](https://tonviewer.com/config#20) and may be changed only by consensus of validators. Note that unlike in other systems, the user cannot set their own gas price, and there is no fee market.
+The price of gas units is determined by the [chain configuration](https://tonviewer.com/config#20) and may be changed only by consensus of validators. Note that, unlike in some other systems, the user cannot set their own gas price, and there is no fee market. Users can cap spend via the attached value and `bounce`.
 
-Current settings in basechain are as follows: 1 unit of gas costs 400 nanotons.
+Current settings in the Basechain are as follows: 1 unit of gas costs 400 nanotons.
 
 ```
 1 gas = 26214400 / 2^16 nanotons = 0.0000004 TON
 ```
 
-Current settings in masterchain are as follows: 1 unit of gas costs 10000 nanotons.
+Current settings in the Masterchain are as follows: 1 unit of gas costs 10000 nanotons.
 
 ```
 1 gas = 655360000 / 2^16 nanotons = 0.00001 TON
@@ -24,19 +24,17 @@ Current settings in masterchain are as follows: 1 unit of gas costs 10000 nanoto
 
 ### Average transaction cost
 
-> **TL;DR:** Today, a basic transaction costs about 0.0025 TON.
-
-Even if Toncoin price increases 100 times, transactions will remain ultra-cheap — about $0.01. Moreover, validators may lower this value if they see commissions have become expensive [read why they're interested](#gas-price-voting-process).
+> **TL;DR:** A basic transaction typically costs a small fraction of a TON; see the [fee calculator](/v3/guidelines/smart-contracts/fee-calculation) for current estimates.
 
 :::info
-The current gas price is defined in the Network Config [param 20](https://tonviewer.com/config#20) and [param 21](https://tonviewer.com/config#21) for the masterchain and basechain, respectively.
+Gas price is defined in Network Config: [param 20](/v3/documentation/network/configs/blockchain-configs#param-20) (Masterchain), [param 21](/v3/documentation/network/configs/blockchain-configs#param-21) (Basechain).
 :::
 
 ### Gas price voting process
 
 The gas fee, like many other parameters of TON, is configurable and may be changed by a special vote made in the mainnet.
 
-Changing any parameter requires approval from 66% of the validators' votes.
+Changing configuration parameters requires approval via configuration proposals, generally more than 3/4 (75%) of validators by weight, confirmed across rounds. See [Changing the parameters](/v3/documentation/network/configs/config-params#changing-the-parameters) and [Governance: config](/v3/documentation/smart-contracts/contracts-specs/governance#config).
 
 #### Could gas cost more?
 
@@ -50,7 +48,7 @@ Validators receive a small fee for processing transactions, and charging higher 
 
 Fees on TON are difficult to calculate in advance, as their amount depends on transaction run time, account status, message content and size, blockchain network settings, and a number of other variables that cannot be calculated until the transaction is sent.
 
-That is why NFT marketplaces typically require an extra amount of TON (~1 TON) and refund the remaining amount (1 - transaction_fee) after the transaction.
+Some NFT marketplaces over‑provision funds and refund the remainder; amounts vary by marketplace.
 
 :::info
 Each contract should check incoming messages for the amount of TON attached to ensure it is enough to cover the fees.
@@ -58,7 +56,7 @@ Each contract should check incoming messages for the amount of TON attached to e
 Check the [low-level fees overview](/v3/documentation/smart-contracts/transaction-fees/fees-low-level) to learn more about the formulas for calculating commissions and [fees calculation](/v3/guidelines/smart-contracts/fee-calculation) to learn how to calculate fees in FunC contracts using the new TVM opcodes.
 :::
 
-However, let's read more about how fees are supposed to function on TON.
+The following sections describe how fees work on TON.
 
 ## Basic fees formula
 
@@ -125,34 +123,34 @@ function FeeCalculator() {
   - _Example_: your TON wallet is also a smart contract, and it pays a storage fee every time you receive or send a transaction. Read more about [how storage fees are calculated](/v3/documentation/smart-contracts/transaction-fees/fees-low-level#storage-fee).
 - `in_fwd_fees` is a charge for importing messages only from outside the blockchain, e.g., `external` messages. Every time you make a transaction, it must be delivered to the validators who will process it. For ordinary messages from contract to contract, this fee is not applicable. Read [the TON Blockchain paper](https://docs.ton.org/tblkch.pdf) to learn more about inbound messages.
   - _Example_: each transaction you make with your wallet app (like Tonkeeper) requires first to be distributed among validators.
-- `computation_fees` is the amount you pay for executing code in the virtual machine. The larger the code, the more fees must be paid.
+- `computation_fees` is the amount you pay for executing code in the virtual machine. Computation fees depend on executed operations (gas used), not code size.
   - _Example_: each time you send a transaction with your wallet (which is a smart contract), you execute the code of your wallet contract and pay for it.
 - `action_fees` is a charge for sending outgoing messages made by a smart contract, updating the smart contract code, updating the libraries, etc.
-- `out_fwd_fees` stands for a charge for sending messages outside the TON Blockchain to interact with off-chain services (e.g., logs) and external blockchains.
+- `out_fwd_fees` is a charge for forwarding outgoing internal messages within TON between shardchains; it depends on message size and routing via HR/IHR.
 
 ## FAQ
 
-Here are the most frequently asked questions by visitors of TON:
+Here are the most frequently asked questions about TON:
 
 ### Fees for sending Toncoin?
 
-The average fee for sending any amount of Toncoin is 0.0055 TON.
+The average fee for sending any amount of Toncoin is 0.0055 TON (source: [fee calculator](/v3/guidelines/smart-contracts/fee-calculation)).
 
 ### Fees for sending Jettons?
 
-The average fee for sending any amount of custom Jettons is 0.037 TON.
+The average fee for sending any amount of custom Jettons is 0.037 TON (source: [fee calculator](/v3/guidelines/smart-contracts/fee-calculation)).
 
 ### Cost of minting NFTs?
 
-The average fee for minting one NFT is 0.08 TON.
+The average fee for minting one NFT is 0.08 TON (source: [fee calculator](/v3/guidelines/smart-contracts/fee-calculation)).
 
 ### Cost of saving data in TON?
 
-Saving 1 MB of data for one year on TON will cost 6.01 TON. Note that you usually don't need to store large amounts of data on-chain. Consider using [TON Storage](/v3/guidelines/web3/ton-storage/storage-daemon) if you need decentralized storage.
+Saving 1 MB of data for one year on TON will cost approximately 6.01 TON. Note that you usually don't need to store large amounts of data on-chain. Consider using [TON Storage](/v3/guidelines/web3/ton-storage/storage-daemon) if you need decentralized storage. For a calculation method, see the [calculator example](/v3/documentation/smart-contracts/transaction-fees/fees-low-level#calculator-example).
 
 ### Is it possible to send a gasless transaction?
 
-In TON, gasless transactions are possible using [wallet v5](/v3/documentation/smart-contracts/contracts-specs/wallet-contracts#preparing-for-gasless-transactions) with a relayer that pays the gas fee for the transaction.
+Gasless transactions can be implemented with [wallet v5](/v3/documentation/smart-contracts/contracts-specs/wallet-contracts#preparing-for-gasless-transactions) and a relayer that pays fees.
 
 ### How to calculate fees?
 
@@ -160,11 +158,11 @@ There is an article about [fee calculation](/v3/guidelines/smart-contracts/fee-c
 
 ## References
 
-- Based on the [@thedailyton article](https://telegra.ph/Commissions-on-TON-07-22) - _[menschee](https://github.com/menschee)_
+- Based on “Commissions on TON” (The Daily TON, 2022‑07‑22) — contributed by _[@menschee](https://github.com/menschee)_. Source: https://telegra.ph/Commissions-on-TON-07-22
 
 ## See also
 
 - [Low-level fees overview](/v3/documentation/smart-contracts/transaction-fees/fees-low-level)—read about the formulas for calculating commissions.
-- [Smart contract function to calculate forward fees in FunC](https://github.com/ton-blockchain/token-contract/blob/main/misc/forward-fee-calc.fc)
+- Reference FunC snippet for computing forward fees: https://github.com/ton-blockchain/token-contract/blob/5046bca227c08497e83e0ad4992337a309176341/misc/forward-fee-calc.fc
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-smart-contracts-transaction-fees-fees.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx`

Related issues (from issues.normalized.md):
- [ ] **2401. Clarify gas definition and articles**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx?plain=1#L9-L12

Reword to “All computation is measured in gas units; each operation has a fixed gas cost,” add “the” before Basechain/Masterchain in this sentence, and note that users cannot set a gas price (they can cap spend via attached value and bounce).

---

- [ ] **2402. Capitalize Basechain/Masterchain**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx?plain=1#L13-L21 and #L31-L33

Change lowercase “basechain/masterchain” to “Basechain/Masterchain” consistently in these sections.

---

- [ ] **2403. Fix TL;DR cost and remove USD comparison**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx?plain=1#L27-L31

Replace the unsourced “0.0025 TON” and the speculative USD comparison with a neutral, approximate statement that links to the calculator and aligns with the FAQ, and avoid marketing terms.

---

- [ ] **2404. Simplify gas price callout and use internal links**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx?plain=1#L31-L33

Change to “Gas price is defined in Network Config: param 20 (Masterchain), param 21 (Basechain)” and link to docs/v3/documentation/network/configs/blockchain-configs.mdx#param-20 and #param-21 (optionally keep tonviewer links).

---

- [ ] **2405. Correct validator approval threshold**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx?plain=1#L37-L40

Update to “Changing configuration parameters requires approval via configuration proposals, generally more than 3/4 (75%) of validators by weight, confirmed across rounds,” and cite docs/v3/documentation/network/configs/config-params.mdx#changing-the-parameters and docs/v3/documentation/smart-contracts/contracts-specs/governance.mdx#config.

---

- [ ] **2406. Neutralize NFT pre-funding example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx?plain=1#L53-L54

Rephrase to “Some NFT marketplaces over‑provision funds and refund the remainder; amounts vary by marketplace,” removing the unsourced “~1 TON” claim.

---

- [ ] **2407. Replace informal transition**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx?plain=1#L61-L62

Replace “let’s read more” with a formal transition such as “The following sections describe how fees work on TON.”

---

- [ ] **2408. Fix and clarify FeeCalculator example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx?plain=1#L75-L120

Include total_fwd_fees in the total, default IHR disabled (ihr_disabled = 1), label TON vs nanotons in outputs, note variables mirror config field names, use const/let instead of var, and change the comment to “also called import fee.”

---

- [ ] **2409. Correct out_fwd_fees description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx?plain=1#L130-L131

Define out_fwd_fees as the charge for forwarding outgoing internal messages within TON between shardchains (per message size and routing via HR/IHR), removing references to off‑chain/external blockchains.

---

- [ ] **2410. Add date/source to FAQ averages**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx?plain=1#L137-L151

Qualify the listed “average” fees with “as of <Month Year>” and/or link to a live source to avoid staleness and improve verifiability.

---

- [ ] **2411. Capitalize Jettons**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx?plain=1#L141-L144

Use “Jettons” with consistent capitalization in this section.

---

- [ ] **2412. Improve reference attribution**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx?plain=1#L161-L164

Format the reference with title and date and attribute the contributor (e.g., “Based on ‘Commissions on TON’ (The Daily TON, 2022‑07‑22) — contributed by @menschee”).

---

- [ ] **2413. Add context and pin forward-fee link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx?plain=1#L167-L168

Introduce the link as a “Reference FunC snippet for computing forward fees” and pin it to a commit hash for stability.

---

- [ ] **2414. Fix computation fee explanation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx?plain=1#elements-of-the-transaction-fee

Replace “the larger the code, the more fees must be paid” with “Computation fees depend on executed operations (gas used), not code size.”

---

- [ ] **2415. Clean up minor grammar and hyphenation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx?plain=1

Change “questions by visitors of TON” to “questions about TON” and ensure consistent “low‑level” hyphenation.

---

- [ ] **2416. Soften storage‑cost precision**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx?plain=1#cost-of-saving-data-in-ton

Change “will cost 6.01 TON” to “will cost approximately 6.01 TON” and link to the method in docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx#calculator-example.

---

- [ ] **2417. Clarify gasless transactions phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx?plain=1#is-it-possible-to-send-a-gasless-transaction

Rephrase to “Gasless transactions can be implemented with wallet v5 and a relayer that pays fees,” linking to docs/v3/documentation/smart-contracts/contracts-specs/wallet-contracts.mdx#preparing-for-gasless-transactions.

---

- [ ] **2418. Standardize Toncoin vs TON usage**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx?plain=1

Use “Toncoin (TON)” on first mention and “TON” as the unit thereafter.

---

- [ ] **3299. Soften MEV claims and fix fee wording and typo**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Replace “eliminates” with “significantly limits,” change “Commissions are fixed” to “Gas price is protocol-defined (no fee market); users can’t bid for priority,” and add the missing space in “ordering,front‑running” (see docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.