### PR TITLE
Split: update docs/v3/guidelines/dapps/tma/guidelines/tips-and-tricks.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/dapps/tma/guidelines/tips-and-tricks.mdx
+++ b/docs/v3/guidelines/dapps/tma/guidelines/tips-and-tricks.mdx
@@ -1,21 +1,21 @@
 import Feedback from '@site/src/components/Feedback';
 
-# Tips and tricks
+# Tips and Tricks
 
 On this page, you'll find a list of frequently asked questions about issues in TMA.
 
-### How to solve the cache overflow issue in TMA?
+### How do I resolve the cache overflow issue in a TMA?
 
 :::tip
-Reinstalling the Telegram application is the only effective solution.
+Reinstalling the Telegram application is a reliable solution.
 :::
 
-### Are there any recommendations on caching headers for HTML files?
+### Are there recommended caching headers for HTML files?
 
 :::tip
-It’s best to disable caching in HTML files. To ensure caching is turned off, specify the following headers in your request:
+It’s best to disable caching in HTML files. To ensure caching is turned off, specify the following headers in the response:
 
-```curl
+```http
 Cache-Control: no-store, must-revalidate
 Pragma: no-cache
 Expires: 0
@@ -23,11 +23,11 @@ Expires: 0
 
 :::
 
-### What is suggested IDE for development TMA?
+### What is the suggested browser for TMA development?
 
 Developing in Google Chrome is more convenient due to its familiar developer tools.
 
-To retrieve the mini-app's launch parameters and open this link in Chrome, use the web version of Telegram: [https://web.telegram.org/](https://web.telegram.org/)
+To retrieve the Mini App's initialization data, open the Mini App link in Chrome via Telegram Web (https://web.telegram.org/).
 
 ### Closing behavior
 
@@ -41,16 +41,16 @@ In many web applications, users may accidentally close the app while scrolling t
   <br />
 </p>
 
-To prevent accidental closures, enable `closing_behavior` in TMA. This method adds a confirmation dialog, where the user can either approve or decline closing of the Web App.
+To prevent accidental closures, enable closing confirmation in TMA with `window.Telegram.WebApp.enableClosingConfirmation()`. This method adds a confirmation dialog where the user can either approve or cancel closing the Mini App.
 
 ```typescript
 window.Telegram.WebApp.enableClosingConfirmation()
 ```
 
-## How to specify a description for a certain language in the TMA?
+### How do I specify a description for a specific language for my TMA?
 
 :::tip
-Use the following methods to configure descriptions in different languages:
+Use the following methods to set the bot’s description in clients for different languages:
 
 - [https://core.telegram.org/bots/api#setmydescription](https://core.telegram.org/bots/api#setmydescription)
 - [https://core.telegram.org/bots/api#setmyshortdescription](https://core.telegram.org/bots/api#setmyshortdescription)


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-dapps-tma-guidelines-tips-and-tricks.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/dapps/tma/guidelines/tips-and-tricks.mdx`

Related issues (from issues.normalized.md):
- [ ] **2847. Use Title Case in H1**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/tips-and-tricks.mdx?plain=1#L3

Change “Tips and tricks” to “Tips and Tricks” for consistency with page titles.

---

- [ ] **2848. Rephrase cache overflow question idiomatically**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/tips-and-tricks.mdx?plain=1#L7

Change the heading to “How do I resolve the cache overflow issue in a TMA?” for natural phrasing and correct article usage.

---

- [ ] **2849. Fix caching headers question and response wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/tips-and-tricks.mdx?plain=1#L13

Change “Are there any recommendations on caching headers for HTML files?” to “Are there recommended caching headers for HTML files?” and state that these are response headers returned by the server (replace “in your request” with “in the response”).

---

- [ ] **2850. Set correct code block language for HTTP headers**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/tips-and-tricks.mdx?plain=1#L18-L22

The block shows raw HTTP header lines, not a curl command; change the fence from “```curl” to “```http” (or “```text”) for correct highlighting.

---

- [ ] **2851. Align heading with content (browser, not IDE)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/tips-and-tricks.mdx?plain=1#L26-L30

Rename the heading to “What is the suggested browser for TMA development?” and fix grammar (“TMA development”) to match the recommendation of Chrome DevTools.

---

- [ ] **2852. Clarify Chrome instruction and use “initialization data”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/tips-and-tricks.mdx?plain=1#L30

Replace “open this link in Chrome” with “open the Mini App link in Chrome via Telegram Web (https://web.telegram.org/)”, use “Mini App” capitalization, and replace “launch parameters” with “initialization data”.

---

- [ ] **2853. Standardize “behavior” spelling and descriptive alt text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/tips-and-tricks.mdx?plain=1#L32-L41

Use US spelling “behavior” in the text and alt text, and replace the non-descriptive alt “closing_behaviour_durgerking” with a meaningful description such as “Mini App closing behavior illustration” (leave the asset filename unchanged).

---

- [ ] **2854. Use closing confirmation API and improve phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/tips-and-tricks.mdx?plain=1#L44-L45

Replace the undefined `closing_behavior` with “closing confirmation” and reference `window.Telegram.WebApp.enableClosingConfirmation()`; remove the comma after “dialog” and change “decline closing of the Web App” to “cancel closing the Mini App,” using “Mini App” consistently.

---

- [ ] **2855. Make localization heading level and wording consistent**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/tips-and-tricks.mdx?plain=1#L50

Change the heading level from “##” to “###” and rephrase to “How do I specify a description for a specific language for my TMA?”; in the answer, clarify that the linked methods set the bot’s description in clients.

---

- [ ] **2856. Soften exclusivity claim about reinstalling Telegram**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/guidelines/tips-and-tricks.mdx?plain=1

Replace “is the only effective solution” with “is a reliable solution” to avoid an unsupported absolute claim.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.