### PR TITLE
Split: update docs/v3/guidelines/dapps/overview.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/dapps/overview.mdx
+++ b/docs/v3/guidelines/dapps/overview.mdx
@@ -3,7 +3,7 @@ import Feedback from '@site/src/components/Feedback';
 import Button from '@site/src/components/button';
 
 # Getting started
-Before diving into DApps, make sure you understand blockchain fundamentals. You may find our [The Open Network](/v3/concepts/dive-into-ton/introduction) and [Blockchain of blockchains](/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains) articles useful.
+Before diving into DApps, make sure you understand blockchain fundamentals. You may find our [The Open Network](/v3/concepts/dive-into-ton/introduction) and [Blockchain](/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains) articles useful.
 
 TON DApps are applications that interact with the blockchain, often without a traditional backend. In most cases, they work with custom [smart contracts](/v3/documentation/smart-contracts/overview). This documentation explains how to process standard assets available in TON, both as examples and to accelerate DApp development.
 
@@ -23,78 +23,46 @@ Choose an SDK
 </Button>
 
 
+## Tools
 
-## TON course: DApps
+Here are key resources for your DApp development journey:
 
-:::tip
-Before starting the course, make sure you have a solid understanding of blockchain basics. If you need a refresher, we recommend taking the [Blockchain basics with TON](https://stepik.org/course/201294/promo) ([RU version](https://stepik.org/course/202221/), [CHN version](https://stepik.org/course/200976/)) course.
-Module 3 covers core dApp concepts.
-:::
-
-The [TON Blockchain course](https://stepik.org/course/176754/) is a comprehensive guide to TON Blockchain development.
-
-Modules 5 and 6 comprehensively cover DApp development. You'll learn how to build a DApp, work with TON Connect, use SDKs, and interact with the blockchain.
-
-
-<Button href="https://stepik.org/course/176754/promo"
-        colorType="primary" sizeType="sm">
-
-Explore the TON Blockchain course
-
-</Button>
-
-
-<Button href="https://stepik.org/course/201638/promo"
-        colorType="secondary" sizeType="sm">
-
-Chinese
-
-</Button>
-
-
-<Button href="https://stepik.org/course/201855/promo"
-        colorType="secondary" sizeType="sm">
-
-Russian
-
-</Button>
-
-
-## Basic tools and resources
-
-Here are key resources for your dApp development journey:
-
-1. [Developer wallets](/v3/concepts/dive-into-ton/ton-ecosystem/wallet-apps)
-2. [Blockchain explorers](/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton)
-3. [API documentation](/v3/guidelines/dapps/apis-sdks/api-types)
-4. [SDKs for various languages](/v3/guidelines/dapps/apis-sdks/sdk)
-5. [Using the testnet](/v3/documentation/smart-contracts/getting-started/testnet)
+1. [Wallets](/v3/concepts/dive-into-ton/ton-ecosystem/wallet-apps)
+2. [Explorers](/v3/concepts/dive-into-ton/ton-ecosystem/explorers-in-ton)
+3. [APIs](/v3/guidelines/dapps/apis-sdks/api-types)
+4. [SDKs](/v3/guidelines/dapps/apis-sdks/sdk)
+5. [The Testnet](/v3/documentation/smart-contracts/getting-started/testnet)
 6. [TON unfreezer](https://unfreezer.ton.org/)
+
+
+### Assets
+
+These resources explain asset types in TON:
+
+- [Toncoin](/v3/documentation/dapps/defi/coins)
+- [Jetton](/v3/documentation/dapps/assets/jetton)
+- [NFT](/v3/documentation/dapps/assets/nft)
+- [USDT](/v3/documentation/dapps/assets/usdt)
+
 
 ### Asset management
 
 Working with assets? These guides cover the essentials:
 
+- [Mastering the transaction](/v3/guidelines/dapps/transactions/overview)
 - [Payments processing](/v3/guidelines/dapps/asset-processing/payments-processing)
 - [Token (jetton) processing](/v3/guidelines/dapps/asset-processing/jettons)
 - [Handling NFTs](/v3/guidelines/dapps/asset-processing/nft-processing/nfts)
 - [Parsing metadata](/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing)
 
-### Introduction to DeFi
 
-Interested in decentralized finance (DeFi)? These resources explain how to manage different asset types:
-
-- [Understanding Toncoin](/v3/documentation/dapps/defi/coins)
-- [Tokens: jettons & NFTs](/v3/documentation/dapps/defi/tokens)
-- [TON payments](/v3/documentation/dapps/defi/ton-payments)
-- [Setting up subscriptions](/v3/documentation/dapps/defi/subscriptions)
 
 ## Tutorials and examples
 
 ### DeFi basics
 
-- Create your first token: [Mint your first jetton](/v3/guidelines/dapps/tutorials/mint-your-first-token)
-- Step-by-step: [NFT collection minting](/v3/guidelines/dapps/tutorials/nft-minting-guide)
+- [Mint your first jetton](/v3/guidelines/dapps/tutorials/mint-your-first-token)
+- [NFT collection minting](/v3/guidelines/dapps/tutorials/nft-minting-guide)
 
 ### Language-specific guides
 
@@ -125,24 +93,43 @@ Interested in decentralized finance (DeFi)? These resources explain how to manag
 - [iOS standard wallet (Swift)](https://github.com/ton-blockchain/wallet-ios)
 - [TonLib CLI (C++)](https://github.com/ton-blockchain/ton/blob/master/tonlib/tonlib/tonlib-cli.cpp)
 
-## 👨‍💻 Contribution
-
-Missing some crucial material? You can either write a tutorial yourself or describe the issue to the community.
 
 
-<Button href="/v3/contribute/participate" colorType="primary" sizeType="sm">
 
-Contribute
+## TON course: DApps
+
+The [TON Blockchain course](https://stepik.org/course/176754/) is a comprehensive guide to TON Blockchain development.
+
+Modules 5 and 6 comprehensively cover DApp development. You'll learn how to build a DApp, work with TON Connect, use SDKs, and interact with the blockchain.
+
+
+<Button href="https://stepik.org/course/176754/promo"
+colorType="primary" sizeType="sm">
+
+English
 
 </Button>
 
 
-<Button href="https://github.com/ton-community/ton-docs/issues/new?assignees=&labels=feature+%3Asparkles%3A%2Ccontent+%3Afountain_pen%3A&template=suggest_tutorial.yaml&title=Suggest+a+tutorial" colorType="secondary" sizeType="sm">
+<Button href="https://stepik.org/course/201638/promo"
+colorType="secondary" sizeType="sm">
 
-Suggest a tutorial
+Chinese
 
 </Button>
 
 
+<Button href="https://stepik.org/course/201855/promo"
+colorType="secondary" sizeType="sm">
+
+Russian
+
+</Button>
+
+
+## See also
+- [Cookbook](/v3/guidelines/dapps/cookbook)
 
 <Feedback />
+
+


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-dapps-overview.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/dapps/overview.mdx`

Related issues (from issues.normalized.md):
- [ ] **2775. Standardize dApp capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/overview.mdx?plain=1

The page mixes “dApps”, “dApp”, and “DApp”; standardize to “dApp” (singular) and “dApps” (plural) everywhere, replacing all inconsistent instances.

---

- [ ] **2776. Add missing semicolon to Button import**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/overview.mdx?plain=1#L3

The import statement lacks a trailing semicolon; add it for consistency with surrounding imports.

---

- [ ] **2777. Soften ‘without a backend’ claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/overview.mdx?plain=1#L8

The line overgeneralizes that dApps have no backend; change to “TON dApps are applications that interact with the blockchain, often without a traditional backend.”

---

- [ ] **2778. Clarify Telegram Mini Apps phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/overview.mdx?plain=1#L10

“Followed by Telegram Mini Apps” is ambiguous; change to “Most developers build them as websites; Telegram Mini Apps are the next most common.”

---

- [ ] **2779. Use quoted string literals for JSX props**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/overview.mdx?plain=1#L12-L23,L39-L60

String props use both {'...'} and "..." syntaxes; use double-quoted string literals consistently (e.g., colorType="primary", sizeType="sm").

---

- [ ] **2780. Pluralize ‘Modules’ and remove redundancy**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/overview.mdx?plain=1#L36

Fix grammar and redundancy by changing “Module 5 and 6 completely fully cover …” to “Modules 5 and 6 comprehensively cover dApp development.”

---

- [ ] **2781. Improve CTA label for TON course**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/overview.mdx?plain=1#L42

“Check TON Blockchain course” is unnatural; change to “Explore the TON Blockchain course.”

---

- [ ] **2782. Use language names instead of codes on buttons**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/overview.mdx?plain=1#L50-L58

Replace “CHN” and “RU” button labels with “Chinese” and “Russian” (optionally “Chinese (CHN)” and “Russian (RU)”).

---

- [ ] **2783. Hyphenate ‘Step-by-step’**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/overview.mdx?plain=1#L97

Change “Step by Step” to the standard “Step-by-step”.

---

- [ ] **2784. Change ‘Payment process’ to ‘Payment processing’**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/overview.mdx?plain=1#L103

Use the idiomatic term “Payment processing” in the link text.

---

- [ ] **2785. Capitalize ‘TON Bridge’**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/overview.mdx?plain=1#L104

Use proper noun casing by changing “TON bridge” to “TON Bridge”.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.