### PR TITLE
Split: update docs/v3/documentation/tvm/changelog/tvm-upgrade-2024-04.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/tvm/changelog/tvm-upgrade-2024-04.mdx
+++ b/docs/v3/documentation/tvm/changelog/tvm-upgrade-2024-04.mdx
@@ -2,7 +2,7 @@ import Feedback from '@site/src/components/Feedback';
 
 # TVM Upgrade April 2024
 
-## Introducing new instructions for low‑fee calculation
+## Introducing new instructions for low‑fees calculation
 
 :::tip
 This upgrade has been active on Mainnet since March 16, 2024. See the details [here](https://t.me/tonstatus/101). A preview of the update for blueprints is available in the following packages: `@ton/sandbox@0.16.0-tvmbeta.3`, `@ton-community/func-js@0.6.3-tvmbeta.3`, and `@ton-community/func-js-bin@0.4.5-tvmbeta.3`


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-tvm-changelog-tvm-upgrade-2024-04.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/tvm/changelog/tvm-upgrade-2024-04.mdx`

Related issues (from issues.normalized.md):
- [x] **2460. Capitalize H1 and spell out month**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2024-04.mdx?plain=1

Change "# TVM upgrade Apr 2024" to "# TVM Upgrade April 2024".

---

- [x] **2461. Rephrase subheading for low-fee instructions**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2024-04.mdx?plain=1

Change "## Introduction of new instructions for low fees calculation" to "## Introducing new instructions for low‑fee calculation".

---

- [x] **2462. Fix tip grammar and date style**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2024-04.mdx?plain=1

Use present perfect and full month: change "This upgrade is active on the Mainnet since Mar 16, 2024." to "This upgrade has been active on Mainnet since March 16, 2024.".

---

- [ ] **2463. Use canonical ConfigParam 8 naming**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2024-04.mdx?plain=1

Replace "Config8 `version >= 6`" with "ConfigParam 8 (GlobalVersion) ≥ 6".

---

- [ ] **2464. Align c7 length, indices, and GETPRECOMPILEDGAS semantics**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2024-04.mdx?plain=1

Correct c7 extension to "from 14 to 17 elements" (indices 0..16) and state c7[16] is gas_usage for precompiled contracts; in the opcodes table, change GETPRECOMPILEDGAS stack to "- i or null" and remove "Reserved; currently returns null." so both sections agree.

---

- [x] **2465. Fix indentation for GETPRECOMPILEDGAS opcode note**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2024-04.mdx?plain=1

Remove the leading spaces before " `asm` opcode: `GETPRECOMPILEDGAS`." so it stays within the bullet list.

---

- [x] **2466. Normalize masterchain/basechain casing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2024-04.mdx?plain=1

Use consistent lowercase "masterchain" and "basechain" across the page, including config parameter descriptions and opcode docs.

---

- [x] **2467. Add missing space before inline code in GETSTORAGEFEE**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2024-04.mdx?plain=1

Insert a space so the text reads "...based on current storage prices. `cells` and `bits`...".

---

- [x] **2468. Move period outside code in GETGASFEESIMPLE formula**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2024-04.mdx?plain=1

Place the period after the code span: "(gas_used * price) / 2^16".

---

- [x] **2469. Remove extra parenthesis in GETFORWARDFEESIMPLE formula**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2024-04.mdx?plain=1

Delete the trailing ")" so it reads "(bits * bit_price + cells * cell_price) / 2^16".

---

- [ ] **2470. Correct CHASHIX stack annotation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2024-04.mdx?plain=1

Change the stack from "cell i - depth" to "cell i - hash".

---

- [ ] **2471. Use consistent parameter name in GETSTORAGEFEE note**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2024-04.mdx?plain=1

Replace "time_delta" with "seconds" in the note to match the argument name.

---

- [ ] **2472. Document SENDMSG return value**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2024-04.mdx?plain=1

Append to the description that it returns the fee for generating the message (in nanotons).

---

- [ ] **2473. Promote "Due payment field" to a subheading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2024-04.mdx?plain=1

Change the bolded "Due payment field" label to a level‑3 heading: "### Due payment field".

---

- [ ] **2474. Remove time-sensitive package versions from tip**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/changelog/tvm-upgrade-2024-04.mdx?plain=1

Delete specific pre‑release version strings (e.g., "tvmbeta.*") or replace them with a timeless pointer to package release notes for tvmbeta builds.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.