### PR TITLE
Split: update docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx
+++ b/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx
@@ -92,7 +92,7 @@ Each opcode consumes 26 gas, except for `PREVMCBLOCKS` and `PREVKEYBLOCK`, which
 
 | Fift syntax | Stack            | Description                                                                                 |
 |:-|:-----------------|:--------------------------------------------------------------------------------------------|
-| `GASCONSUMED` | _`- g_c`_        | Returns the total gas consumed by the VM so far, including this instruction.<br/>_26 gas_. |
+| `GASCONSUMED` | _`- g_c`_        | Returns the total gas consumed by the VM so far, including this instruction. <br/>_26 gas_. |
 
 ## Arithmetics
 New variants of [the division opcode](/v3/documentation/tvm/instructions) `A9mscdf` have been introduced.


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-tvm-changelog-tvm-upgrade-2023-07.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx`

Related issues (from issues.normalized.md):
- [x] **2435. Standardize “MasterChain” capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1#L61-L63

The text mixes “MasterChain” and “masterchain”; use “MasterChain” consistently (e.g., “if the MasterChain sequence number is below 16.”).

---

- [ ] **2436. Remove duplicated gas sentence in c7 opcodes**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1#L76-L79

The gas-cost line is repeated; remove the first duplicate and keep: “Each opcode consumes 26 gas, except for `PREVMCBLOCKS` and `PREVKEYBLOCK`, which require 34 gas.”

---

- [ ] **2437. Fix GLOBALID naming and spacing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1#L89

Replace “network config 19.” with “ConfigParam 19.” and remove the extra space.

---

- [ ] **2438. Remove extra space before period in GASCONSUMED**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1#L95

Change “including this instruction .” to “including this instruction.”

---

- [ ] **2439. Rename “Arithmetics” heading to “Arithmetic”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1#L97

Use the standard term “Arithmetic” for the section heading.

---

- [ ] **2440. Correct ADDDIVMODC stack signature**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1#L131

In the stack signature replace “y” with “z”: “x w z - q=ceil((x+w)/z)”.

---

- [ ] **2441. Use CHKSIGNS/CHKSIGNU instead of CHKSIGN**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1#L219

Replace “CHKSIGN” with “CHKSIGNS”/“CHKSIGNU” (Ed25519 signature verification).

---

- [ ] **2442. Fix apostrophe in RIST255_PUSHL description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1#L269

Change “group`s order” to “group’s order.”

---

- [ ] **2443. Clarify BLS “Messages” bullet**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1#L284

Replace “Messages: slice. Several bits should be divisible by 8.” with “Messages: slice; the bit length must be divisible by 8.”

---

- [x] **2444. Remove spaces before periods in BLS section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1#L296,L325

Remove stray spaces before periods such as “invalid .”, “...`22840`_ .”, and “`2^255` .”.

---

- [ ] **2445. Remove trailing hyphen from BLS_FASTAGGREGATEVERIFY**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1#L297

Delete the trailing hyphen so the mnemonic reads “BLS_FASTAGGREGATEVERIFY”.

---

- [ ] **2446. Fix grammar in BLS_PAIRING description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1#L324

Rewrite as “calculates the product of the pairings of `x_i` and `y_i`,” and add a space after the comma in “`x_i, y_i`”.

---

- [ ] **2447. Use consistent exit_code naming in RUNVM**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1#L336-L367

Use “exit_code” consistently in both the stack signature and the narrative (replace “exitcode” with “exit_code”).

---

- [x] **2448. Use “shard blocks” instead of “shardblocks”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1

Replace “shardblocks” with “shard blocks” for consistency with terminology used elsewhere.

---

- [ ] **2449. Use “divisor” instead of “divider”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1

Change “The divider is zero.” to “The divisor is zero.”

---

- [ ] **2450. Replace Unicode minus in formulas**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1

Replace U+2212 (−) with ASCII hyphen-minus (-) in formulas (e.g., “max(arg-255, 0)”).

---

- [ ] **2451. Add caveat for RUNVM flag +2**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1

Add that “+2: pushes an implicit 0 before executing the code” only works when flag “+1” is also set.

---

- [ ] **2452. Remove or cite Everscale comparison**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1

Remove the sentence claiming opcode value “10” aligns with Everscale TVM, or add an internal citation to support it.

---

- [ ] **2453. Rephrase crypto intro tense**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1

Change “Currently, the only cryptographic algorithm available is …” to “Before this upgrade, the only cryptographic algorithm available was …”.

---

- [ ] **2454. Clarify ECRECOVER parameters**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1

Rephrase to: “inputs are a 32-byte hash, a 1-byte recovery id `v`, and 256-bit integers `r` and `s`; returns header byte `h` and 256-bit coordinates `x1` and `x2` (65 bytes total).”

---

- [ ] **2455. Remove or cite Apple Secure Enclave claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1

Remove the statement “It is compatible with Apple Secure Enclave.” or add an internal citation supporting it.

---

- [x] **2456. Add language tag to BlockId code fence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1

Add a language identifier (e.g., “text”) to the BlockId/PrevBlocksInfo code fence for proper formatting.

---

- [ ] **2457. Fix “TVM instructions” link target**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1

Update the link to a valid internal page that exists in this repository, or confirm the deployed route resolves to avoid a 404.

---

- [x] **2458. Remove trailing spaces after code fence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1

Remove the trailing spaces after the closing code fence to avoid formatting inconsistencies.

---

- [x] **2459. Remove double space in BLS_VERIFY**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2023-07.mdx?plain=1

Change “It returns true if valid, false otherwise.” to “It returns true if valid, false otherwise.”

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.