### PR TITLE
Split: update docs/v3/guidelines/dapps/tma/tutorials/app-examples.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/dapps/tma/tutorials/app-examples.mdx
+++ b/docs/v3/guidelines/dapps/tma/tutorials/app-examples.mdx
@@ -10,7 +10,7 @@ Explore the examples below to learn how to create your own Telegram Mini App.
 
 <p align="center">
   <br />
-    <img width="240" src="/img/docs/telegram-apps/tapps.png" alt="logo of telegram mini apps" />
+    <img width="240" src="/img/docs/telegram-apps/tapps.png" alt="Logo of Telegram Mini Apps" />
       <br />
 </p>
 
@@ -29,7 +29,7 @@ Open demo
 </Button>
 
 
-<Button href="https://github.com/Telegram-Mini-Apps-Dev/vanilla-js-boilerplate.git" colorType={'secondary'} sizeType={'sm'}>
+<Button href="https://github.com/Telegram-Mini-Apps-Dev/vanilla-js-boilerplate" colorType={'secondary'} sizeType={'sm'}>
 
 GitHub
 
@@ -68,7 +68,7 @@ cd vanilla-js-boilerplate
 2. Make any necessary modifications.
 3. Create your own GitHub repository, commit, and push your updates.
 4. In GitHub, navigate to Settings > Pages > Build and Deployment.
