### PR TITLE
Split: update docs/v3/guidelines/dapps/asset-processing/payments-processing.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/dapps/asset-processing/payments-processing.mdx
+++ b/docs/v3/guidelines/dapps/asset-processing/payments-processing.mdx
@@ -267,7 +267,7 @@ ton://transfer/<destination-address>?
 
 ## Explorers
 
-[tonviewer.com](https://tonviewer.com), [tonscan.org](https://tonscan.org) and [explorer.toncoin.org](https://explorer.toncoin.org/) can display the page for a transaction. To generate a transaction link in an explorer, the service needs to get the lt (logical time), the transaction hash, and the account address (the address of the account for which the `lt` and `txhash` were obtained using the [getTransactions](toncenter.com/api/v2/#/transactions/get_transactions_getTransactions_get) method). Then  [tonviewer.com](https://tonviewer.com), [tonscan.org](https://tonscan.org), and [explorer.toncoin.org](https://explorer.toncoin.org/) can display the page for this transaction in the following format:
+To generate a transaction link, the service must obtain the account address, logical time (lt), and transaction hash by calling the [getTransactions](toncenter.com/api/v2/#/transactions/get_transactions_getTransactions_get) method. Using these values, [tonviewer.com](https://tonviewer.com), [tonscan.org](https://tonscan.org) and [explorer.toncoin.org](https://explorer.toncoin.org/) explorers render the transaction page according to the following formats:
 
 `https://tonviewer.com/transaction/{hash as base64url}`
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-dapps-asset-processing-payments-processing.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/dapps/asset-processing/payments-processing.mdx`

Related issues (from issues.normalized.md):
- [x] **2745. Fix incoming/outgoing transaction lookup**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/payments-processing.mdx?plain=1#retrieve-incoming-outgoing-transactions

The bullets invert which helper to use; swap them so incoming transactions check `in_msg` with `tryLocateSourceTx` and outgoing transactions check `out_msg` with `tryLocateResultTx`.

---

- [x] **2746. Use “non-bounceable” term consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/payments-processing.mdx?plain=1#wallet-deployment

Replace “non-bounce”/“non-bounce flag” with “non-bounceable” to align with terminology used elsewhere in the docs.

---

- [ ] **2747. Remove or cite “use revision 0 by default”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/payments-processing.mdx?plain=1#wallet-deployment

Either remove the unverified “use revision 0 by default” recommendation for `getAccountAddress` or add a citation to a canonical page that establishes this default.

---

- [x] **2748. Remove unsupported numeric storage fee claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/payments-processing.mdx?plain=1#send-payments

Replace “Storage fees are typically less than 1 Toncoin per year” with a non-numeric statement linking to fees docs (e.g., “Keep the wallet funded to cover storage fees”: docs/v3/documentation/smart-contracts/transaction-fees/fees-low-level.mdx#storage-fee).

---

- [ ] **2749. Clarify wallet type and avoid hardcoded expiration**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/payments-processing.mdx?plain=1#send-payments

Correct the wallet variant wording (e.g., `wallet.v3` vs `wallet.highload.v2`) and remove the “60-second default” unless you add a supporting citation.

---

- [x] **2750. Reconcile deprecation note for ton:// links**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/payments-processing.mdx?plain=1#invoices-with-ton-link

Reword to acknowledge deprecation and limit usage (e.g., “Although deprecated, for simple one-time flows you may still generate a ton:// link; prefer TON Connect.”).

---

- [ ] **2751. Remove “official explorer” claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/payments-processing.mdx?plain=1#explorers

Drop the “official” label and list explorers neutrally to avoid conflicting claims across the docs.

---

- [ ] **2752. Include tonviewer in explorers sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/payments-processing.mdx?plain=1#explorers

Update the lead sentence to include tonviewer.com (e.g., “tonviewer.com, tonscan.org and explorer.toncoin.org can display…”), matching the URL formats shown.

---

- [x] **2753. Fix Java catch clause syntax**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/payments-processing.mdx?plain=1#checking-wallet-address-validity

Change `catch (e)` to valid Java syntax `catch (Exception e)`.

---

- [ ] **2754. Standardize Python code fence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/payments-processing.mdx?plain=1#wallet-creation

Change the code fence from ```py to ```python for consistent syntax highlighting.

---

- [x] **2755. Remove extra spaces after workchain value**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/payments-processing.mdx?plain=1#wallet-deployment

Collapse the multiple spaces after `workchain=0` to a single space (“`workchain=0` to minimize…”).

---

- [x] **2756. Fix mnemonic placeholder typo**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/payments-processing.mdx?plain=1#toncoin-withdrawals-send-toncoins

Change “one two tree ...” to “one two three ...” in the example mnemonic.

---

- [x] **2757. Make Go address-parse snippet compile**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/payments-processing.mdx?plain=1#checking-wallet-address-validity

Add `import "errors"` and wrap the parse/check in a function (e.g., `func main()`) so `return errors.New(...)` is valid and the snippet compiles.

---

- [ ] **2758. Generalize invoice ID recommendation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/payments-processing.mdx?plain=1#invoice-based-approach

Replace the over-specific “uuid32” suggestion with a format-agnostic requirement, e.g., “Generate a unique invoice identifier per user (for example, a UUID).”

---

- [ ] **2759. Correct deposit filter logic**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/asset-processing/payments-processing.mdx?plain=1#invoice-based-approach

Require an incoming message by changing the check to `if not tx.in_msg: return False`, so the filter returns True only when there is one incoming and zero outgoing messages.

---

- [x] **3150. Add deprecation note for ton:// links**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tutorials/telegram-bot-examples/accept-payments-in-a-telegram-bot-2.mdx?plain=1

Add a short note in the Deposit section that ton:// links are deprecated and link to alternatives in docs/v3/guidelines/dapps/asset-processing/payments-processing.mdx#invoices-with-ton-link.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.