### PR TITLE
Split: update docs/v3/documentation/tvm/specification/runvm.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/tvm/specification/runvm.mdx
+++ b/docs/v3/documentation/tvm/specification/runvm.mdx
@@ -36,6 +36,6 @@ Gas cost:
 
 ## See also
 
-- [TVM overview](/v3/documentation/tvm/overview)
+- [TVM instructions](/v3/documentation/tvm/instructions)
 
 <Feedback />

--- a/docs/v3/documentation/tvm/specification/runvm.mdx
+++ b/docs/v3/documentation/tvm/specification/runvm.mdx
@@ -27,8 +27,6 @@ Flags are the same as for Fift `RUNVMX`; `RUNVMX` reads flags from the stack:
   - If `RUNVM` fails with an exception, only one element is returned, `exit_arg`, which should not be confused with `exit_code`.
   - In the case of running out of gas, `exit_code` is set to `-14`, and `exit_arg` contains the amount of gas.
 
-Note: when an exception occurs with the `+256` flag, only `exit_arg` is returned; `exit_code` and stack/register values are not returned.
-
 Gas cost:
 - 66 gas.
 - 1 gas for each stack element passed to the child VM (the first 32 elements are free).

--- a/docs/v3/documentation/tvm/specification/runvm.mdx
+++ b/docs/v3/documentation/tvm/specification/runvm.mdx
@@ -3,7 +3,7 @@ import Feedback from '@site/src/components/Feedback';
 
 # RUNVM specification
 
-The `RUNVM` instruction creates an isolated VM instance, allowing code execution while safely retrieving data such as stack state, registers, and gas consumption, ensuring the caller's state remains unaffected and allowing arbitrary code to run safely. This is helpful for [v4-style plugins](/v3/documentation/smart-contracts/contracts-specs/wallet-contracts#wallet-v4), Tact's `init`-style subcontract calculations, and similar use cases.
+The `RUNVM` instruction creates an isolated VM instance, allowing code execution while safely retrieving data such as stack state, registers, and gas consumption, ensuring the caller's state remains unaffected and allowing arbitrary code to run safely. This is helpful for [v4-style plugins](/v3/documentation/smart-contracts/contracts-specs/wallet-contracts#wallet-v4) and similar use cases.
 
 | Fift syntax | Stack | Description                                                                                                                                                                                                                                                                                                                                                                                                          |
 |:-|:-|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -36,6 +36,6 @@ Gas cost:
 
 ## See also
 
-- [TVM overview](/v3/documentation/tvm/tvm-overview)
+- [TVM overview](/v3/documentation/tvm/overview)
 
 <Feedback />

--- a/docs/v3/documentation/tvm/specification/runvm.mdx
+++ b/docs/v3/documentation/tvm/specification/runvm.mdx
@@ -3,20 +3,18 @@ import Feedback from '@site/src/components/Feedback';
 
 # RUNVM specification
 
-Currently, TVM does not provide a mechanism for executing external untrusted code within a secure sandbox environment. In other words, any external code invoked has unrestricted access and can permanently modify the contract's code and data or trigger actions such as transferring all funds.
-
-The `RUNVM` instruction creates an isolated VM instance, allowing code execution while safely retrieving data such as stack state, registers, and gas consumption. This ensures the caller's state remains unaffected. This allows arbitrary code to run safely, which is helpful for [v4-style plugins](/v3/documentation/smart-contracts/contracts-specs/wallet-contracts#wallet-v4), Tact's `init`-style subcontract calculations, and similar use cases.
+The `RUNVM` instruction creates an isolated VM instance, allowing code execution while safely retrieving data such as stack state, registers, and gas consumption, ensuring the caller's state remains unaffected and allowing arbitrary code to run safely. This is helpful for [v4-style plugins](/v3/documentation/smart-contracts/contracts-specs/wallet-contracts#wallet-v4), Tact's `init`-style subcontract calculations, and similar use cases.
 
 | Fift syntax | Stack | Description                                                                                                                                                                                                                                                                                                                                                                                                          |
 |:-|:-|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `flags RUNVM` | _`x_1 ... x_n n code [r] [c4] [c7] [g_l] [g_m] - x'_1 ... x'_m exitcode [data'] [c4'] [c5] [g_c]`_ | Executes a child VM with the given `code` and stack values `x_1 ... x_n`. Returns the modified stack `x'_1 ... x'_m` along with an exit code. <br/> Flags determine other arguments and return values. See details below.|
