### PR TITLE
Split: update docs/v3/guidelines/dapps/tma/tutorials/design-guidelines.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/dapps/tma/tutorials/design-guidelines.mdx
+++ b/docs/v3/guidelines/dapps/tma/tutorials/design-guidelines.mdx
@@ -48,7 +48,13 @@ The example above clearly shows what will change on iOS; for the `bg_color`/`sec
 
 6. For cells that trigger a destructive action, use `destructive_text_color` instead of a custom color.
 
-![Destructive text color example](/img/docs/tma-design-guidelines/tma-design_7.png)
+<p align="center">
+  <br />
+
+  <img width="360" src="/img/docs/tma-design-guidelines/tma-design_7.png" alt="Destructive text color example" />
+
+  <br />
+</p>
 
 7. Use `hint_color` for hint text under sections; on backgrounds like `secondary_bg_color`, use `link_color`.
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-dapps-tma-tutorials-design-guidelines.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/dapps/tma/tutorials/design-guidelines.mdx`

Related issues (from issues.normalized.md):
- [x] **2901. Define TMA on first use**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/design-guidelines.mdx?plain=1#L3-L6

Define "Telegram Mini Apps (TMA)" at first mention and then use "TMA" consistently.

---

- [x] **2902. Use consistent Mini Apps terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/design-guidelines.mdx?plain=1#L6

Change "Mini App color palette" to "the color palette for Mini Apps" for consistency.

---

- [x] **2903. Convert single-item numbered list in Changelog**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/design-guidelines.mdx?plain=1#L12-L16

Replace the single numbered item under "Changelog" with a bullet list item to avoid a one-item numbered list.

---

- [x] **2904. Add descriptive alt text to all images**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/design-guidelines.mdx?plain=1#L16,L33,L37,L41,L45,L49,L56

Provide meaningful alt text for each image by filling the Markdown brackets and the HTML img alt attribute.

---

- [x] **2905. Replace Unicode bullets with Markdown list**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/design-guidelines.mdx?plain=1#L20-L24

Replace lines starting with "•" with "-" Markdown list markers; keep token names in backticks and avoid wrapping full sentences in code.

---

- [x] **2906. Clarify Android notes and fix comma usage**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/design-guidelines.mdx?plain=1#L31

Rephrase to "Many new colors have been added, with most noticeable on Android; the examples focus on Android but apply to all platforms," and clarify that "there should be no changes on Android" applies only to the `bg_color`/`secondary_bg_color` update.

---

- [x] **2907. Fix subject–verb agreement for header colors**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/design-guidelines.mdx?plain=1#L35

Change "Telegram header colors has become available for Mini Apps." to "Telegram header colors have become available for Mini Apps."

---

- [x] **2908. Backtick token names consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/design-guidelines.mdx?plain=1#L39

Wrap "accent_text_color" and "link_color" in backticks and prefer "developers" over "everyone" in the sentence.

---

- [x] **2909. Streamline accessibility phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/design-guidelines.mdx?plain=1#L43

Change "improve the accessibility" to "improve accessibility."

---

- [x] **2910. Use article in destructive color guidance**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/design-guidelines.mdx?plain=1#L51

Change "use `destructive_text_color` instead of custom color" to "use `destructive_text_color` instead of a custom color."

---

- [ ] **2911. Replace brittle HTML alignment and breaks**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/design-guidelines.mdx?plain=1#L53-L59

Replace the centered HTML image and <br /> with standard Markdown image syntax and rely on CSS/utility classes for alignment and spacing.

---

- [x] **2912. Replace rhetorical question and redundant phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/design-guidelines.mdx?plain=1#L63

Replace the rhetorical question and "hint sections under different sections" with "Use `hint_color` for hint text under sections; on backgrounds like `secondary_bg_color`, use `link_color`."

---

- [x] **2913. Fix heading hierarchy (use H2 before H3)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/design-guidelines.mdx?plain=1

Change "### Changelog" and "### Reasons for these changes" to H2 (##) to avoid skipping from H1 to H3.

---

- [ ] **2914. Specify product for version reference**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/design-guidelines.mdx?plain=1

Change "Starting with version 6.10" to "Starting with Telegram app version 6.10" (or the correct product) to make the scope explicit.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.