### PR TITLE
Split: update docs/v3/guidelines/dapps/asset-processing/compressed-nfts.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/dapps/asset-processing/compressed-nfts.mdx
+++ b/docs/v3/guidelines/dapps/asset-processing/compressed-nfts.mdx
@@ -14,7 +14,7 @@ Compressed NFT (cNFT) is a specialized digital asset format that optimizes data 
 - **Enhanced security**: Merkle trees enable fast data integrity checks and robust asset protection.
 - **Cost reduction**: Shift minting costs to end users and create “virtual” on-chain items only when needed.
 
-## Supporting compressed NFT in wallets and marketplaces
+## Supporting compressed NFTs in wallets and marketplaces
 
 **Current limitations**\
 Most popular wallets and marketplaces do not display unclaimed cNFTs or NFTs from collections that are not official partners. For example, the Telegram wallet and the Getgems marketplace index only the first 200 items for unofficial collections, which poses challenges for larger collections.
@@ -106,6 +106,8 @@ Set up a server to host your API and the interface for claiming NFTs. Also, obta
    git clone https://github.com/nessshon/cnft-toolbox 
    ```
 
+   Then change to the project directory: `cd cnft-toolbox`.
+
 2. **Install dependencies**
 
    Install Docker, Docker Compose, and ngrok, and ensure they are properly configured on your machine.
@@ -122,14 +124,14 @@ Set up a server to host your API and the interface for claiming NFTs. Also, obta
    ngrok http 8080 
    ```
 
-   **For production:** Set up a custom domain and configure Nginx to proxy requests to your API on port 8080. This involves:
+   **For production:** Set up a custom domain and configure NGINX to proxy requests to your API on port 8080. This involves:
 
    - Registering a domain and pointing it to your server.
-   - Configuring Nginx to proxy requests to your API on port 8080.
+   - Configuring NGINX to proxy requests to your API on port 8080.
 
 5. **Create a `.env` file**
 
-   Duplicate the `env.example` file to `.env` and update it with your specific configuration. The table below describes each key:
+   In the repository root (same directory as `docker-compose.yml`), duplicate the `env.example` file to `.env` and update it with your specific configuration. The table below describes each key:
 
    | **Key**                   | **Description**                                                                 | **Example**                                      | **Notes**                                          |
    | ------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------ | -------------------------------------------------- |


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-dapps-asset-processing-compressed-nfts.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/dapps/asset-processing/compressed-nfts.mdx`

Related issues (from issues.normalized.md):
- [ ] **2621. Pluralize “compressed NFTs” in heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/compressed-nfts.mdx?plain=1#L17

Change the heading to “Supporting compressed NFTs in wallets and marketplaces” for grammatical correctness and consistency.

---

- [ ] **2622. Add cd after cloning**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/compressed-nfts.mdx?plain=1#L101-L108

After the git clone command, add “cd cnft-toolbox” so subsequent docker-compose commands run in the correct project directory.

---

- [ ] **2623. Standardize Nginx capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/compressed-nfts.mdx?plain=1#L128-L132

Use a consistent brand form for the web server name; choose “NGINX” (official) or “Nginx” per the style guide and apply it consistently in this section.

---

- [ ] **2624. Clarify .env file location**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/compressed-nfts.mdx?plain=1#L133-L147

State that “.env” belongs in the repository root (same directory as docker-compose.yml); e.g., “In the repository root, copy env.example to .env.”

---

- [ ] **2625. Use API_BASE_URL consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/compressed-nfts.mdx?plain=1#L173-L176

Replace “<API_URI>” in example endpoints with “<API_BASE_URL>” or define “<API_URI>” as synonymous with the API_BASE_URL value; also update the setaddr example (around L200–L205) and later references.

---

- [ ] **2626. Clarify royalty calculation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/compressed-nfts.mdx?plain=1#L191-L193

Make the formula explicit: “Royalty is calculated as <royalty-base> / <royalty-factor>; for a 10% royalty, use <royalty-base>=10 and <royalty-factor>=100.”

---

- [ ] **2627. Use “deep link” instead of “deeplink”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/compressed-nfts.mdx?plain=1#L196-L199

Replace “deeplink” with “deep link” at L196–199 and L268–270 (and elsewhere on this page) to match site-wide terminology.

---

- [ ] **2628. Fix bot section heading grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/compressed-nfts.mdx?plain=1#L214

Change “Run the Telegram bot for NFT claiming interface” to “Run the Telegram bot for the NFT-claiming interface” (adding “the” and hyphenating as a compound modifier).

---

- [ ] **2629. Replace unstable Notion link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/compressed-nfts.mdx?plain=1#L288

Replace the Notion link “Understanding compressed NFT on the TON blockchain” with a stable, canonical source (e.g., in-repo documentation or a versioned GitHub page).

---

- [ ] **2630. Correct fee terminology in Features**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/compressed-nfts.mdx?plain=1#features

Replace “reducing gas costs” with “reducing storage and forwarding fees” to accurately reflect which fees decrease when on-chain data is minimized.

---

- [ ] **2631. Refocus Features security claim on integrity**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/compressed-nfts.mdx?plain=1#features

Reword “Enhanced security” from “robust asset protection” to “Merkle trees enable efficient data integrity verification” to avoid vague claims.

---

- [ ] **2632. Remove unverified vendor limit claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/compressed-nfts.mdx?plain=1#supporting-compressed-nft-in-wallets-and-marketplaces

Remove or qualify the statement about wallets/marketplaces indexing only the first 200 items for unofficial collections unless a canonical citation is provided.

---

- [ ] **2633. Explain differing /ctl genupd parameters**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/compressed-nfts.mdx?plain=1#configuration-and-deployment-guide

Add a note clarifying why /ctl genupd sometimes takes full collection parameters and elsewhere a path plus collection address, and specify when to use each form.

---

- [ ] **2634. Qualify maximum DEPTH value**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/compressed-nfts.mdx?plain=1#claiming-api-and-interface-setup

Remove the hard-coded “maximum DEPTH is 30” or mark it as implementation-specific (e.g., “check your tool’s limits”) unless a canonical source is cited.

---

- [ ] **2635. Add production TLS and origin guidance**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/compressed-nfts.mdx?plain=1#claiming-api-and-interface-setup

In the production setup note, mention configuring TLS and ensuring API_BASE_URL matches the public origin, or state that TLS details are out of scope.

---

- [ ] **2636. Avoid implying a formal standard**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/compressed-nfts.mdx?plain=1#conclusion

Replace “The Compressed NFT standard” with “this approach/pattern” unless a formal standard is cited and linked.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.