### PR TITLE
Split: update docs/v3/guidelines/dapps/apis-sdks/api-keys.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/dapps/apis-sdks/api-keys.mdx
+++ b/docs/v3/guidelines/dapps/apis-sdks/api-keys.mdx
@@ -4,7 +4,10 @@ import Feedback from '@site/src/components/Feedback';
 
 ## Overview
 
-When using the TON Center HTTP API, a token (API key) is generally not required. However, having a key may provide higher request rate limits. There are several available plans, all of which can be viewed in the TON Center Mini App.
+When using the TON Center HTTP API, a token (API key) is generally not required. However, having a key may provide higher request rate limits. There are several available plans, all of which can be viewed in 
+the [TON Center Mini App](https://t.me/tonapibot). Each subscription plan comes with specific rate limits, ranging from **10 requests/second** on the Free plan up to **100 requests/second** on Advanced, 
+with higher or tailored limits available on Enterprise. Choosing a paid plan also unlocks more tokens per network and access to private liteservers.
+
 
 ## How to get a key
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-dapps-apis-sdks-api-keys.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/dapps/apis-sdks/api-keys.mdx`

Related issues (from issues.normalized.md):
- [x] **2541. Standardize TON Center branding and Mini App capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/api-keys.mdx?plain=1#L7,L15,L17,L35

Replace “Toncenter” with “TON Center,” capitalize “Mini App,” add the article in “viewed in the TON Center Mini App,” and update any alt text to use “TON Center” with correct capitalization.

---

- [x] **2542. Clarify API name to “TON Center HTTP API”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/api-keys.mdx?plain=1#L7

Change “TON HTTP API” to the precise provider name “TON Center HTTP API.”

---

- [x] **2543. Capitalize Telegram Start button label**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/api-keys.mdx?plain=1#L11

Change the UI reference from `start` to `Start` to match the Telegram button label.

---

- [x] **2544. Fix MANAGE instruction and use consistent verb**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/api-keys.mdx?plain=1#L29

Change “Click the `MANAGE` at the top of the app...” to “Press the `MANAGE` button at the top of the app...” and use “Press” consistently across the steps.

---

- [x] **2545. Remove repetition in troubleshooting line**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/api-keys.mdx?plain=1#L35

Replace “Try updating Telegram and try again.” with “Update the Telegram app and try again.”

---

- [x] **2546. Align bot handle or clarify difference**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/api-keys.mdx?plain=1

Use a single canonical handle for obtaining TON Center API keys (e.g., @tonapibot) or clearly explain the roles of @toncenter vs @tonapibot.

---

- [x] **2547. Clarify rate-limit claim or link to official limits**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/api-keys.mdx?plain=1

Replace “removes request limitations” with a precise, doc-consistent statement about request rates or link to the authoritative limits page.

---

- [x] **2548. Confirm and fix Mini App launch button label**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/api-keys.mdx?plain=1

Verify the exact Telegram UI label (e.g., “Manage API Keys” or “TON Center”) and use a single correct label; if multiple exist in different contexts, clarify when each appears.

---

- [x] **2549. Use “Toncoin” for the currency name**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/api-keys.mdx?plain=1

Change “Send the required amount of TON...” to “Send the required amount of Toncoin...”.

---

- [x] **2550. Remove conversational filler**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/api-keys.mdx?plain=1

Remove “That’s it!” and keep the concise instructional sentence (e.g., “Fill in the required fields and press `Create`. Your API key is ready to use.”).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.