### PR TITLE
Split: update docs/v3/guidelines/dapps/tma/overview.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/dapps/tma/overview.mdx
+++ b/docs/v3/guidelines/dapps/tma/overview.mdx
@@ -29,8 +29,8 @@ Mini Apps run within Telegram and are instantly accessible — without the need 
 - **User authentication**: Securely authenticate users using Telegram’s built-in login mechanism, with signed user data passed to the app.
 - **Bot interaction**: Bots handle backend processing, user interaction, session state, and real-time messaging.
 - **Web-based development**: Built with HTML, CSS, and JavaScript, leveraging Telegram’s APIs to create feature-rich applications.
-- **Integrated payments**: Use Wallet Pay for crypto and fiat payments.
-- **Monetization**: Wallet Pay and on-chain subscriptions.
+- **Integrated payments**: Supports over 20 providers, including Google Pay and Apple Pay.
+- **Monetization**: subscriptions, in-app purchases, and advertising models are supported.
 - **Web3 and TON support**: Featuring TON SDK, TON Connect, and token-based transactions, allowing seamless integration with blockchain-powered applications.
 - **Community development**: Telegram has a strong developer ecosystem, where third-party developers actively create and share TMAs, fostering innovation and diversity.
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-dapps-tma-overview.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/dapps/tma/overview.mdx`

Related issues (from issues.normalized.md):
- [x] **2875. Standardize TMA parenthetical in frontmatter**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/overview.mdx?plain=1#L2

Replace “Telegram Mini Apps (or TMAs)” with “Telegram Mini Apps (TMAs)” for consistency with body usage.

---

- [x] **2876. Remove user count; use "within" and "installation"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/overview.mdx?plain=1#L21

Generalize and refine the sentence to: “Mini Apps run within Telegram and are instantly accessible — without the need for installation or redirects.”

---

- [x] **2877. Add "and" to technology list**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/overview.mdx?plain=1#L31

Change “Built with HTML, CSS, JavaScript…” to “Built with HTML, CSS, and JavaScript…” for correct coordination.

---

- [ ] **2878. Align Integrated payments bullet with Wallet Pay guidance**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/overview.mdx?plain=1#L32

Replace the line with: “Integrated payments: Use Wallet Pay for crypto and fiat payments.”

---

- [ ] **2879. Update Monetization bullet to documented models**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/overview.mdx?plain=1#L33

Replace the line with: “Monetization: Wallet Pay and on-chain subscriptions.”

---

- [x] **2880. Replace ampersand with "and" in feature label**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/overview.mdx?plain=1#L34

Change “Web3 & TON support” to “Web3 and TON support” for formal style consistency.

---

- [x] **2881. Use "Mini App development" phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/overview.mdx?plain=1#L46

Change “to discuss Mini Apps development” to “to discuss Mini App development.”

---

- [x] **2882. Change "for TMA" to "for TMA development" in SDK table**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/overview.mdx?plain=1#L60

Update the row text to read “…a simple, lightweight, tree-shakeable UI library for TMA development.”

---

- [x] **2883. Use "inline mode," not "inline queries"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/overview.mdx?plain=1#key-features

Replace “launching from chats, groups, or inline queries” with “launching from chats, groups, or inline mode.”

---

- [x] **2884. Clarify TON SDK tip scope**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/overview.mdx?plain=1#mini-apps-sdks

Revise the tip to: “If your Mini App interacts with the TON Blockchain, choose a JavaScript/TypeScript SDK.”

---

- [x] **3154. Add cross-link to Telegram Mini Apps overview**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tutorials/telegram-bot-examples/accept-payments-in-a-telegram-bot-2.mdx?plain=1

Add a link in the caution to docs/v3/guidelines/dapps/tma/overview.mdx for navigability.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.