-5. If GitHub Actions is enabled, your assets will deploy automatically, and you'll receive a public URL like:`https://<username>.github.io/vanilla-js-boilerplate/`.
+5. If GitHub Actions is enabled, your assets will deploy automatically, and you'll receive a public URL like: `https://<username>.github.io/vanilla-js-boilerplate/`.
 6. Use this URL with [@BotFather](https://t.me/BotFather) to create your own Telegram Mini App (TMA).
 
 ## Modern TMA example
@@ -98,7 +98,7 @@ $ yarn create vite
 
 Follow the on-screen prompts.
 
-Or you can simply run this command to create a React project with TypeScript Support:
+Or you can simply run this command to create a React project with TypeScript support:
 
 ```bash
 # npm 7+, extra double-dash is needed:
@@ -125,19 +125,19 @@ yarn
 yarn dev --host
 ```
 
-The `--host` option provides a URL with an IP address, which can be used for testing during development. In development mode, a self-signed SSL certificate is used. This allows testing with hot reload only in the web version of Telegram [https://web.telegram.org](https://web.telegram.org/a/#6549734463) due to platform restrictions on iOS, Android, and macOS.
+The `--host` option provides a URL with an IP address, which can be used for testing during development. After installing and enabling `@vitejs/plugin-basic-ssl`, the dev server uses a self-signed SSL certificate. This allows testing with hot reload only in the web version of Telegram [https://web.telegram.org/a/](https://web.telegram.org/a/) due to platform restrictions on iOS, Android, and macOS.
 
 ```bash npm2yarn
 npm install @vitejs/plugin-basic-ssl
 ```
 
-Then change `vite.config.ts`. Add import:
+Then update `vite.config.ts`: add the import:
 
 ```ts
 import basicSsl from '@vitejs/plugin-basic-ssl';
 ```
 
-And add the plugin
+And add the plugin:
 
 ```ts
 export default defineConfig({
@@ -152,7 +152,7 @@ You can use `ngrok` to expose your local server to the internet with an SSL cert
 ngrok http 5173
 ```
 
-Also, we are going to prepare our project for deployment:
+Prepare the project for deployment:
 
 ```ts
 export default defineConfig({
@@ -184,7 +184,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ['master']
+    branches: ['main']
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -232,8 +232,8 @@ jobs:
         uses: actions/deploy-pages@v1
 ```
 
-In GitHub repository settings, go to Settings → Pages and choose GitHub Actions for Build and Deployment. After each push to master, GitHub Pages will automatically deploy your code.
-![Screenshot 2023-09-11 at 22.07.44.png](/img/docs/telegram-apps/modern-1.png)
+In GitHub repository settings, go to Settings → Pages and choose GitHub Actions for Build and Deployment. After each push to the default branch, GitHub Pages will automatically deploy your code.
+![GitHub Pages build and deployment settings](/img/docs/telegram-apps/modern-1.png)
 
 Telegram provides an SDK via a direct [link](https://core.telegram.org/bots/webapps#initializing-web-apps), but using `@twa-dev/sdk` offers TypeScript support and better integration.
 
@@ -242,7 +242,7 @@ Telegram provides an SDK via a direct [link](https://core.telegram.org/bots/weba
 npm install @twa-dev/sdk
 ```
 
-Open the `/src/main.tsx` file and add the following:
+Open the `src/main.tsx` file and add the following:
 
 ```tsx
 import WebApp from '@twa-dev/sdk'
@@ -296,13 +296,13 @@ function App() {
 export default App
 ```
 
-And now we need to create a Telegram Bot so that we can launch Telegram Mini App within the messenger application.
+Now create a Telegram bot so you can launch the Mini App within the Telegram app.
 
 ### Setting up a bot for the app
 
 To launch the Telegram Mini App within the messenger, you need to create a bot and configure it. Follow these steps:
 
-<Button href="/v3/guidelines/dapps/tma/tutorials/step-by-step-guide#setting-up-a-bot-for-the-mini-app" colorType={'primary'} sizeType={'sm'}>
+<Button href="/v3/guidelines/dapps/tma/tutorials/step-by-step-guide/#setting-up-a-bot-for-the-mini-app" colorType={'primary'} sizeType={'sm'}>
 
 Set up a bot
 
@@ -314,6 +314,6 @@ When using a self-signed SSL certificate, you may see security warnings.
 
 **Fix:** Click **Advanced** and then **Proceed to `<local dev server address>`** to continue debugging in the web version of Telegram.
 
-![Screenshot 2023-09-11 at 18.58.24.png](/img/docs/telegram-apps/modern-2.png)
+![Browser SSL warning for self‑signed certificate](/img/docs/telegram-apps/modern-2.png)
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-dapps-tma-tutorials-app-examples.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/dapps/tma/tutorials/app-examples.mdx`

Related issues (from issues.normalized.md):
- [ ] **2885. Capitalize alt text for logo**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/app-examples.mdx?plain=1#L13

Capitalize proper nouns in the image alt: change alt="logo of telegram mini apps" to alt="Logo of Telegram Mini Apps".

---

- [ ] **2886. Remove .git suffix from repo link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/app-examples.mdx?plain=1#L32

Change the GitHub repository link to the canonical non-.git URL: https://github.com/Telegram-Mini-Apps-Dev/vanilla-js-boilerplate.

---

- [ ] **2887. Add space before inline code URL**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/app-examples.mdx?plain=1#L71

Add a space after “like:” so it reads “like: `https://<username>.github.io/vanilla-js-boilerplate/`”.

---

- [ ] **2888. Remove shell prompts from commands**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/app-examples.mdx?plain=1#L90-L97

Remove leading “$ ” from commands for copy‑paste consistency (e.g., “npm create vite@latest”, “yarn create vite”).

---

- [ ] **2889. Use lowercase in "TypeScript support"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/app-examples.mdx?plain=1#L101

Use lowercase “support” when not part of a proper noun: “TypeScript support”.

---

- [ ] **2890. Fix article and tense in comment**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/app-examples.mdx?plain=1#L110

Change to “# this changes the directory to the recently created project”.

---

- [ ] **2891. Fix Telegram Web link to stable /a/ URL**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/app-examples.mdx?plain=1#L128

Make the link text and target stable and matching: [https://web.telegram.org/a/](https://web.telegram.org/a/).

---

- [ ] **2892. Clarify HTTPS in dev requires SSL plugin**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/app-examples.mdx?plain=1#L128-L133

Clarify that the dev server uses a self‑signed certificate only after installing and enabling @vitejs/plugin-basic-ssl.

---

- [ ] **2893. Add colon after "And add the plugin"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/app-examples.mdx?plain=1#L140-L146

End the lead‑in with a colon: “And add the plugin:”.

---

- [ ] **2894. Align Actions branch with default branch**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/app-examples.mdx?plain=1#L186-L187, L235

Make the YAML trigger target the repository’s default branch (e.g., branches: ['main']) and say “After each push to the default branch”.

---

- [ ] **2895. Use relative path for src/main.tsx**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/app-examples.mdx?plain=1#L245

Remove the leading slash: “Open the `src/main.tsx` file”.

---

- [ ] **2896. Simplify Telegram bot sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/app-examples.mdx?plain=1#L299-L300

Streamline to “Now create a Telegram bot so you can launch the Mini App within the Telegram app.”

---

- [ ] **2897. Add trailing slash in internal link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/app-examples.mdx?plain=1

Update the “Set up a bot” link to include a trailing slash before the anchor: /v3/guidelines/dapps/tma/tutorials/step-by-step-guide/#setting-up-a-bot-for-the-mini-app.

---

- [ ] **2898. Improve "vite.config.ts" import instruction**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/app-examples.mdx?plain=1

Rephrase to “Then update `vite.config.ts`: add the import:”.

---

- [ ] **2899. Streamline deployment section lead-in**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/app-examples.mdx?plain=1

Change “Also, we are going to prepare our project for deployment:” to “Prepare the project for deployment:”.

---

- [ ] **2900. Use descriptive alt text for screenshots**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/app-examples.mdx?plain=1

Replace filename-based alt texts with descriptive phrases (e.g., “GitHub Pages build and deployment settings”, “Browser SSL warning for self‑signed certificate”).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.