### PR TITLE
Split: update docs/v3/guidelines/dapps/tma/tutorials/step-by-step-guide.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/dapps/tma/guidelines/publishing.mdx
+++ b/docs/v3/guidelines/dapps/tma/guidelines/publishing.mdx
@@ -64,7 +64,7 @@ If receiving text data alone is insufficient or you need a more advanced and per
 
 Clicking the button opens a Mini App at the specified URL. The Mini App receives the user’s [theme settings](https://core.telegram.org/bots/webapps#color-schemes), , basic information (ID, name, username, language code), and a unique session identifier **query_id**, enabling message sending on behalf of the user.
 
-The bot can call the Bot API method [answerWebAppQuery](https://core.telegram.org/bots/api#answerwebappquery) to send an inline message from the user back to the bot and close the Mini App. After receiving the message, the bot can continue interacting with the user.
+The bot can call the Bot API method [`answerWebAppQuery`](https://core.telegram.org/bots/api#answerwebappquery) to send an inline message from the user back to the bot and close the Mini App. After receiving the message, the bot can continue interacting with the user.
 
 **Good for:**
 

--- a/docs/v3/guidelines/dapps/tma/tutorials/step-by-step-guide.mdx
+++ b/docs/v3/guidelines/dapps/tma/tutorials/step-by-step-guide.mdx
@@ -12,7 +12,7 @@ Telegram Mini Apps (TMA) are web applications that run inside the Telegram app. 
 <script src="https://telegram.org/js/telegram-web-app.js"></script>
 ```
 :::tip
-It's best to disable caching using HTTP response headers. To ensure caching is turned off, configure these headers in your server responses:
+It's best to disable caching using HTTP response headers. To ensure caching is disabled, configure these headers in your server responses:
 
 ```text
 Cache-Control: no-store, must-revalidate
@@ -21,17 +21,17 @@ Expires: 0
 ```
 :::
 
-2. Once the script is connected, the **[window.Telegram.WebApp](https://core.telegram.org/bots/webapps#initializing-web-apps)** object becomes available. Learn more about creating a Mini App using [`telegram-web-app.js`](/v3/guidelines/dapps/tma/tutorials/app-examples#basic-tma-example) here.
+2. Once the script is loaded, the [`window.Telegram.WebApp`](https://core.telegram.org/bots/webapps#initializing-web-apps) object becomes available. Learn more about creating a Mini App using [`telegram-web-app.js`](/v3/guidelines/dapps/tma/tutorials/app-examples#basic-tma-example).
 
-3. You can also connect the SDK using the npm package for Telegram Mini Apps SDK:
+3. You can also use the `@twa-dev/sdk` npm package:
 
 ```bash npm2yarn
-npm i @twa-dev/sdk
+npm install @twa-dev/sdk
 ```
 
 See the Modern TMA example for `@twa-dev/sdk` [in this guide](/v3/guidelines/dapps/tma/tutorials/app-examples#modern-tma-example).
 
-4. Once your Mini App is ready and deployed to a web server, move on to the next step.
+4. Once your Mini App is deployed, continue with [Setting up a bot for the Mini App](#setting-up-a-bot-for-the-mini-app).
 
 ## Setting up a bot for the Mini App
 
@@ -40,8 +40,8 @@ To connect your Mini App to Telegram, you need to create a bot and set up a Mini
 ### 1. Start a chat with BotFather
 
 - Open the Telegram app or web version.
-- Search for `@BotFather` in the search bar or click this link [https://t.me/BotFather](https://t.me/BotFather).
-- Start a chat with BotFather by clicking `START`.
+- Search for `@BotFather` in the search bar or click this link [@BotFather](https://t.me/BotFather).
+- Start a chat with BotFather by clicking **START**.
 
 ### 2. Create a new bot
 
@@ -49,17 +49,16 @@ To connect your Mini App to Telegram, you need to create a bot and set up a Mini
 - Choose a display name for your bot. It can include spaces.
 - Choose a unique username for your bot that ends with `bot`, such as `sample_bot`.
 
-### 3. Set up the bot Mini App
+### 3. Set up the Mini App for the bot
 
 - Send the `/mybots` command to [@BotFather](https://t.me/BotFather).
-- Select your bot from the list and choose **Bot settings**.
-- Select **Menu button**.
-- Choose **Edit menu button URL** and enter the URL when prompted by BotFather (e.g., a link from GitHub Pages deployment).
+- Select your bot from the list and choose **Bot Settings**.
+- Select **Menu Button**.
+- Choose **Edit menu button URL** and enter the URL when prompted by BotFather (e.g., a link from GitHub pages deployment).
 
 ### 4. Access the bot
 
 - Search for your bot using its username in Telegram's search bar.
-- Click the button next to the attachment picker to launch your Telegram Mini App in the Telegram app.
-- You’re awesome!
+- Tap the Menu button (next to the attachment icon) to launch your Telegram Mini App.
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-dapps-tma-tutorials-step-by-step-guide.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/dapps/tma/tutorials/step-by-step-guide.mdx`

Related issues (from issues.normalized.md):
- [x] **2915. Remove redundant “apps … applications”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/step-by-step-guide.mdx?plain=1#L5

Replace “TMAs can be used to create apps, games, and other types of applications.” with “TMAs can be used to create apps and games.”

---

- [x] **2916. Use “Telegram app” consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/step-by-step-guide.mdx?plain=1#L5,L62

Replace “Telegram messenger”/“messenger” with “Telegram app” in these locations to use the canonical product name.

---

- [ ] **2917. Say “disabled,” not “turned off,” in caching tip**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/step-by-step-guide.mdx?plain=1#L15-L21

Change the sentence to “To ensure caching is disabled, configure these headers in your server responses:”.

---

- [ ] **2918. Say “script is loaded,” not “connected”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/step-by-step-guide.mdx?plain=1#L24

Replace “Once the script is connected” with “Once the script is loaded, the window.Telegram.WebApp object becomes available.”

---

- [ ] **2919. Code-format window.Telegram.WebApp link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/step-by-step-guide.mdx?plain=1#L24

Change the bold link to a code-formatted link: [`window.Telegram.WebApp`](https://core.telegram.org/bots/webapps#initializing-web-apps).

---

- [ ] **2920. Use explicit npm install command**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/step-by-step-guide.mdx?plain=1#L28-L30

Replace `npm i @twa-dev/sdk` with `npm install @twa-dev/sdk` for clarity and consistency.

---

- [ ] **2921. Use correct UI label “Start” (not `START`)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/step-by-step-guide.mdx?plain=1#L44

Replace the all-caps, code-styled `START` with bold title-case text: Start.

---

- [ ] **2922. Rephrase heading for clarity**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/step-by-step-guide.mdx?plain=1#L52

Change the heading “Set up the bot Mini App” to “Set up the Mini App for the bot.”

---

- [ ] **2923. Name the Menu button explicitly**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/step-by-step-guide.mdx?plain=1#L62

Replace “Click the button next to the attachment picker” with “Tap the Menu button (next to the attachment icon) to launch your Telegram Mini App.”

---

- [ ] **2924. Remove redundant “here” after descriptive link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/step-by-step-guide.mdx?plain=1

Delete the trailing “here” in “Learn more about creating a Mini App using [`telegram-web-app.js`](/v3/guidelines/dapps/tma/tutorials/app-examples#basic-tma-example) here.”

---

- [ ] **2925. Simplify SDK package phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/step-by-step-guide.mdx?plain=1

Replace “connect the SDK using the npm package for Telegram Mini Apps SDK” with “You can also use the `@twa-dev/sdk` npm package.”

---

- [ ] **2926. Align BotFather menu setting wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/step-by-step-guide.mdx?plain=1

Update the instruction to the canonical phrasing: “In BotFather, select Bot Settings → Menu Button and set the URL (or use /setmenubutton).”

---

- [ ] **2927. Use descriptive link text for @BotFather**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/step-by-step-guide.mdx?plain=1

Replace the raw URL “https://t.me/BotFather” with a descriptive link: [@BotFather](https://t.me/BotFather).

---

- [ ] **2928. Remove informal closing line**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/step-by-step-guide.mdx?plain=1

Delete “You’re awesome!” to maintain a professional, instructional tone.

---

- [ ] **2929. Add forward link to next section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tma/tutorials/step-by-step-guide.mdx?plain=1

Change “Once your Mini App is ready and deployed to a web server, move on to the next step.” to include a direct link: “Once your Mini App is deployed, continue with Setting up a bot for the Mini App (#setting-up-a-bot-for-the-mini-app).”

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.