### PR TITLE
Split: update docs/v3/documentation/tvm/tvm-overview.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/documentation/tvm/overview.mdx
+++ b/docs/v3/documentation/tvm/overview.mdx
@@ -1,20 +1,18 @@
 import Feedback from '@site/src/components/Feedback';
 
-import Button from '@site/src/components/button'
-
 # Overview
 
 The TON Virtual Machine (TVM) executes all TON smart contracts. TVM operates as a **stack machine**, which ensures efficiency and ease of implementation.
 
 This document provides a high-level overview of how TVM processes transactions.
 
-## TON course: TVM
-
-:::tip
-Before starting the course, ensure you have a solid understanding of blockchain basics. If you need to fill knowledge gaps, consider taking the [Blockchain basics with TON](/v3/concepts/educational-resources#blockchain-basics) course.
-:::
+## TON Blockchain course
 
 The [TON Blockchain course](/v3/concepts/educational-resources#ton-blockchain-development) is a comprehensive guide to TON Blockchain development. Module 2 covers **TVM**, transactions, scalability, and business cases in detail.
+
+:::tip
+Before starting the course, ensure you have a solid understanding of blockchain basics. If you need to fill knowledge gaps, consider taking the [Blockchain basics](/v3/concepts/educational-resources#blockchain-basics) course.
+:::
 
 ## Transactions and phases
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-documentation-tvm-tvm-overview.mdx` into `main`.

Changed file(s):
- M: `docs/v3/documentation/tvm/tvm-overview.mdx`

Related issues (from issues.normalized.md):
- [x] **1603. Link cskip_no_gas to compute-phase docs**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/precompiled-contracts.mdx?plain=1

Link the term cskip_no_gas to docs/v3/documentation/tvm/tvm-overview.mdx#when-the-compute-phase-is-skipped for the canonical explanation of skip reasons.

---

- [ ] **2524. Fix broken “TVM instructions” link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/tvm-overview.mdx?plain=1#tvm-instructions

Replace the link to “/v3/documentation/tvm/instructions” with a valid, existing destination (or remove it) and choose the canonical target for “TVM instructions.”

---

- [ ] **2525. Correct Credit phase: exclude storage fees**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/tvm-overview.mdx?plain=1#transactions-and-phases

Change the wording to “Credit phase: credits the incoming message value to the account balance; storage fees are handled in the storage phase.”

---

- [x] **2526. Clarify Bounce phase conditions**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/tvm-overview.mdx?plain=1#transactions-and-phases

State that if the Compute or Action phase ends with an error and the inbound message has the bounce flag set, the Bounce phase generates a bounce message.

---

- [ ] **2527. Use canonical compute phase result fields**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/tvm-overview.mdx?plain=1#transactions-and-phases

Remove non-canonical names “gas_details” and “new_storage” and say the result includes an exit code and may update c4 (persistent data) and c5 (output actions).

---

- [x] **2528. Correct description of control register c3**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/tvm-overview.mdx?plain=1#control-registers

Change the c3 description to “initialized with the smart contract code cell.”

---

- [x] **2529. Remove dated gas threshold from compute-skip reasons**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/tvm-overview.mdx?plain=1#when-the-compute-phase-is-skipped

Delete the time-sensitive numeric threshold and keep only the spec-defined reasons (no state, bad state, or no gas), optionally linking to the reference for ComputeSkipReason.

---

- [ ] **2530. Remove misleading “TVM 4.3.5” label**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/tvm-overview.mdx?plain=1#compute-phase

Drop the “TVM 4.3.5” label and use a neutral caption such as “TON Blockchain paper (may include outdated information).”

---

- [x] **2531. Remove unsupported 1024 cell-depth claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/tvm-overview.mdx?plain=1#results-of-tvm-execution

Remove the “maximum cell depth during execution is <1024” statement and keep only the documented 512 depth limit for c4/c5.

---

- [x] **2532. Align page title phrasing with referring pages**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/tvm-overview.mdx?plain=1#overview-of-tvm

Harmonize the page title to “TVM overview” (or coordinate updates to referring link text) to keep terminology consistent.

---

- [x] **2533. Use full language names on course buttons**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/tvm-overview.mdx?plain=1#ton-course-tvm

Change button labels from “CHN” and “RU” to “Chinese” and “Russian” for consistency.

---

- [x] **2534. Replace “stack principle” with “stack machine”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/tvm/tvm-overview.mdx?plain=1#L7-L12

Rewrite “TVM operates on the stack principle” to “TVM operates as a stack machine” for clear, idiomatic wording.

---

- [ ] **4321. Inconsistent casing for “TVM retracer”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/fift/overview.mdx?plain=1

This page uses “TVM Retracer” (capital “R”), while the TVM overview uses “TVM retracer”. For terminology consistency within the docs, use “TVM retracer” here as well. Change the link label to “TVM retracer”. This is a terminology consistency decision. Reference: docs/v3/documentation/tvm/tvm-overview.mdx (tip section lists “TVM retracer”).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.