### PR TITLE
Split: update docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx
+++ b/docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx
@@ -1,6 +1,6 @@
 import Feedback from '@site/src/components/Feedback';
 
-import ConceptImage from '@site/src/components/conceptImage'
+import ConceptImage from '@site/src/components/conceptImage';
 
 # Testing Mini Apps
 
@@ -8,9 +8,9 @@ import ConceptImage from '@site/src/components/conceptImage'
 
 To log in to the test environment, use one of the following methods:
 
-- **iOS:** Tap 10 times on the Settings icon. Navigate to > Accounts > Login to another account > Test.
-- **Telegram Desktop:** Open ☰ Settings > Shift + Alt + Right click **Add Account** and select **Test Server**.
-- **macOS:** Click the Settings icon 10 times to open the Debug Menu. `⌘` + Click **Add Account** and log in using your phone number.
+- **iOS:** Tap the Settings icon 10 times. Go to Accounts > Log in to another account > Test.
+- **Telegram Desktop:** Open ☰ Settings > Shift+Alt+right-click **Add Account** and select **Test Server**.
+- **macOS:** Click the Settings icon 10 times to open the Debug Menu. ⌘-click **Add Account** and log in using your phone number.
 
 The test environment is completely separate from the main environment. You must create a **new user account** and a **new bot** using [@BotFather](https://t.me/BotFather).
 
@@ -19,7 +19,9 @@ Once you have received your bot token, send requests to the Bot API using this f
 
 `https://api.telegram.org/bot<token>/test/METHOD_NAME`
 
-**Note:** When using the test environment, you may use HTTP links without TLS to test your Mini App.
+:::note
+When using the test environment, you may use HTTP URLs without TLS to test your Mini App.
+:::
 
 ## Debug mode for Mini Apps
 
@@ -27,10 +29,10 @@ Use the following tools to identify app-specific issues in your Mini App.
 
 ### Android
 
-- [Enable USB-Debugging](https://developer.chrome.com/docs/devtools/remote-debugging/) on your device.
-- In Telegram Settings, scroll to the bottom, press and hold the **version number** two times.
+- [Enable USB debugging](https://developer.chrome.com/docs/devtools/remote-debugging/) on your device.
+- In Telegram Settings, scroll to the bottom. Long-press the **version number**.
 - Choose *Enable WebView Debug* in Debug Settings.
-- Connect your phone to your computer and open chrome://inspect/#devices in Chrome.
+- Connect your phone to your computer and open `chrome://inspect/#devices` in Chrome.
 - Launch your Mini App on your phone, and it will appear in Chrome’s Inspect Devices tab.
 
 ### iOS
@@ -40,7 +42,7 @@ iOS WebView debugging requires the Safari desktop browser on macOS.
 **On iOS device:**
 - Go to *Settings*.
 - Scroll down and tap Safari.
-- Scroll to the bottom and press *Advanced*.
+- Scroll to the bottom and tap *Advanced*.
 - Enable *Web Inspector*.
 
 **On macOS:**
@@ -51,22 +53,22 @@ iOS WebView debugging requires the Safari desktop browser on macOS.
 
 **Next steps:**
 - Connect your iOS device to the Mac via USB cable.
-- Open Mini App inside iOS Telegram client.
+- Open the Mini App inside the Telegram app on iOS.
 - In Safari on macOS, go to *Develop* in the menu bar.
 - Select the connected iPhone.
-- (Optional) select *Connect via network* and disconnect the cable.
+- (Optional) Select *Connect via network* and disconnect the cable.
 - Under the *Telegram* block, select the opened WebView URL.
 
 ### Telegram Desktop on Windows, Linux, and macOS
 
-- Download and launch the latest version of Telegram Desktop on **Windows**, **Linux** or **macOS** (5.0.1 at the time of writing)
-- Go to *Settings > Advanced > Experimental settings > Enable webview inspection*.
-- on Windows and Linux, right-click in the WebView and choose *Inspect*.
-- On macOS, you need to access the Inspect through [Safari Developer menu](https://support.apple.com/en-gb/guide/safari/sfri20948/mac) as Inspect is not available via right-click.
+- Download and launch the latest version of Telegram Desktop on **Windows**, **Linux**, or **macOS**.
+- Go to *Settings > Advanced > Experimental settings > Enable WebView inspection*.
+- On Windows and Linux, right-click in the WebView and choose *Inspect*.
+- On macOS, access Inspect through the [Develop menu in Safari](https://support.apple.com/guide/safari/sfri20948/mac) as Inspect is not available via right-click.
 
-### Telegram macOS
+### Telegram for macOS
 
-- Download and launch the [beta version](https://telegram.org/dl/macos/beta) of Telegram macOS.
+- Download and launch the [beta version](https://telegram.org/dl/macos/beta) of Telegram for macOS (a separate client from Telegram Desktop).
 - Quickly click the Settings icon five times to open the debug menu and enable **Debug Mini Apps**.
 
 Right-click inside the Mini App and choose *Inspect Element*.
@@ -75,26 +77,26 @@ Right-click inside the Mini App and choose *Inspect Element*.
 
 [Eruda](https://github.com/liriliri/eruda) is a tool that provides a web-based console for debugging and inspecting web pages on mobile devices and desktop browsers.
 
-![1](/img/docs/telegram-apps/eruda-1.png)
+![Eruda console UI](/img/docs/telegram-apps/eruda-1.png)
 
-### Step 1: include Eruda library
+### Step 1: Include Eruda Library
 
 To begin, add the Eruda library to your HTML file:
 
-**Option 1:** use a CDN (recommended).
+**Option 1:** Use a CDN (recommended).
 
 ```html
 <!-- Include Eruda from CDN (Recommended) -->
 <script src="https://cdn.jsdelivr.net/npm/eruda"></script>
 ```
 
-**Option 2:** install via npm.
+**Option 2:** Install via npm.
 
 ```bash npm2yarn
-npm install eruda --save
+npm install eruda
 ```
 
-### Step 2: initialise Eruda
+### Step 2: Initialize Eruda
 
 If using the CDN, initialize Eruda when the page loads:
 
@@ -109,22 +111,21 @@ If using the CDN, initialize Eruda when the page loads:
 
 If you prefer modern tooling and packages, add this script to your project:
 
-```jsx
+```js
 import eruda from 'eruda'
 
 eruda.init()
 ```
 
-### Step 3: launch Eruda
+### Step 3: Launch Eruda
 
 After deploying your Mini App:
 
 - Open it in Telegram.
 - Press the Eruda icon to start debugging.
 
-<ConceptImage style={{maxWidth:'200pt', margin: '10pt 20pt 0 0', display: 'flex-box'}} src="/img/docs/telegram-apps/eruda-2.png" />
-<ConceptImage style={{maxWidth:'200pt', margin: '10pt 20pt', display: 'flex-box'}}  src="/img/docs/telegram-apps/eruda-3.png" />
+<ConceptImage alt="Eruda button in Mini App UI" style={{maxWidth:'200px', margin: '10pt 20pt 0 0', display: 'flex'}} src="/img/docs/telegram-apps/eruda-2.png" />
+<ConceptImage alt="Eruda panels and console output" style={{maxWidth:'200px', margin: '10pt 20pt', display: 'flex'}}  src="/img/docs/telegram-apps/eruda-3.png" />
 
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-dapps-tma-guidelines-testing-apps.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx`

Related issues (from issues.normalized.md):
- [ ] **2825. Add semicolon to ConceptImage import**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx?plain=1#L3

Add a trailing semicolon for consistency: import ConceptImage from '@site/src/components/conceptImage';.

---

- [ ] **2826. Fix iOS menu path phrasing and grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx?plain=1#L11

Remove the stray chevron and use clear wording: “Go to Accounts > Log in to another account > Test.”.

---

- [ ] **2827. Standardize keyboard shortcut formatting**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx?plain=1#L12-L13

Use consistent shortcut styling: “Shift+Alt+right-click” and “⌘-click” (or “Command-click”) for Add Account.

---

- [ ] **2828. Use “HTTP URLs” and convert note to admonition**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx?plain=1#L22

Replace “HTTP links without TLS” with “HTTP URLs without TLS” and format the callout as an admonition (:::note … :::).

---

- [ ] **2829. Android: correct “USB debugging” spelling**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx?plain=1#L30

Change “USB-Debugging” to “USB debugging”.

---

- [ ] **2830. Android: clarify debug interaction**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx?plain=1#L31

Replace “press and hold the version number two times” with a single precise action: “Long-press the version number.”.

---

- [ ] **2831. Format chrome:// URL as code**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx?plain=1#L33

Wrap the URI in backticks: `chrome://inspect/#devices`.

---

- [ ] **2832. Use iOS-appropriate verb “tap”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx?plain=1#L43

Change “press Advanced” to “tap Advanced”.

---

- [ ] **2833. Improve grammar in iOS step**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx?plain=1#L54

Rewrite to “Open the Mini App inside the Telegram app on iOS.”.

---

- [ ] **2834. Capitalize sentence after (Optional)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx?plain=1#L57

Capitalize the verb: “(Optional) Select Connect via network.”.

---

- [ ] **2835. Remove hardcoded Telegram Desktop version**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx?plain=1#L62

Delete “(5.0.1 at the time of writing)” and say “Download and launch the latest version of Telegram Desktop on Windows, Linux, or macOS.”.

---

- [ ] **2836. Capitalize WebView consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx?plain=1#L63

Use “WebView” casing in “Enable WebView inspection”.

---

- [ ] **2837. Capitalize Windows/Linux bullet and hyphenate right-click**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx?plain=1#L64

Start with a capital and use proper hyphenation: “On Windows and Linux, right-click in the WebView and choose Inspect.”.

---

- [ ] **2838. Use correct Safari menu name and canonical link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx?plain=1#L65

Replace “Safari Developer menu” with “Develop menu in Safari” and update the link to the non-localized Apple documentation URL.

---

- [ ] **2839. Use official client name and clarify distinction**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx?plain=1#L67

Change “Telegram macOS” to “Telegram for macOS” and note that it is a separate client from Telegram Desktop.

---

- [ ] **2840. Provide descriptive alt text for images**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx?plain=1#L78

Replace the alt text “1” with a meaningful description (e.g., “Eruda console UI”) and add concise alt text to the subsequent ConceptImage images.

---

- [ ] **2841. Capitalize and parallelize step headings**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx?plain=1#L80-L118

Use consistent Title Case and imperative verbs: “Step 1: Include Eruda Library,” “Step 2: Initialize Eruda,” “Step 3: Launch Eruda.”.

---

- [ ] **2842. Simplify npm install command**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx?plain=1#L93-L95

Drop the redundant flag and use “npm install eruda” (the npm2yarn fence will generate equivalents).

---

- [ ] **2843. Standardize to American English “Initialize”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx?plain=1#L97-L106

Replace “initialise” with “Initialize” to match code and house style.

---

- [ ] **2844. Use js code fence for plain JavaScript**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx?plain=1#L112-L116

Change the fence from jsx to js for accurate syntax highlighting.

---

- [ ] **2845. Fix invalid CSS display value**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx?plain=1#L125-L126

Replace display: 'flex-box' with a valid value (e.g., display: 'flex').

---

- [ ] **2846. Prefer web-friendly CSS units**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/testing-apps.mdx?plain=1#L125-L126

Change maxWidth: '200pt' to a web-friendly unit such as '200px' (or rem).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.