### PR TITLE
Split: update docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx
+++ b/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx
@@ -2,7 +2,7 @@ import Feedback from '@site/src/components/Feedback';
 
 # Metadata parsing
 
-The metadata standard covering NFTs, NFT collections, and jettons, is outlined in TON Enhancement Proposal 64 [TEP-64](https://github.com/ton-blockchain/TEPs/blob/master/text/0064-token-data-standard.md).
+The metadata standard covering NFTs, NFT collections, and jettons is outlined in TON Enhancement Proposal 64 [TEP-64](https://github.com/ton-blockchain/TEPs/blob/master/text/0064-token-data-standard.md).
 
 On TON, entities can have three types of metadata: on-chain, semi-chain, and off-chain.
 
@@ -12,7 +12,7 @@ On TON, entities can have three types of metadata: on-chain, semi-chain, and off
 
 ## Snake data encoding
 
-The Snake encoding format allows part of the data to be stored in a standardized cell, while the remaining portion is stored in a child cell recursively. The Snake encoding format must be prefixed using the 0x00 byte. The TL-B scheme:
+The Snake encoding format allows part of the data to be stored in a standardized cell, while the remaining portion is stored in a child cell recursively. In this scheme, the Snake encoding format is typically prefixed with the `0x00` byte (see note below for exceptions). The TL-B scheme:
 
 ```tlb
 tail#_ {bn:#} b:(bits bn) = SnakeData ~0;
@@ -22,6 +22,8 @@ cons#_ {bn:#} {n:#} b:(bits bn) next:^(SnakeData ~n) = SnakeData ~(n + 1);
 The Snake format stores additional data in a cell when the data exceeds the maximum size that a single cell can store. It does this by placing part of the data in the root cell and the remaining portion in the first child cell, continuing recursively until all data is stored.
 
 Below is an example of Snake format encoding and decoding in TypeScript:
+
+> Note: `bufferToChunks`, `BitBuilder`, and `BitReader` are provided by the surrounding tooling and helper utilities.
 
 ```typescript
 export function makeSnakeCell(data: Buffer): Cell {
@@ -74,11 +76,11 @@ export function flattenSnakeCell(cell: Cell): Buffer {
 }
 ```
 
-The 0x00 byte prefix is not always required in the root cell when using the Snake format, such as with off-chain NFT content. Additionally, cells are filled with bytes instead of bits to simplify parsing. To prevent issues when adding a reference in a child cell after it has already been written to its parent cell, the Snake cell is constructed in reverse order.
+The `0x00` byte prefix is not always required in the root cell when using the Snake format, such as with off-chain NFT content. Additionally, cells are filled with bytes instead of bits to simplify parsing. To prevent issues when adding a reference in a child cell after it has already been written to its parent cell, the Snake cell is constructed in reverse order.
 
 ## Chunked encoding
 
-The chunked encoding format stores data using a dictionary structure, mapping a chunk_index to a chunk. Chunked encoding must be prefixed with the 0x01 byte. The TL-B scheme:
+The chunked encoding format stores data using a dictionary structure, mapping a chunk_index to a chunk. Chunked encoding must be prefixed with the `0x01` byte. This in-structure marker is distinct from the top‑level content marker `0x01` that indicates off-chain content. The TL-B scheme:
 
 ```tlb
 chunked_data#_ data:(HashMapE 32 ^(SnakeData ~0)) = ChunkedData;
@@ -116,64 +118,46 @@ export function ParseChunkDict(cell: Slice): Buffer {
 
 | Attribute     | Type         | Requirement | Description                                                                                             |
 | ------------- | ------------ | ----------- | ------------------------------------------------------------------------------------------------------- |
-| `uri`         | ASCII string | optional    | A URI pointing to the JSON document with metadata used by the "Semi-chain content layout."              |
-| `name`        | UTF8 string  | optional    | Identifies the asset.                                                                                   |
-| `description` | UTF8 string  | optional    | Describes the asset.                                                                                    |
-| `image`       | ASCII string | optional    | A URI pointing to a resource with a MIME type image.                                                    |
-| `image_data`  | binary\*     | optional    | Either a binary representation of the image for the on-chain layout or base64 for the off-chain layout. |
+| `uri`         | ASCII string | optional    | A URI pointing to a JSON document with metadata used by the "semi-chain content layout."               |
+| `name`        | UTF-8 string | optional    | Identifies the asset.                                                                                   |
+| `description` | UTF-8 string | optional    | Describes the asset.                                                                                    |
+| `image`       | ASCII string | optional    | A URI pointing to a resource with an image MIME type.                                                   |
+| `image_data`  | binary       | optional    | Either a binary representation of the image for the on-chain layout or base64 for the off-chain layout. |
 
 ## Jetton metadata attributes
 
-1. `uri` - Optional. Used by "Semi-chain content layout". ASCII string. A URI pointing to JSON document with metadata.
-2. `name` - Optional. UTF8 string. Identifies the asset.
-3. `description` - Optional. UTF8 string. Describes the asset.
-4. `image` - Optional. ASCII string. A URI pointing to a resource with a mime type image.
-5. `image_data` - Optional. Either a binary representation of the image for onchain layout or base64 for offchain layout.
-6. `symbol` - Optional. UTF8 string. The symbol of the token - e.g. "XMPL". Used in the form "You received 99 XMPL".
-7. `decimals` - Optional. If not specified, 9 is used by default. UTF8 encoded string with number from 0 to 255. The number of decimals the token uses - e.g. 8, means that the token amount must be divided by 100000000 to get its custom representation.
-8. `amount_style` - Optional. Necessary for external applications to understand the format of displaying the number of tokens.
-
-- "n" - Displays the number of jettons as-is. For example, if a user has 100 tokens with 0 decimals, it displays "100 tokens".
-- "n-of-total" - Displays the number of jettons relative to the total supply. If totalSupply = 1000 and a user holds 100 jettons, it is displayed as "100 of 1000".
-- "%" - Displays jettons as a percentage of the total supply. If totalSupply = 1000 and a user holds 100 jettons, it is displayed as "10%".
-
-9. `render_type` - Optional. Required by external applications to understand which group a token belongs to and how to display it.
-
-- "currency" - Displays as a currency (default value).
-- "game" - Displays as an NFT while also considering the `amount_style`.
-
 | Attribute      | Type         | Requirement | Description                                                                                                                                                                                                                                                                    |
 | -------------- | ------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `uri`          | ASCII string | optional    | A URI pointing to the JSON document with metadata used by the "Semi-chain content layout."                                                                                                                                                                                     |
-| `name`         | UTF8 string  | optional    | Identifies the asset                                                                                                                                                                                                                                                           |
-| `description`  | UTF8 string  | optional    | Describes the asset                                                                                                                                                                                                                                                            |
-| `image`        | ASCII string | optional    | A URI pointing to a resource with a mime type image                                                                                                                                                                                                                            |
-| `image_data`   | binary\*     | optional    | Either a binary representation of the image of an on-chain layout or base64 for off-chain layout                                                                                                                                                                               |
-| `symbol`       | UTF8 string  | optional    | Token symbol - for example, "XMPL" and uses the form "You have received 99 XMPL"                                                                                                                                                                                               |
-| `decimals`     | UTF8 string  | optional    | The number of decimal places used by the token. If not specified, the default is 9. A UTF8-encoded string with numbers from 0 to 255. - for example, 8 means that the token amount must be divided by 100000000 to get its custom representation.                              |
-| `amount_style` |              | optional    | Required by external applications to understand the format of displaying the number of tokens. Defined using _n_, _n-of-total_, _%_.                                                                                                                                           |
-| `render_type`  |              | optional    | Needed by external applications to understand what group a token belongs to and how to display it. "currency" - displays as currency (default). "game" - display used for games, displays as NFT, but also displays the number of tokens and respects the amount_style value. |
+| `uri`          | ASCII string | optional    | A URI pointing to a JSON document with metadata used by the "semi-chain content layout."                                                                                                                                                                                      |
+| `name`         | UTF-8 string | optional    | Identifies the asset                                                                                                                                                                                                                                                           |
+| `description`  | UTF-8 string | optional    | Describes the asset                                                                                                                                                                                                                                                            |
+| `image`        | ASCII string | optional    | A URI pointing to a resource with an image MIME type                                                                                                                                                                                                                           |
+| `image_data`   | binary       | optional    | Either a binary representation of the image for the on-chain layout or base64 for the off-chain layout                                                                                                                                                                         |
+| `symbol`       | UTF-8 string | optional    | Token symbol — for example, "XMPL" — used in the form "You have received 99 XMPL"                                                                                                                                                                                              |
+| `decimals`     | UTF-8 string | optional    | The number of decimal places used by the token. If not specified, the default is 9. A UTF-8-encoded string with a number from 0 to 255 — for example, 8 means the token amount must be divided by 100000000 to get its user representation.                                     |
+| `amount_style` | string       | optional    | Required by external applications to understand the format of displaying the number of tokens. Defined using `n`, `n-of-total`, `%`.                                                                                                                                            |
+| `render_type`  | string       | optional    | Needed by external applications to understand what group a token belongs to and how to display it. `currency` — displays as currency (default). `game` — display used for games, displays as NFT, but also displays the number of tokens and respects the `amount_style` value. |
 
 > `amount_style` parameters:
 
-- _n_ - number of jettons (default value). If the user has 100 tokens with 0 decimals, then it displays that the user has 100 tokens.
-- _n-of-total_ - the number of jettons out of the total number of issued jettons. For example, if the totalSupply of jettons is 1000 and the user has 100 jettons in their wallet, it must be displayed in the user's wallet as 100 of 1000 or in another textual or graphical way to demonstrate the ratio of user tokens to the total amount of tokens available.
-- _%_ - the percentage of jettons from the total number of jettons issued. For example, if the total number of tokens is 1000 and the user has 100 tokens, the percentage should be displayed as 10% of the user's wallet balance (100 ÷ 1000 = 0.1 or 10%).
+- `n` - number of jettons (default value). If the user has 100 tokens with 0 decimals, then it displays that the user has 100 tokens.
+- `n-of-total` - the number of jettons out of the total number of issued jettons. For example, if the totalSupply of jettons is 1000 and the user has 100 jettons in their wallet, it must be displayed in the user's wallet as 100 of 1000 or in another textual or graphical way to demonstrate the ratio of user tokens to the total amount of tokens available.
+- `%` - the percentage of jettons from the total number of jettons issued. For example, if the total number of tokens is 1000 and the user has 100 tokens, the percentage should be displayed as 10% of the user's wallet balance (100 ÷ 1000 = 0.1 or 10%).
 
 > `render_type` parameters:
 
-- _currency_ - displayed as a currency (default value).
-- _game_ - display used for games that appears as an NFT but also displays the number of tokens and takes into account the `amount_style` value.
+- `currency` - displayed as a currency (default value).
+- `game` - display used for games that appears as an NFT but also displays the number of tokens and takes into account the `amount_style` value.
 
 ## Parsing metadata
 
-To parse metadata, NFT data must first be obtained from the blockchain. To better understand this process, consider reading the [retrieving NFT data](/v3/guidelines/dapps/asset-processing/nft-processing/nfts#retrieving-nft-data) section of our TON asset processing documentation section.
+To parse metadata, NFT data must first be obtained from the blockchain. To better understand this process, consider reading the [retrieving NFT data](/v3/guidelines/dapps/asset-processing/nft-processing/nfts) section of our TON asset processing documentation.
 
 After on-chain NFT data is retrieved, it must be parsed. To carry out this process, the NFT content type must be determined by reading the first byte that makes up the inner workings of the NFT.
 
 ### Off-chain
 
-f the metadata byte string starts with 0x01, it signifies off-chain NFT content. The remaining portion of the NFT content is decoded using the Snake encoding format as an ASCII string. Once the NFT URL is obtained and the NFT identification data is retrieved, the process is complete. Here is an example of a URL using off-chain NFT content metadata parsing::
+If the metadata byte string starts with `0x01`, it signifies off-chain NFT content. The remaining portion of the NFT content is decoded using the Snake encoding format as an ASCII string. Once the NFT URL is obtained and the NFT identification data is retrieved, the process is complete. Here is an example of a URL using off-chain NFT content metadata parsing:
 `https://s.getgems.io/nft/b/c/62fba50217c3fe3cbaad9e7f/95/meta.json`
 
 URL contents (from directly above):
@@ -192,9 +176,9 @@ URL contents (from directly above):
 
 If the metadata byte string starts with `0x00`, it indicates on-chain or semi-chain NFT metadata.
 
-The metadata is stored in a dictionary where the key is the SHA256 hash of the attribute name, and the value is the data stored using the Snake or Chunked format.
+The metadata is stored in a dictionary where the key is the SHA-256 hash of the attribute name, and the value is the data stored using the Snake or Chunked format.
 
-To determine the NFT type, a developer must read known NFT attributes such as `uri`, `name`, `image`, `description`, and `image_data`. If the `uri` field is present within the metadata, it indicates a semi-chain layout, requiring the off-chain content specified in uri to be downloaded and merged with the dictionary values.
+To determine the NFT type, a developer must read known NFT attributes such as `uri`, `name`, `image`, `description`, and `image_data`. If the `uri` field is present within the metadata, it indicates a semi-chain layout, requiring the off-chain content specified in `uri` to be downloaded and merged with the dictionary values.
 
 Examples:
 
@@ -208,9 +192,9 @@ On-chain NFT parser: [stackblitz/ton-onchain-nft-parser](https://stackblitz.com/
 
 ## Important notes on NFT metadata
 
-1. For NFT metadata, the `name`, `description`, and `image`(or `image_data`) fields are required to display the NFT.
-2. For jetton metadata, the `name`, `symbol`, `decimals` and `image`(or `image_data`) fields are primary.
-3. Anyone can create an NFT or Jetton using any `name`, `description`, or `image`. To prevent scams and confusion, apps should clearly distinguish NFTs from other assets.
+1. For NFT metadata, the `name`, `description`, and `image` (or `image_data`) fields are commonly used to display the NFT.
+2. For jetton metadata, the `name`, `symbol`, `decimals` and `image` (or `image_data`) fields are commonly used.
+3. Anyone can create an NFT or jetton using any `name`, `description`, or `image`. To prevent scams and confusion, apps should clearly distinguish NFTs from other assets.
 4. Some items may include a `video` field linking to video content associated with the NFT or jetton.
 
 ## References


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-dapps-asset-processing-nft-processing-metadata-parsing.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx`

Related issues (from issues.normalized.md):
- [ ] **2693. Remove extra comma after “jettons”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L5

“The metadata standard covering NFTs, NFT collections, and jettons, is outlined …” → remove the comma after “jettons”.

---

- [ ] **2694. Clarify Snake 0x00 prefix requirement**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L15,L77

Soften “must be prefixed using 0x00” to “is typically prefixed with `0x00` in this scheme (see note below for exceptions)” to avoid contradiction with the later exception.

---

- [ ] **2695. Format hex byte literals as code**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L15,L81,L176,L193

Wrap all hex byte literals (e.g., 0x00, 0x01) in backticks for consistency and readability.

---

- [ ] **2696. Note missing helpers in code examples**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L27-L74,L89-L113

Add a note that `bufferToChunks`, `BitBuilder`, and `BitReader` come from the surrounding tooling (or include minimal definitions), with a reference to the helper implementation.

---

- [ ] **2697. Disambiguate 0x01 usage (chunked vs off-chain)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L81,L176

Clarify that top-level `0x01` indicates off-chain content while the chunking marker applies within the encoding context; adjust wording to make scopes explicit.

---

- [ ] **2698. Add article before “JSON document”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L119,L127

Use “A URI pointing to a JSON document …”.

---

- [ ] **2699. Normalize “semi-chain” to lowercase in quoted names**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L119,L127,L147

Change “Semi-chain content layout” to “semi-chain content layout” inside quotes for consistency.

---

- [ ] **2700. Replace “UTF8” with “UTF-8”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L120-L121,L128-L133,L148-L153

Use the standard “UTF-8” spelling in all instances (including “UTF-8-encoded”).

---

- [ ] **2701. Capitalize and rephrase “MIME type”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L122,L130,L150

Use “MIME type” (uppercase) and clearer phrasing, e.g., “a URI pointing to a resource with an image MIME type.”

---

- [ ] **2702. Remove unexplained asterisk from “binary*”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L123,L151

Drop the asterisk from the `binary` type (the descriptions already explain on-chain binary vs off-chain base64).

---

- [ ] **2703. Consolidate duplicate jetton attribute definitions**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L127-L166,L147-L156

Remove the numbered list and keep the table (after terminology fixes) to eliminate duplication and inconsistencies.

---

- [ ] **2704. Standardize to “on-chain”/“off-chain”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L131

Replace “onchain/offchain” with “on-chain/off-chain” consistently.

---

- [ ] **2705. Fix punctuation and wording in `decimals` description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L133,L153

Use “e.g., 8 means …”, “a number from 0 to 255”, and remove any stray hyphens; prefer “user representation” over “custom representation”.

---

- [ ] **2706. Align `decimals` type with the rest of the docs**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L133,L153

Define `decimals` as a number (integer in the range 0–255) rather than a UTF-8 string to match jettons documentation, and update the list/table accordingly.

---

- [ ] **2707. Clarify `image_data` wording (jettons table)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L151

Rewrite as: “Either a binary representation of the image for the on-chain layout or base64 for the off-chain layout.”

---

- [ ] **2708. Fix grammar in jetton `symbol` description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L152

Use an em dash and improve flow: “Token symbol — for example, "XMPL" — used in the form “You have received 99 XMPL”.”

---

- [ ] **2709. Add missing Type values in jetton table**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L154-L155

Set the “Type” column for `amount_style` and `render_type` to “string”.

---

- [ ] **2710. Standardize option literal formatting**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L157-L166

Use backticks for all `amount_style` and `render_type` option names (e.g., `n`, `n-of-total`, `%`, `fiat`, `crypto`, `game`, `amount`, `score`, `level`).

---

- [ ] **2711. Fix broken link and redundant “section”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L170

Change the link to “/v3/guidelines/dapps/asset-processing/nft-processing/nfts” (no non-existent anchor) and remove the repeated word: “… documentation section.”

---

- [ ] **2712. Correct Off-chain subsection typo and punctuation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L176-L177

Change “f the metadata byte string …” to “If the metadata byte string …”, replace “parsing::” with “parsing:”, and wrap `0x01` in backticks.

---

- [ ] **2713. Use “SHA-256” spelling**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L195

Replace “SHA256” with “SHA-256”.

---

- [ ] **2714. Add backticks around the second `uri`**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L197

Format the second occurrence as code: “content specified in `uri` …”.

---

- [ ] **2715. Insert missing spaces before parentheses in notes**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L211-L212

Add a space: “`image` (or `image_data`)”.

---

- [ ] **2716. Rephrase normative claims in notes**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L211-L212

Change “required to display”/“are primary” to non-normative language such as “commonly used to display”.

---

- [ ] **2717. Lowercase “jetton” mid-sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx?plain=1#L213

Change “Jetton” to “jetton” for consistency.

---

- [ ] **3308. Clarify Toncoin decimals and jetton precision**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Replace “Mainnet supports a 9-digit accuracy for currencies” with “Toncoin uses 9 decimals; jettons define decimals per token (often 9),” and add citations to docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx and docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx#properties.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.