-| `RUNVMX` | _`x_1 ... x_n n code [r] [c4] [c7] [g_l] [g_m] flags - x'_1 ... x'_m exitcode [data'] [c4'] [c5] [g_c]`_ | It is the same as `RUNVM` but retrieves flags from the stack.                                                                                                                                                                                                                                                                                                                                                        |
+| `flags RUNVM` | _`x_1 ... x_n n code [r] [c4] [c7] [g_l] [g_m] - x'_1 ... x'_m exit_code [c4'] [c5'] [g_c]`_ | Executes a child VM with the given `code` and stack values `x_1 ... x_n`. Returns the modified stack `x'_1 ... x'_m` along with an exit code. <br/> Flags determine other arguments and return values. See details below.|
+| `RUNVMX` | _`x_1 ... x_n n code [r] [c4] [c7] [g_l] [g_m] flags - x'_1 ... x'_m exit_code [c4'] [c5'] [g_c]`_ | Same as `RUNVM`, but retrieves flags from the stack.                                                                                                                                                                                                                                                                                                                                                                 |
 
 
-Flags operate similarly to `RUNVMX` in Fift:
+Flags are the same as for Fift `RUNVMX`; `RUNVMX` reads flags from the stack:
 
 - `+1`: sets `c3` to code.
-- `+2`: pushes an implicit `0` before executing the code. Note, it only works with +1 flag set
+- `+2`: pushes an implicit `0` before executing the code. Note: it only works when the `+1` flag is set.
 - `+4`: takes persistent data `c4` from the stack and returns its final value.
 - `+8`: takes the gas limit `g_l` from the stack and returns the consumed gas `g_c`.
 - `+16`: takes `c7` (smart contract context) from the stack.
@@ -29,14 +27,15 @@ Flags operate similarly to `RUNVMX` in Fift:
   - If `RUNVM` fails with an exception, only one element is returned, `exit_arg`, which should not be confused with `exit_code`.
   - In the case of running out of gas, `exit_code` is set to `-14`, and `exit_arg` contains the amount of gas.
 
+Note: when an exception occurs with the `+256` flag, only `exit_arg` is returned; `exit_code` and stack/register values are not returned.
+
 Gas cost:
-- 66 gas;
-- 1 gas for each stack element passed to the child VM (the first 32 elements are free);
+- 66 gas.
+- 1 gas for each stack element passed to the child VM (the first 32 elements are free).
 - 1 gas for each stack element returned from the child VM (the first 32 elements are free).
 
 ## See also
 
-- [TVM instructions](/v3/documentation/tvm/instructions)
+- [TVM overview](/v3/documentation/tvm/tvm-overview)
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-tvm-specification-runvm.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/tvm/specification/runvm.mdx`

Related issues (from issues.normalized.md):
- [x] **2486. Combine repetitive 'This' sentences in intro**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/specification/runvm.mdx?plain=1#L8

Merge the two consecutive "This ..." sentences into one for flow (e.g., a single sentence that both describes safe data retrieval and that the caller’s state remains unaffected).

---

- [x] **2487. Use exit_code consistently in stack signatures**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/specification/runvm.mdx?plain=1#L12-L13

Replace exitcode with exit_code in the table’s stack signatures to match the narrative and established convention.

---

- [x] **2488. Remove undefined [data'] from return signature**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/specification/runvm.mdx?plain=1#L12-L13

Delete [data'] from the return list unless a distinct, documented return is intended (minimal fix: remove it).

---

- [x] **2489. Use [c5'] to denote final value**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/specification/runvm.mdx?plain=1#L12-L13

Change [c5] to [c5'] in the return signature to align with “[c4']” and the “final value of c5” wording.

---

- [ ] **2490. Clarify exit_arg vs returns on +256 errors**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/specification/runvm.mdx?plain=1#L12-L13,L26-L30

Add a note that when an exception occurs with the +256 flag, only exit_arg is returned instead of exit_code and the stack/register values.

---

- [x] **2491. Clarify flags phrasing relative to RUNVMX**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/specification/runvm.mdx?plain=1#L16

Rephrase to “Flags are the same as for Fift RUNVMX; RUNVMX reads flags from the stack.”

---

- [x] **2492. Fix +2 flag note grammar and dependency**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/specification/runvm.mdx?plain=1#L19

Change to “Note: it only works when the +1 flag is set.” (with code formatting and a period), and confirm/remove the dependency to match canonical behavior across docs.

---

- [x] **2493. Standardize punctuation in Gas cost list**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/specification/runvm.mdx?plain=1#L32-L35

End each bullet point with a period (replace the current semicolons with periods).

---

- [ ] **2494. Fix broken 'TVM instructions' link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/specification/runvm.mdx?plain=1#L39

Update the “See also” link from /v3/documentation/tvm/instructions to a valid target or remove it until a canonical URL exists.

---

- [x] **2495. Resolve contradictory sandboxing statement**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/specification/runvm.mdx?plain=1

Remove or rephrase the opening claim that TVM lacks sandboxing to reflect RUNVM’s isolated execution (e.g., make it historical or omit it).

---

- [x] **2496. Shorten RUNVMX row description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/specification/runvm.mdx?plain=1

Replace “It is the same as RUNVM but retrieves flags from the stack.” with “Same as RUNVM, but retrieves flags from the stack.”

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.