### PR TITLE
Split: update docs/v3/guidelines/dapps/asset-processing/mass-mint-tools.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/dapps/asset-processing/mass-mint-tools.mdx
+++ b/docs/v3/guidelines/dapps/asset-processing/mass-mint-tools.mdx
@@ -2,21 +2,20 @@ import Feedback from '@site/src/components/Feedback';
 
 # Mass minting tools
 
-In an era of launching major on-chain projects with millions of users, peak loads can impact the user experience across entire TON Ecosystem.
+As major on-chain projects reach millions of users, peak loads can impact the user experience across the entire TON ecosystem.
 
-To prevent these issues and ensure a smooth launch, we recommend using the high-load distribution system provided on this page.
+To prevent these issues and ensure a smooth launch, we recommend using the high-load distribution tools listed on this page.
 
 ### Mass sender
 
 :::info
-Recommended for token airdrops. Battle-tested on Notcoin and DOGS in September.
-
+Recommended for token airdrops. Battle-tested on Notcoin and DOGS.
 :::
 
 Access: [Mass sender](https://docs.tonconsole.com/tonconsole/jettons/mass-sending)
 
 Specification:
-- Directly distributes tokens, with the project covering gas fees during claims.
+- Directly distributes tokens, with the project covering gas fees.
 - Low network load (latest versions are optimized).
 - Self-regulates load by slowing distribution when network activity is high.
 
@@ -24,41 +23,39 @@ Specification:
 
 Access: [Mintless jettons](/v3/guidelines/dapps/asset-processing/mintless-jettons)
 
-:::info
-  battle-tested on HAMSTER
-:::
-
 Specification:
-- Users claim airdrop tokens without transactions,
-- Projects don't earn from claims,
+- Users receive airdrop jettons without a separate claim transaction.
 - Minimal network load.
 
 
-### TokenTable v4
+### TokenTable
 
 :::info
-  battle-tested on Avacoin, DOGS
+Battle-tested on Avacoin and DOGS.
 :::
 
-Access: [www.tokentable.xyz](https://www.tokentable.xyz/)
+Access: [TokenTable](https://docs.tokentable.xyz/)
 
-- Higher network load than mass sender, as users make transactions when claiming,
-- Projects can also earn from user claims,
+Specification:
+- Users make claim transactions (users cover fees), resulting in higher network load than direct mass sending.
+Specification:
+- Higher network load than mass sender, as users make transactions when claiming.
+- Projects can also earn from user claims.
 - Projects pay TokenTable for setup.
 
 
 ### Gigadrop
 
 :::info
-  battle-tested on HAMSTER
+Battle-tested on HAMSTER.
 :::
 
-Access: [gigadrop.io](https://gigadrop.io/)
+Access: [Gigadrop](https://gigadrop.io/)
 
-- Higher network load than mass sender, as users make transactions when claiming,
-- Flexible load control,
-- Claim integration within your app,
+Specification:
+- Higher network load than mass sender, as users make transactions when claiming.
+- Flexible load control.
+- Claim integration within your app.
 - Projects can also earn from user claims.
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-dapps-asset-processing-mass-mint-tools.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/dapps/asset-processing/mass-mint-tools.mdx`

Related issues (from issues.normalized.md):
- [ ] **2664. Fix intro grammar and capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/mass-mint-tools.mdx?plain=1

Change “across entire TON Ecosystem” to “across the entire TON ecosystem.”

---

- [ ] **2665. Simplify awkward opening clause**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/mass-mint-tools.mdx?plain=1

Replace “In an era of launching major on-chain projects with millions of users” with “As major on-chain projects reach millions of users,”.

---

- [ ] **2666. Replace “distribution system” with “distribution tools”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/mass-mint-tools.mdx?plain=1

Change “using the high-load distribution system provided on this page” to “using the high-load distribution tools listed on this page.”

---

- [ ] **2667. Standardize info callout casing and punctuation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/mass-mint-tools.mdx?plain=1

Start each “:::info” sentence with a capital letter (e.g., “Battle-tested...”) and end with a period for consistency.

---

- [ ] **2668. Replace trailing commas in bullets with periods**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/mass-mint-tools.mdx?plain=1

In the “Mintless jettons”, “TokenTable”, and “Gigadrop” lists, replace trailing commas at the end of bullet items with periods for consistency.

---

- [ ] **2669. Correct mintless claim wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/mass-mint-tools.mdx?plain=1

Replace “Users claim airdrop tokens without transactions,” with “Users receive airdrop jettons without a separate claim transaction.”

---

- [ ] **2670. Clarify ambiguous date reference in callout**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/mass-mint-tools.mdx?plain=1

Either specify the year (e.g., “in September 2024”) or remove the month from “Battle-tested on Notcoin and DOGS in September.”

---

- [ ] **2671. Remove or correct HAMSTER case claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/mass-mint-tools.mdx?plain=1

Either remove “battle-tested on HAMSTER” as unsupported or change to “Battle-tested on HMSTR (Hamster Kombat).” with an internal citation.

---

- [ ] **2672. Fix Gigadrop feature bullets (phrasing and sourcing)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/mass-mint-tools.mdx?plain=1

Reword “Claim integration within your app” to “Integrates the claim flow into your app.” and remove or add an internal citation for “Flexible load control” and any other unsupported feature claims.

---

- [ ] **2673. Standardize “Access” link text to product names**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/mass-mint-tools.mdx?plain=1

Use product names as link text uniformly (e.g., “Access: Mintless jettons”, “Access: Mass sender”, “Access: TokenTable”, “Access: Gigadrop”) while keeping the correct target URLs.

---

- [ ] **2674. Remove unsupported project earnings claims**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/mass-mint-tools.mdx?plain=1

Remove or neutralize bullets asserting project earnings from claims (e.g., “Projects don't earn from claims.” and “Projects can also earn from user claims.”) and, if needed, replace with a neutral fee-responsibility statement without economic assertions.

---

- [ ] **2675. Remove “during claims” from Mass sender bullet**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/mass-mint-tools.mdx?plain=1

Change “Directly distributes tokens, with the project covering gas fees during claims.” to “Directly distributes tokens, with the project covering gas fees.”

---

- [ ] **2676. Standardize TokenTable naming and link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/mass-mint-tools.mdx?plain=1

Rename the section heading to “TokenTable” (drop “v4”) and change its Access link to https://docs.tokentable.xyz/.

---

- [ ] **2677. Align “Specification:” labels across sections**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/mass-mint-tools.mdx?plain=1

Add the “Specification:” label above the bullet lists in the “TokenTable” and “Gigadrop” sections to match the other sections.

---

- [ ] **2678. Remove unsupported TokenTable pricing claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/mass-mint-tools.mdx?plain=1

Delete the bullet “Projects pay TokenTable for setup.” or rephrase without asserting specific commercial terms.

---

- [ ] **2679. Clarify load comparison phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/mass-mint-tools.mdx?plain=1

Change wording like “Higher network load than mass sender, as users make transactions when claiming,” to “Users make claim transactions (users cover fees), resulting in higher network load than direct mass sending.”

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.