### PR TITLE
Split: update docs/v3/guidelines/dapps/cookbook.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/dapps/cookbook.mdx
+++ b/docs/v3/guidelines/dapps/cookbook.mdx
@@ -14,7 +14,7 @@ During product development, various questions often arise regarding interactions
 
 ### How to convert between user-friendly and raw addresses, assemble, and extract them from strings?
 
-TON addresses uniquely identify contracts on TON Blockchain, indicating their workchain and original state hash. [Two common formats](/v3/documentation/smart-contracts/addresses#raw-and-user-friendly-addresses) are: **raw** (workchain and HEX-encoded hash separated by the ":" character) and **user-friendly** (base64-encoded with certain flags).
+TON addresses uniquely identify contracts on TON Blockchain, indicating their workchain and original state hash. [Two common formats](/v3/documentation/smart-contracts/addresses/address-formats) are: **raw** (workchain and HEX-encoded hash separated by the ":" character) and **user-friendly** (base64-encoded with certain flags).
 
 ```
 User-friendly: EQDKbjIcfM6ezt8KjKJJLshZJJSqX7XOA4ff-W72r5gqPrHF
@@ -32,8 +32,8 @@ To obtain a TON address object from a string in your SDK, you can use the follow
     const address1 = Address.parse('EQDKbjIcfM6ezt8KjKJJLshZJJSqX7XOA4ff-W72r5gqPrHF');
     const address2 = Address.parse('0:ca6e321c7cce9ecedf0a8ca2492ec8592494aa5fb5ce0387dff96ef6af982a3e');
 
-    // toString arguments: urlSafe, bounceable, testOnly
-    // default values: true, true, false
+    // toStrings arguments: urlSafe, bounceable, testOnly
+    // defaults values: true, true, false
 
     console.log(address1.toString()); // EQDKbjIcfM6ezt8KjKJJLshZJJSqX7XOA4ff-W72r5gqPrHF
     console.log(address1.toRawString()); // 0:ca6e321c7cce9ecedf0a8ca2492ec8592494aa5fb5ce0387dff96ef6af982a3e
@@ -107,7 +107,7 @@ To obtain a TON address object from a string in your SDK, you can use the follow
 
 ### Flags in user-friendly addresses
 
-There are two flags in user-friendly addresses: **bounceable**/**non-bounceable** and **testnet**/**any-net**. These flags are represented in the first character of the address, which corresponds to the first 6 bits of the address encoding. These flags can be detected by looking at the first character, according to [TEP-2](https://github.com/ton-blockchain/TEPs/blob/master/text/0002-address.md#smart-contract-addresses):
+There are two flags in user-friendly addresses: **bounceable**/**non-bounceable** and **Testnet-only**. These flags are represented in the first character of the address, which corresponds to the first 6 bits of the address encoding. These flags can be detected by looking at the first character, according to [TEP-2](https://github.com/ton-blockchain/TEPs/blob/master/text/0002-address.md#smart-contract-addresses):
 
 | Address beginning | Binary form | Bounceable | Testnet-only |
 | :---------------: | :---------: | :--------: | :----------: |
@@ -129,8 +129,8 @@ Also, in some libraries, you may notice a serialization parameter called `urlSaf
 
     const address = Address.parse('EQDKbjIcfM6ezt8KjKJJLshZJJSqX7XOA4ff-W72r5gqPrHF');
 
-    // toStrings arguments: urlSafe, bounceable, testOnly
-    // defaults values: true, true, false
+    // toString arguments: urlSafe, bounceable, testOnly
+    // default values: true, true, false
 
     console.log(address.toString()); // EQDKbjIcfM6ezt8KjKJJLshZJJSqX7XOA4ff-W72r5gqPrHF
     console.log(address.toString({urlSafe: false})) // EQDKbjIcfM6ezt8KjKJJLshZJJSqX7XOA4ff+W72r5gqPrHF
@@ -324,7 +324,7 @@ Most SDKs follow a similar process for sending messages from your wallet:
       seqno,
       secretKey: keyPair.secretKey,
       messages: [internal({
-        value: '1',
+        value: toNano('1'),
         to: 'EQCD39VS5jcptHL8vMjEXrzGaRcCVYto7HUn4bpAOg8xqB2N',
         body: 'Example transfer body',
       })]
@@ -435,7 +435,7 @@ Most SDKs follow a similar process for sending messages from your wallet:
   </TabItem>
 </Tabs>
 
-### Writing comments: long strings in snake format
+### Writing comments: long strings in snake cells
 
 Sometimes, it's necessary to store large strings in cells, but the maximum size for a cell is 1023 bits. In these cases, you can use snake cells, which reference other cells recursively.
 
@@ -458,7 +458,7 @@ Sometimes, it's necessary to store large strings in cells, but the maximum size 
     }
 
     function readStringTail(slice) {
-        const str = new TextDecoder('ascii').decode(slice.array); // decode uint8array to string
+        const str = new TextDecoder('utf-8').decode(slice.array); // decode uint8array to string
         if (slice.refs.length > 0) {
             return str + readStringTail(slice.refs[0]); // read next cell
         } else {
@@ -889,7 +889,7 @@ However, if you know the jetton wallet code and storage structure, you can calcu
 
     ```
 
-    Read the simple example [here](/example-code-snippets/pythoniq/jetton-offline-address-calc-wrapper.py).
+    Read the simple example [here](/static/example-code-snippets/pythoniq/jetton-offline-address-calc-wrapper.py).
   </TabItem>
 </Tabs>
 
@@ -989,7 +989,7 @@ Of course, one can always do calculation in indivisible units.
         const jettonTransferBody = new TonWeb.boc.Cell();
         jettonTransferBody.bits.writeUint(0xf8a7ea5, 32); // opcode for jetton transfer
         jettonTransferBody.bits.writeUint(0, 64); // query id
-        jettonTransferBody.bits.writeCoins(new TonWeb.utils.BN('5')); // jetton amount, amount * 10^9
+        jettonTransferBody.bits.writeCoins(TonWeb.utils.toNano('5')); // jetton amount, amount * 10^9
         jettonTransferBody.bits.writeAddress(destinationAddress);
         jettonTransferBody.bits.writeAddress(destinationAddress); // response destination
         jettonTransferBody.bits.writeBit(false); // no custom payload
@@ -2104,7 +2104,7 @@ Create a listener function that will assert specific transaction on certain acco
                     const inBOC = inMsg?.body;
                     if (typeof inBOC === 'undefined') {
 
-                        reject(new Error('Invalid external'));
+                        throw new Error('Invalid external');
                         continue;
                     }
                     const extHash = Cell.fromBase64(exBoc).hash().toString('hex')

--- a/docs/v3/guidelines/dapps/cookbook.mdx
+++ b/docs/v3/guidelines/dapps/cookbook.mdx
@@ -32,8 +32,8 @@ To obtain a TON address object from a string in your SDK, you can use the follow
     const address1 = Address.parse('EQDKbjIcfM6ezt8KjKJJLshZJJSqX7XOA4ff-W72r5gqPrHF');
     const address2 = Address.parse('0:ca6e321c7cce9ecedf0a8ca2492ec8592494aa5fb5ce0387dff96ef6af982a3e');
 
-    // toStrings arguments: urlSafe, bounceable, testOnly
-    // defaults values: true, true, false
+    // toString arguments: urlSafe, bounceable, testOnly
+    // default values: true, true, false
 
     console.log(address1.toString()); // EQDKbjIcfM6ezt8KjKJJLshZJJSqX7XOA4ff-W72r5gqPrHF
     console.log(address1.toRawString()); // 0:ca6e321c7cce9ecedf0a8ca2492ec8592494aa5fb5ce0387dff96ef6af982a3e
@@ -55,7 +55,7 @@ To obtain a TON address object from a string in your SDK, you can use the follow
     console.log(address1.toString(true, true, true)); // EQDKbjIcfM6ezt8KjKJJLshZJJSqX7XOA4ff-W72r5gqPrHF
     console.log(address1.toString(false)); // 0:ca6e321c7cce9ecedf0a8ca2492ec8592494aa5fb5ce0387dff96ef6af982a3e
 
-    console.log(address1.toString(true, true, true)); // EQDKbjIcfM6ezt8KjKJJLshZJJSqX7XOA4ff-W72r5gqPrHF
+    console.log(address2.toString(true, true, true)); // EQDKbjIcfM6ezt8KjKJJLshZJJSqX7XOA4ff-W72r5gqPrHF
     console.log(address2.toString(false)); // 0:ca6e321c7cce9ecedf0a8ca2492ec8592494aa5fb5ce0387dff96ef6af982a3e
     ```
   </TabItem>
@@ -302,6 +302,7 @@ Most SDKs follow a similar process for sending messages from your wallet:
   <TabItem value="js-ton-v4" label="JS (@ton) for Wallet V4">
     ```ts
     import { TonClient, WalletContractV4, internal } from "@ton/ton";
+    import { toNano } from "@ton/core";
     import { mnemonicNew, mnemonicToPrivateKey } from "@ton/crypto";
 
     const client = new TonClient({
@@ -402,7 +403,7 @@ Most SDKs follow a similar process for sending messages from your wallet:
                     storeBytes("Comment".toByteArray())
                 }
             )
-            sendMode = 0
+            sendMode = 3
         })
     }
     ```
@@ -905,7 +906,7 @@ When constructing a message for a jetton transfer, refer to [TEP-74](https://git
 
 <div class="text--center">
   <ThemedImage
-    alt=""
+    alt="Jetton transfer message flow diagram"
     sources={{
   light: '/img/docs/ecosystem-messages-layout/ecosystem_messages_layout_5.svg?raw=true',
   dark: '/img/docs/ecosystem-messages-layout/ecosystem_messages_layout_5_dark.svg?raw=true',
@@ -973,7 +974,7 @@ Of course, one can always do calculation in indivisible units.
                 apiKey: '<YOUR_API_KEY>'
             })
         );
-        const destinationAddress = new TonWeb.Address('put destination wallet address');
+        const destinationAddress = new TonWeb.utils.Address('put destination wallet address');
 
         const forwardPayload = new TonWeb.boc.Cell();
         forwardPayload.bits.writeUint(0, 32); // 0 opcode means we have a comment
@@ -989,7 +990,8 @@ Of course, one can always do calculation in indivisible units.
         const jettonTransferBody = new TonWeb.boc.Cell();
         jettonTransferBody.bits.writeUint(0xf8a7ea5, 32); // opcode for jetton transfer
         jettonTransferBody.bits.writeUint(0, 64); // query id
-        jettonTransferBody.bits.writeCoins(TonWeb.utils.toNano('5')); // jetton amount, amount * 10^9
+        // jetton amount must be scaled by token decimals (commonly 9)
+        jettonTransferBody.bits.writeCoins(TonWeb.utils.toNano('5')); // example: 5 tokens with 9 decimals
         jettonTransferBody.bits.writeAddress(destinationAddress);
         jettonTransferBody.bits.writeAddress(destinationAddress); // response destination
         jettonTransferBody.bits.writeBit(false); // no custom payload
@@ -1247,8 +1249,8 @@ Changing the owner of a collection is simple. Specify the `opcode = 3`, any `que
                 apiKey: '<YOUR_API_KEY>'
             })
         );
-        const collectionAddress  = new TonWeb.Address('put your collection address');
-        const newOwnerAddress = new TonWeb.Address('put new owner wallet address');
+        const collectionAddress  = new TonWeb.utils.Address('put your collection address');
+        const newOwnerAddress = new TonWeb.utils.Address('put new owner wallet address');
 
         const messageBody  = new TonWeb.boc.Cell();
         messageBody.bits.writeUint(3, 32); // opcode for changing owner
@@ -1358,10 +1360,10 @@ Often, the collection's metadata is stored in a format similar to `0.json` and c
                 apiKey: '<YOUR_API_KEY>'
             })
         );
-        const collectionAddress  = new TonWeb.Address('put your collection address');
-        const newCollectionMeta = 'put url fol collection meta';
+        const collectionAddress  = new TonWeb.utils.Address('put your collection address');
+        const newCollectionMeta = 'put url for collection meta';
         const newNftCommonMeta = 'put common url for nft meta';
-        const royaltyAddress = new TonWeb.Address('put royalty address');
+        const royaltyAddress = new TonWeb.utils.Address('put royalty address');
 
         const collectionMetaCell = new TonWeb.boc.Cell();
         collectionMetaCell.bits.writeUint(1, 8); // we have off-chain metadata
@@ -1787,7 +1789,8 @@ Below is an example on how you can fetch 5 most recent transactions on any block
 <Tabs groupId="code-examples">
   <TabItem value="js-ton" label="JS (@ton)">
     ```js
-    import { Address, TonClient, beginCell, fromNano } from '@ton/ton';
+    import { Address, beginCell, fromNano } from '@ton/core';
+    import { TonClient } from '@ton/ton';
 
     async function main() {
         const client = new TonClient({


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-dapps-cookbook.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/dapps/cookbook.mdx`

Related issues (from issues.normalized.md):
- [ ] **1491. Fix SDK reference to Address.spec.ts**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/addresses/address-formats.mdx?plain=1#address-conversion

Replace the root ton-core repo link with internal cross-references to docs/v3/guidelines/dapps/cookbook.mdx#how-to-convert-between-user-friendly-and-raw-addresses-assemble-and-extract-them-from-strings and docs/v3/guidelines/dapps/apis-sdks/sdk.mdx; if keeping an external reference, update it to the stable file URL https://github.com/ton-org/ton-core/blob/main/src/address/Address.spec.ts.

---

- [ ] **1501. Cite or remove hex flag constants**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/addresses/address-formats.mdx?plain=1#user-friendly-address

Either add an explicit citation (e.g., TEP‑2 or docs/v3/guidelines/dapps/cookbook.mdx#flags-in-user-friendly-addresses) for 0x11/0x51/0x80, or remove these literals and describe the flags behavior without hard‑coding hex values.

---

- [x] **2760. Fix broken link to address formats**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/cookbook.mdx?plain=1#L17

The “Two common formats” link points to a nonexistent anchor; change the target to /v3/documentation/smart-contracts/addresses/address-formats.

---

- [x] **2761. Standardize TonWeb Address class usage**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/cookbook.mdx?plain=1#L50-L52, L976, L1250-L1251, L1362-L1364

Use TonWeb.utils.Address consistently across the page (instead of mixing with new TonWeb.Address) to avoid confusion.

---

- [x] **2762. Log address2 in TonWeb example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/cookbook.mdx?plain=1#L55-L60

Change console.log(address1.toString(true, true, true)); to console.log(address2.toString(true, true, true)); to print both forms for address2 as intended.

---

- [x] **2763. Use “Testnet-only” flag terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/cookbook.mdx?plain=1#L110

Replace “testnet/any-net” with “Testnet-only” to align with the addresses/address-formats terminology.

---

- [x] **2764. Fix typos in comment (“toString”, “default values”)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/cookbook.mdx?plain=1#L132-L139

Correct “toStrings arguments” to “toString arguments” and “defaults values” to “default values”.

---

- [x] **2765. Clarify TON amount units with toNano**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/cookbook.mdx?plain=1#L327

Replace value: '1' with value: toNano('1') and import toNano to make the nanotons unit explicit.

---

- [x] **2766. Update Kotlin sendMode or justify**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/cookbook.mdx?plain=1#L405

Use sendMode = 3 (include IGNORE_ERRORS) per safety guidance, or add a note explaining why sendMode = 0 is intentional for this SDK.

---

- [x] **2767. Rename heading to “snake cells”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/cookbook.mdx?plain=1#L438-L441

Rename the heading to “Writing comments: long strings in snake cells” to match established terminology.

---

- [x] **2768. Decode with UTF-8, not ASCII**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/cookbook.mdx?plain=1#L461-L470

Replace new TextDecoder('ascii') with new TextDecoder('utf-8') to correctly handle non-ASCII characters.

---

- [x] **2769. Fix or remove broken example link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/cookbook.mdx?plain=1#L892

The link to /example-code-snippets/pythoniq/jetton-offline-address-calc-wrapper.py is invalid; replace it with a valid in-repo path or remove the link.

---

- [x] **2770. Add alt text to jetton transfer diagram**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/cookbook.mdx?plain=1#L906-L913

Provide a descriptive alt attribute (e.g., alt="Jetton transfer message flow diagram") for accessibility.

---

- [x] **2771. Scale jetton amount by token decimals**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/cookbook.mdx?plain=1#L989-L997

Replace new TonWeb.utils.BN('5') with a value scaled by the jetton’s decimals (e.g., TonWeb.utils.toNano('5') for 9 decimals or BN(amount * 10^decimals)).

---

- [x] **2772. Fix typo “fol” → “for” in NFT collection update**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/cookbook.mdx?plain=1#L1363

Change 'put url fol collection meta' to 'put url for collection meta'.

---

- [x] **2773. Throw instead of calling undefined reject**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/cookbook.mdx?plain=1#L2104-L2109

Replace reject(new Error('Invalid external')) with throw new Error('Invalid external') in the async function.

---

- [ ] **2774. Unify TS Address import source**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/cookbook.mdx?plain=1

Import Address consistently from a single package (e.g., import { Address } from '@ton/core') unless a specific snippet requires otherwise.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.