### PR TITLE
Split: update docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.mdx
+++ b/docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.mdx
@@ -1,7 +1,6 @@
 import Feedback from '@site/src/components/Feedback';
 
 # HTTP API by GetBlock
-
 :::info
 [GetBlock](https://getblock.io/) is a Web3 infrastructure provider that offers HTTP-based API endpoints for clients to interact with multiple blockchain networks, including TON.
 :::
@@ -10,42 +9,42 @@ This guide covers essential steps in acquiring and using private RPC endpoints b
 
 ## How to access TON Blockchain endpoints
 
-To start using GetBlock’s endpoints, users need to log in to their accounts, and retrieve a TON endpoint URL. Follow these instructions:
+To start using GetBlock’s endpoints, users need to log in to their accounts and retrieve a TON endpoint URL. Follow these instructions:
 
 ### 1. Create a GetBlock account
 
-Visit the GetBlock [website](https://getblock.io/?utm_source=external&utm_medium=article&utm_campaign=ton_docs) and click on the "Get Started for Free" button. Sign up using your email address or by connecting your MetaMask wallet.
+Visit the GetBlock [website](https://getblock.io/) and click on the "Get Started for Free" button. Sign up using your email address or by connecting a supported wallet (e.g., MetaMask) for GetBlock account authentication; this is unrelated to TON interactions.
 
-![GetBlock.io_main_page](/img/docs/getblock-img/unnamed-2.png?=RAW)
+![GetBlock homepage](/img/docs/getblock-img/unnamed-2.png)
 
 ### 2. Select TON Blockchain
 
-After signing in, go to the "My Endpoints" section. Choose TON from the "Protocols" dropdown menu and select the desired network and API type (JSON-RPC or JSON-RPC(v2)).
+After signing in, go to the "My Endpoints" section. Choose TON from the "Protocols" dropdown menu and select the desired network and API type (JSON-RPC or JSON-RPC v2).
 
-![GetBlock_account__dashboard](/img/docs/getblock-img/unnamed-4.png)
+![GetBlock dashboard — My Endpoints](/img/docs/getblock-img/unnamed-4.png)
 
 ### 3. Generate your endpoint URL
 
-Click the **Get** button to generate your TON Blockchain endpoint URL. The structure of the endpoint will be: `https://go.getblock.io/[ACCESS TOKEN]/`.
+Click the **Get** button to generate your TON Blockchain endpoint URL. The structure of the endpoint will be: `https://go.getblock.io/[ACCESS-TOKEN]/`.
 
 Access tokens act as unique identifiers for your requests, eliminating the need for separate API keys or authorization headers.
 
 Users have the flexibility to generate multiple endpoints, roll tokens if compromised, or delete unused endpoints.
 
-![GetBlock_account_endpoints](/img/docs/getblock-img/unnamed-3.png)
+![Generated TON endpoint token](/img/docs/getblock-img/unnamed-3.png)
 
-Now, you can use these URLs to interact with TON Blockchain, query data, send transactions, and build decentralized applications without the hassle of infrastructure setup and maintenance.
+Now you can use these URLs to interact with TON Blockchain, query data, send transactions, and build decentralized applications without the hassle of infrastructure setup and maintenance.
 
 ### Free requests and user limits
 
-Each registered user receives 40,000 free requests per day, with a cap of 60 requests per second (RPS). This balance is renewed daily and can be used for any supported blockchain.
+Each registered user receives 40,000 free requests per day with a cap of 60 requests per second (RPS). Limits are provider-specific and subject to change. This balance is renewed daily and can be used for any supported blockchain.
 
 ### Shared nodes
 
-- Entry-level opportunity where same nodes are utilized by several clients simultaneously;
-- Rate limit increased to 200 RPS;
-- Well-suited for individual use or for applications that have lower transaction volumes and resource requirements compared to fully-scaled production applications;
-- A more affordable option for individual developers or small teams with limited budgets.
+- Entry-level option where the same nodes are used by multiple clients.
+- Rate limit increased to 200 RPS.
+- Well suited for individual use or for applications that have lower transaction volumes and resource requirements than fully scaled production applications.
+- More affordable option for individual developers or small teams with limited budgets.
 
 Shared nodes provide a cost-effective solution for accessing TON Blockchain infrastructure without the need for significant upfront investment or commitment.
 
@@ -53,9 +52,9 @@ As developers scale their applications and require additional resources, they ca
 
 ### Dedicated nodes
 
-- One node is exclusively allocated to a single client;
-- No request limits;
-- Opens access to archive nodes, a variety of server locations, and custom settings;
+- One node is exclusively allocated to a single client.
+- No request limits.
+- Provides access to archive nodes, multiple server locations, and custom settings.
 - Guarantees premium-level service and support to clients.
 
 This is a next-level solution for developers and decentralized applications (dApps) that require enhanced throughput, higher speed of node connection, and guaranteed resources as they scale.
@@ -68,37 +67,37 @@ In this section, we delve into the practical usage of the TON HTTP API provided 
 
 You can use the `/getAddressBalance` method to get the balance for a specific TON address:
 
-```
+```bash
 curl --location --request GET 'https://go.getblock.io/[ACCESS-TOKEN]/getAddressBalance?address=EQDXZ2c5LnA12Eum-DlguTmfYkMOvNeFCh4rBD0tgmwjcFI-' \
 --header 'Content-Type: application/json'
 ```
 
-Make sure to replace `ACCESS-TOKEN` with your actual access token provided by GetBlock.
+Make sure to replace `[ACCESS-TOKEN]` with your actual access token provided by GetBlock.
 
 This will output the balance in nanotons.
 
-![getAddressBalance_response_on_TON_Blockchain](/img/docs/getblock-img/unnamed-2.png)
+![Sample getAddressBalance response](/img/docs/getblock-img/unnamed-5.png)
 
-Some other available methods to query the TON blockchain:
+Some other available GetBlock methods to query the TON Blockchain:
 
-| # | Method | Endpoint           | Description                                                                          |
+| # | Method | Path               | Description                                                                          |
 | - | ------ | ------------------ | ------------------------------------------------------------------------------------ |
-| 1 | GET    | getAddressState    | Returns the current state of a specified address (uninitialized, active, or frozen). |
-| 2 | GET    | getMasterchainInfo | Fetches the state of the masterchain.                                                |
-| 3 | GET    | getTokenData       | Retrieves details about an NFT or jetton associated with the address.                |
-| 4 | GET    | packAddress        | Converts a TON address from raw format to human-readable format.                     |
-| 5 | POST   | sendBoc            | Sends serialized BOC files with external messages for blockchain execution.          |
+| 1 | GET    | `/getAddressState`    | Returns the current state of a specified address (uninitialized, active, or frozen). |
+| 2 | GET    | `/getMasterchainInfo` | Fetches the state of the masterchain.                                                |
+| 3 | GET    | `/getTokenData`       | Retrieves details about an NFT or jetton associated with the address.                |
+| 4 | GET    | `/packAddress`        | Converts a TON address from raw format to human-readable format.                     |
+| 5 | POST   | `/sendBoc`            | Sends serialized BOC files with external messages for blockchain execution.          |
 
-For a comprehensive list of methods and detailed API documentation, please refer to GetBlock's [documentation](https://getblock.io/docs/ton/json-rpc/ton_jsonrpc/).
+For the official method list and detailed API documentation, see GetBlock’s [TON JSON-RPC reference](https://getblock.io/docs/ton/json-rpc/ton_jsonrpc/).
 
 ### Deploying smart contracts
 
-Developers can utilize the TON library to deploy and interact with contracts. The library will initialize a client to connect to the network via the GetBlock HTTP API endpoints.
+Developers can use an SDK to deploy and interact with contracts. The SDK will initialize a client to connect to the network via the GetBlock HTTP API endpoints. See the [SDK list](/v3/guidelines/dapps/apis-sdks/sdk).
 
-![Image from TON Blueprint IDE](/img/docs/getblock-img/unnamed-6.png)
+![Deploying via TON Blueprint IDE](/img/docs/getblock-img/unnamed-6.png)
 
-By following this guide, developers can easily access TON Blockchain using GetBlock's infrastructure. Whether you're working on decentralized applications (dApps) or simply querying data, GetBlock simplifies the process by offering ready-to-use HTTP API endpoints with various features.
+By following this guide, developers can easily access TON Blockchain using GetBlock's infrastructure. Whether you're working on decentralized applications (DApps) or simply querying data, GetBlock simplifies the process by offering ready-to-use HTTP API endpoints with various features.
 
-Feel free to learn more at the [website](https://getblock.io/?utm_source=external&utm_medium=article&utm_campaign=ton_docs) or drop a line to GetBlock’s support via live chat, [Telegram](https://t.me/GetBlock_Support_Bot), or a website form.
+Feel free to learn more at the [website](https://getblock.io/) or drop a line to GetBlock’s support via live chat, [Telegram](https://t.me/GetBlock_Support_Bot), or a [website form](https://getblock.io/contact/).
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-dapps-apis-sdks-getblock-ton-api.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.mdx`

Related issues (from issues.normalized.md):
- [ ] **2563. Standardize access token placeholder**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.mdx?plain=1

Use the same placeholder everywhere; change all occurrences to [ACCESS-TOKEN] in prose, endpoint patterns, and examples.

---

- [ ] **2564. Replace duplicate response screenshot**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.mdx?plain=1

The response image reuses /img/docs/getblock-img/unnamed-2.png; replace the response screenshot with the correct image (e.g., /img/docs/getblock-img/unnamed-5.png).

---

- [ ] **2565. Fix indented admonition closing fence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.mdx?plain=1

Change the indented tip block terminator from " :::" to ":::” on its own line to render properly.

---

- [ ] **2566. Correct GET curl example and add language tag**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.mdx?plain=1

Label the code block (bash) and remove the unnecessary Content-Type header for the GET request; use a single-line curl with the full URL and query string.

---

- [ ] **2567. Use “JSON-RPC v2” notation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.mdx?plain=1

Replace “JSON-RPC(v2)” with “JSON-RPC v2” for conventional formatting.

---

- [ ] **2568. Fix bullet grammar and punctuation in plan sections**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.mdx?plain=1

Use periods at the end of each bullet and improve phrasing, e.g., “Entry-level option where the same nodes are used by multiple clients.” and “Provides access to archive nodes, multiple server locations, and custom settings.”

---

- [ ] **2569. Standardize “TON Blockchain” capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.mdx?plain=1

Use “TON Blockchain” consistently per internal guidance, adjusting body text and headings accordingly.

---

- [ ] **2570. Remove superfluous commas**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.mdx?plain=1

Delete the comma before “and” in “users need to log in to their accounts and retrieve a TON endpoint URL,” and remove or omit the comma after “Now” (“Now you can use these URLs …” or “You can use these URLs …”).

---

- [ ] **2571. Improve image alt texts**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.mdx?plain=1

Replace file-like alt texts with human-readable descriptions, e.g., “GetBlock homepage,” “GetBlock dashboard — My Endpoints,” “Generated TON endpoint token,” “Sample getAddressBalance response,” and describe the TON Blueprint IDE image by what it shows.

---

- [ ] **2572. Remove tracking parameters from links**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.mdx?plain=1

Strip UTM query parameters from GetBlock links and, where appropriate, link to https://getblock.io/nodes/ton/.

---

- [ ] **2573. Remove unsupported ?=RAW from image URL**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.mdx?plain=1

Delete the “?=RAW” query suffix from /img/docs/getblock-img/unnamed-2.png so the static asset is referenced correctly.

---

- [ ] **2574. Qualify or remove unverified rate limits**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.mdx?plain=1

Remove hardcoded limit figures or mark them as provider-specific and subject to change, and avoid contradictions with plan descriptions.

---

- [ ] **2575. Rename table columns for clarity**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.mdx?plain=1

Change “Method” to “HTTP method” and “Endpoint” to “Path” (or “Method name”), and add leading slashes to paths (e.g., “/getAddressState”).

---

- [ ] **2576. Align example method with table**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.mdx?plain=1

Add /getAddressBalance to the “Some other available methods” table or update the example to a method already listed.

---

- [ ] **2577. Clarify method list to match GetBlock API**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.mdx?plain=1

Ensure the methods/paths listed are from GetBlock’s API (not TON Center) and link to the official method list: https://getblock.io/docs/ton/json-rpc/ton_jsonrpc/.

---

- [ ] **2578. Replace vague “TON library” with SDK reference**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.mdx?plain=1

Use “SDK” terminology and link to the SDK list at docs/v3/guidelines/dapps/apis-sdks/sdk.mdx instead of “TON library.”

---

- [ ] **2579. Standardize capitalization to “DApps”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.mdx?plain=1

Replace “dApps” with “DApps” throughout to match the glossary.

---

- [ ] **2580. Use Title Case for tip title**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.mdx?plain=1

Change the tip title to “TON Infrastructure Status” for consistency.

---

- [ ] **2581. Clarify MetaMask sign-in mention**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.mdx?plain=1

Specify that MetaMask (or a supported wallet) is used only for GetBlock account authentication and is unrelated to TON interactions.

---

- [ ] **2582. Add link for “website form” or remove reference**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/getblock-ton-api.mdx?plain=1

Provide a working hyperlink to the referenced support form or remove the mention to avoid dead-end guidance.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.