### PR TITLE
Split: update docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx
+++ b/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx
@@ -59,15 +59,15 @@ The model is used to precisely describe and analyze distributed systems. For exa
 
 An **account** in TON is an actor characterized by the following components:
 
-- **Account properties** — common properties of any account: _ID, balance, status, and last transaction (`last_tx`)_
+- **Account properties** — common properties of any account: _ID, balance, status, and last transaction logical time (`last_trans_lt`)_
 - **Data** — user defined data
 - **Code** — custom logic defining the account's behavior
 
 The general state fully defines all account types in TON. Examples:
 
 - `(ID1, 0 TON, unexist)`
-- `(ID2, 10 TON, uninit, last_tx)`
-- `(ID3, -0.5 TON, frozen)`
+- `(ID2, 10 TON, uninit, last_trans_lt)`
+ - `(ID3, 0 TON, frozen)`
 
 ![](/img/docs/blockchain-fundamentals/account_eng.svg)
 
@@ -81,7 +81,7 @@ A **smart contract** is an account whose _code_ and _data_ are already deployed 
 
 - An **account** is an actor that has a general state — such as balance, address, and status — and may optionally include code and data.
 
-Example: `(ID1, 0 TON, unexist)` or `(ID2, 2 TON, inited, last_tx, data, code)`
+Example: `(ID1, 0 TON, unexist)` or `(ID2, 2 TON, inited, last_trans_lt, data, code)`
 
 - A **smart contract** is an actor with **deployed** code and data that define its specific behavior.
 
@@ -97,9 +97,9 @@ In TON, contracts or actors do not call each other directly. Instead, they commu
 
 **Asynchrony** is a property of communication, meaning that a message does not need to be processed immediately. This implies the following:
 
-1. _Immediate responses are not guaranteed_. The receiver may delay responding or may not respond at all.
-2. _Senders remain non-blocking_. After sending a message, an actor continues handling other messages or tasks without blocking or waiting for a response to the previous one—even if that response never arrives.
-3. _Message ordering is preserved per destination account_. Each account processes incoming messages in the order they are received. If a message is malformed or incomplete, it is skipped, and the following message is processed without delay.
+1. _No immediate response is guaranteed_. The receiver may delay responding or may not respond at all.
+2. _The sender does not wait for a reply_. After sending a message, an actor continues handling other messages or tasks without blocking or waiting for a response to the previous one—even if that response never arrives.
+3. _Messages are processed sequentially per destination account_. Each account processes incoming messages one at a time. If a message is malformed or incomplete, it may be skipped.
 
 This is different from synchronous models, where the flow is: call → wait for a response → continue.
 In TON, a result can only be received as a separate message — and only if it is explicitly sent.
@@ -131,7 +131,7 @@ Transactions are processed **asynchronously**, meaning that each account’s upd
 
 Earlier, we mentioned that an account is an actor defined by the following components:
 
-- Account properties (ID, balance, status, `last_tx`)
+- Account properties (ID, balance, status, `last_trans_lt`)
 - Data
 - Code
 
@@ -153,31 +153,32 @@ account$1 addr:MsgAddressInt storage_stat:StorageInfo
 - Storage statistics — `StorageInfo`
 
 <details>
-  ```tlb
+  <summary>Full TL‑B account schema</summary>
 
-  account_none$0 = Account;
-  account$1 addr:MsgAddressInt storage_stat:StorageInfo
-  storage:AccountStorage = Account;
+```tlb
+account_none$0 = Account;
+account$1 addr:MsgAddressInt storage_stat:StorageInfo
+storage:AccountStorage = Account;
 
-  account_storage$_ last_trans_lt:uint64
-  balance:CurrencyCollection state:AccountState
-  = AccountStorage;
+account_storage$_ last_trans_lt:uint64
+balance:CurrencyCollection state:AccountState
+= AccountStorage;
 
-  account_uninit$00 = AccountState;
-  account_active$1 _:StateInit = AccountState;
-  account_frozen$01 state_hash:bits256 = AccountState;
+account_uninit$00 = AccountState;
+account_active$1 _:StateInit = AccountState;
+account_frozen$01 state_hash:bits256 = AccountState;
 
-  acc_state_uninit$00 = AccountStatus;
-  acc_state_frozen$01 = AccountStatus;
-  acc_state_active$10 = AccountStatus;
-  acc_state_nonexist$11 = AccountStatus;
+acc_state_uninit$00 = AccountStatus;
+acc_state_frozen$01 = AccountStatus;
+acc_state_active$10 = AccountStatus;
+acc_state_nonexist$11 = AccountStatus;
 
 
-  _ fixed_prefix_length:(Maybe (## 5)) special:(Maybe TickTock)
-  code:(Maybe ^Cell) data:(Maybe ^Cell)
-  library:(Maybe ^Cell) = StateInit;
+_ fixed_prefix_length:(Maybe (## 5)) special:(Maybe TickTock)
+code:(Maybe ^Cell) data:(Maybe ^Cell)
+library:(Maybe ^Cell) = StateInit;
 
-  ```
+```
 </details>
 
 Let’s clarify which properties are part of the **account properties**, according to the TL-B schema:
@@ -187,9 +188,9 @@ Let’s clarify which properties are part of the **account properties**, accordi
 - Status → `AccountState`
 - Last transaction logical time (`last_trans_lt`) — also part of the general state
 
-Meanwhile, the data and code are defined within the state:` AccountState` field.
+Meanwhile, the data and code are defined within the state: `AccountState` field.
 
-Now, let’s take a closer look at the account properties and how it’s represented in the data layout.
+Now, let’s take a closer look at the account properties and how they’re represented in the data layout.
 
 ### Account status
 
@@ -198,8 +199,9 @@ TON defines account states `AccountState` as follows:
 | Status   | TL-B code | Description                                                                                                                                                                                                                                  |
 | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `uninit` | `00`      | The account exists but contains no code or data. It may hold a non-zero balance but is not initialized yet.                                                                                                                                  |
-| `frozen` | `01`      | The account is frozen: its code and data are deleted, but a hash of the previous state is retained. It can't be used, but it can be restored. The account has zero or negative balance, or doesn't meet the workchain’s minimum requirement. |
-| `active` | `10`      | The account includes a `StateInit`, which stands for State Initialized, with deployed code and data. It means that it's already initialized. It is an active smart contract, ready to process incoming messages.                             |
+| `frozen` | `01`      | The account is frozen: its code and data are deleted, but a hash of the previous state is retained. It can't be used, but it can be restored. This occurs when storage‑fee debt exceeds network limits.                                   |
+| `active` | `10`      | The account includes a `StateInit` (initial code and data) with deployed code and data. It means that it's already initialized. It is an active smart contract, ready to process incoming messages.                                        |
+| `nonexist` | `11`   | The account does not exist. It has no balance, code, or data, and can be created on first initialization or incoming transfer.                                                                                                              |
 
 ```tlb
 account_uninit$00 = AccountState;
@@ -215,10 +217,10 @@ The diagram below illustrates the lifecycle of an account in the TON blockchain,
 
 Smart contracts are a set of promises in digital form, including protocols that govern how the parties fulfil these promises.
 
-In TON, typically by smart contract recognize:
+In TON, a smart contract typically refers to:
 
-- The program code executed, as described in FunC, Tact, or Tolk, in the blockchain.
-- The account that implements business logic and content code.
+- Program code executed on the blockchain, written in FunC, Tact, or Tolk.
+- The account that contains the contract code and implements the business logic.
 
 In technical terms, a smart contract in TON is an `Account` in the active state (`AccountState = active`) with:
 
@@ -226,13 +228,12 @@ In technical terms, a smart contract in TON is an `Account` in the active state 
 - an initialized `data` field in `StateInit` — storing the persistent contract state
 
 :::note
-An account may be in the `active` state with `state_init.code = None`. For example, immediately after a `SetCode` action in the VM. This is an edge case: such a state is not valid for execution but is technically possible.
+An account may be in the `active` state with `state_init.code = None`. For example, immediately after a `SetCode` action in the VM. This is an edge case: such a state is not valid for execution but is technically possible and implementation‑specific.
 :::
 
 ### Address
 
-An address in TON is a unique identifier for a smart contract required for interaction between network participants.
-The account itself has an address, but we define the address entirely for arbitrary use only through a smart contract.
+Every account has an address. In practice, addresses are primarily used for smart contracts and can be determined from the initial StateInit even before deployment.
 It consists of the following components:
 
 - **WorkChain ID** — a 32-bit signed integer indicating the WorkChain to which the account belongs (e.g., -1 for the MasterChain, 0 for the BaseChain).
@@ -276,7 +277,7 @@ In other words, an AccountChain is a _micro-blockchain_ scoped to a single accou
 Like a regular blockchain, it is a linear, append-only sequence of transactions — but dedicated to just one account.
 It stores and orders the entire history of that account’s operations and interactions, ensuring transparency and traceability.
 
-At the network level, many such chains are grouped into a **ShardChain** or simply **shard**, which manages a collection of accounts. This abstraction supports logical grouping _AccountChains_ across physical infrastructure _ShardChain ↔ Validator_.
+At the network level, many such chains are grouped into a **ShardChain** or simply **shard**, which manages a collection of accounts. This abstraction supports logical grouping of AccountChains across the physical infrastructure (ShardChain ↔ Validator).
 
 The diagram below provides a graphical representation of an AccountChain and its structure.
 ![](/img/docs/blockchain-fundamentals/accountchain.svg)

--- a/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx
+++ b/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx
@@ -32,13 +32,13 @@ An **actor** is an abstract behavioral model, formalized as a computational obje
 
 In other words:
 
-An actor is an independent entity with its state and behavior. Actors interact by exchanging messages. Each actor can:
+An actor is an independent entity with its own state and behavior. Actors interact by exchanging messages. Each actor can:
 
 - change its state
 - send messages to other actors
 - spawn new actors
 
-![](/img/docs/blockchain-fundamentals/actor.svg)
+![Actor properties](/img/docs/blockchain-fundamentals/actor.svg)
 
 ### Actor model
 
@@ -52,7 +52,7 @@ Key properties of the model:
 
 The model is used to precisely describe and analyze distributed systems. For example:
 
-- Email can be modelled as an actor system: users are represented as actors and email addresses serve as actor addresses.
+- Email can be modeled as an actor system: users are represented as actors and email addresses serve as actor addresses.
 - Web services with endpoints (e.g., SOAP) can be interpreted as actors that handle messages sent to their addresses.
 
 ### Account
@@ -60,36 +60,36 @@ The model is used to precisely describe and analyze distributed systems. For exa
 An **account** in TON is an actor characterized by the following components:
 
 - **Account properties** — common properties of any account: _ID, balance, status, and last transaction logical time (`last_trans_lt`)_
-- **Data** — user defined data
+- **Data** — user-defined data
 - **Code** — custom logic defining the account's behavior
 
 The general state fully defines all account types in TON. Examples:
 
-- `(ID1, 0 TON, unexist)`
+- `(ID1, 0 TON, nonexist)`
 - `(ID2, 10 TON, uninit, last_trans_lt)`
- - `(ID3, 0 TON, frozen)`
+- `(ID3, -0.5 TON, frozen)`
 
-![](/img/docs/blockchain-fundamentals/account_eng.svg)
+![Account properties](/img/docs/blockchain-fundamentals/account_eng.svg)
 
 ### Smart contract
 
 A **smart contract** is an account whose _code_ and _data_ are already deployed to the blockchain in addition to its general state.
 
-![](/img/docs/blockchain-fundamentals/smart-contract.svg)
+![Smart contract](/img/docs/blockchain-fundamentals/smart-contract.svg)
 
 #### Difference between an account and a smart contract
 
 - An **account** is an actor that has a general state — such as balance, address, and status — and may optionally include code and data.
 
-Example: `(ID1, 0 TON, unexist)` or `(ID2, 2 TON, inited, last_trans_lt, data, code)`
+Example: `(ID1, 0 TON, nonexist)` or `(ID2, 2 TON, active, last_trans_lt, data, code)`
 
 - A **smart contract** is an actor with **deployed** code and data that define its specific behavior.
 
-Example: `(ID2, 2 TON, inited, data, code)`
+Example: `(ID2, 2 TON, active, data, code)`
 
 #### Entity structure in TON Blockchain
 
-![](/img/docs/blockchain-fundamentals/structure_eng.svg)
+![Entity structure](/img/docs/blockchain-fundamentals/structure_eng.svg)
 
 ### Asynchrony
 
@@ -104,23 +104,22 @@ In TON, contracts or actors do not call each other directly. Instead, they commu
 This is different from synchronous models, where the flow is: call → wait for a response → continue.
 In TON, a result can only be received as a separate message — and only if it is explicitly sent.
 
-![](/img/docs/blockchain-fundamentals/asynchrony.gif)
+![Asynchrony](/img/docs/blockchain-fundamentals/asynchrony.gif)
 
-### Message feature
+### Message
 
 A message is a set of instructions intended for a single actor. In TON Blockchain, it serves as the fundamental unit of interaction between accounts. All logic execution, state changes, and contract-to-contract communication are initiated by messages.
 
-### Transaction feature
+### Transaction
 
 In TON, a transaction is a record of an account's state update caused by processing an incoming message.
-If the message does not result in an update — for example, due to an error in the compute phase — no transaction is created.
 
 Depending on the contract logic, a transaction may also produce one or more outgoing messages.
 
 ### Asynchronous transactions
 
 In TON, accounts interact exclusively through messages — this is the core of actor-based communication.
-Each successfully processed message results in a transaction,
+Each delivered message results in a transaction,
 which records the entire context: the triggering message, state updates, and any generated outbound messages.
 
 Transactions are processed **asynchronously**, meaning that each account’s updates and message handling occur independently over time.
@@ -196,12 +195,12 @@ Now, let’s take a closer look at the account properties and how they’re repr
 
 TON defines account states `AccountState` as follows:
 
-| Status   | TL-B code | Description                                                                                                                                                                                                                                  |
-| -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `uninit` | `00`      | The account exists but contains no code or data. It may hold a non-zero balance but is not initialized yet.                                                                                                                                  |
-| `frozen` | `01`      | The account is frozen: its code and data are deleted, but a hash of the previous state is retained. It can't be used, but it can be restored. This occurs when storage‑fee debt exceeds network limits.                                   |
-| `active` | `10`      | The account includes a `StateInit` (initial code and data) with deployed code and data. It means that it's already initialized. It is an active smart contract, ready to process incoming messages.                                        |
-| `nonexist` | `11`   | The account does not exist. It has no balance, code, or data, and can be created on first initialization or incoming transfer.                                                                                                              |
+| Status   | TL-B code | Description                                                                                                                                                                                                                                        |
+| -------- | --------- |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `uninit` | `00`      | The account exists but contains no code or data. It may hold a non-zero balance but is not initialized yet.                                                                                                                                        |
+| `frozen` | `01`      | The account is frozen: its code and data are deleted, but a hash of the previous state is retained. It can't be used, but it can be restored. This occurs when storage‑fee debt exceeds network limits.                                            |
+| `active` | `10`      | The account includes a `StateInit` (State Initialized) with deployed code and data. It means that it's already initialized. It is an active smart contract, ready to process incoming messages.                                                               |
+| `nonexist` | `11`   | The account does not exist. It has no balance, code, or data, and can be created on first initialization or incoming transfer.                                                                                                                     |
 
 ```tlb
 account_uninit$00 = AccountState;
@@ -211,11 +210,11 @@ account_frozen$01 state_hash:bits256 = AccountState;
 
 The diagram below illustrates the lifecycle of an account in the TON blockchain, showing how its state changes under different conditions.
 
-![](/img/docs/blockchain-fundamentals/account_states.svg)
+![Account's lifecycle](/img/docs/blockchain-fundamentals/account_states.svg)
 
 ### Smart contract structure
 
-Smart contracts are a set of promises in digital form, including protocols that govern how the parties fulfil these promises.
+Smart contracts are a set of promises in digital form, including protocols that govern how the parties fulfill these promises.
 
 In TON, a smart contract typically refers to:
 
@@ -233,31 +232,32 @@ An account may be in the `active` state with `state_init.code = None`. For examp
 
 ### Address
 
-Every account has an address. In practice, addresses are primarily used for smart contracts and can be determined from the initial StateInit even before deployment.
+An address in TON is a unique identifier for a smart contract required for interaction between network participants.
+Every account has an address, which can be determined even before deployment from the smart contract’s `StateInit`.
 It consists of the following components:
 
 - **WorkChain ID** — a 32-bit signed integer indicating the WorkChain to which the account belongs (e.g., -1 for the MasterChain, 0 for the BaseChain).
-- **Account ID** — a 256-bit hash of the `StateInit` structure, which includes the contract’s initialized `code`, `data`, and, optionally, a `library`. It is stored as an arbitrary `SliceData` and may not exactly match the hash of `StateInit`.
+- **Account ID** — a 256-bit hash derived from the contract’s initial _code_ and _data_.
 
-:::important
-`StateInit` (short for _state initialized_) can change as the contract evolves.
-The `account_id` never changes, as it’s based on the very first `StateInit` recorded at deployment.
-:::
 
 The address is defined as:
 
 <BlockMath math="\text{Address} := (\text{workchain\_id}, \text{account\_id})" />
 
-, where
+where:
 
-<BlockMath math="\text{account\_id}:= \text{HASH(StateInit)}" />
+<BlockMath math="\text{account\_id}:= \text{HASH(initial\_code, initial\_data)}" />
 
-An address corresponds to the first initialized state of a contract and can be calculated even **before** the contract is deployed.
-This allows you to use the address ahead of time — for example, to receive tokens or set up interactions.
+:::important
+`StateInit` (_State Initialized_) defines the contract’s initialization parameters: _code_, _data_, and optionally a _library_.
+These fields may change during the contract’s lifecycle, but the `account_id` is calculated **only once**, from the very first `StateInit` recorded at deployment.
+:::
 
-An address depends only on the `StateInit` used _at the moment of the contract's first deployment_. Even a small change to the `code`, `data`, or `library` in this initialized state results in a completely different `account_id` — and, therefore, a different **address**.
+Because the address depends only on the initial `StateInit`, it can be deterministically computed before deployment.
+This allows third parties to reference the contract address in advance, such as for token transfers or integration setup.
 
-In fact, during message processing, validators verify the sender’s address — if it’s incorrect, they silently replace it with the correct one.
+Even a minimal change in the initial code or data leads to a completely different `account_id`, and therefore a different address.
+During message processing, validators verify the sender’s address. If the provided address does not match, it is automatically replaced with the correct one.
 
 ## Blockchain structure
 
@@ -280,18 +280,18 @@ It stores and orders the entire history of that account’s operations and inter
 At the network level, many such chains are grouped into a **ShardChain** or simply **shard**, which manages a collection of accounts. This abstraction supports logical grouping of AccountChains across the physical infrastructure (ShardChain ↔ Validator).
 
 The diagram below provides a graphical representation of an AccountChain and its structure.
-![](/img/docs/blockchain-fundamentals/accountchain.svg)
+![AccountChains](/img/docs/blockchain-fundamentals/accountchain.svg)
 
 ### ShardChain
 
 A **ShardChain** is a blockchain that groups multiple AccountChains.
 
 While an AccountChain represents the transaction history of a single account, a ShardChain processes and stores data for a group of accounts that share a common binary address prefix (e.g., all addresses starting with `0b00101`).
-ShardChains also facilitate message routing between accounts, ensuring both delivery and order: if one message is sent before another, it will arrive first.
+ShardChains handle message routing between accounts. The ordering of messages is preserved per account.
 
 Each validator is responsible for a specific ShardChain or a group of them, allowing the network to process transactions concurrently across different shards.
 
-![](/img/docs/blockchain-fundamentals/shardchain.svg)
+![ShardChains](/img/docs/blockchain-fundamentals/shardchain.svg)
 
 ### WorkChain and BaseChain
 
@@ -304,7 +304,7 @@ TON supports up to 2³² WorkChains, each of which can be divided into up to 2�
 Currently, TON operates with only one WorkChain, known as the **BaseChain**. It's the primary execution chain used for everyday transactions and smart contracts. The BaseChain is the _WorkChain with an ID of `0`_.
 It is optimized for low fees, making it suitable for regular users and developers.
 
-![](/img/docs/blockchain-fundamentals/basechain.svg)
+![BaseChain](/img/docs/blockchain-fundamentals/basechain.svg)
 
 ### MasterChain
 
@@ -320,7 +320,7 @@ Gas costs are intentionally high in the MasterChain to ensure stability, priorit
 
 Thanks to the hierarchical structure of WorkChains and ShardChains, TON forms a **blockchain of blockchains** — a scalable architecture where each chain operates independently, and all blocks reference their predecessors via cryptographic hashes.
 
-![](/img/docs/blockchain-fundamentals/chain-of-chains.svg)
+![Blockchain architecture](/img/docs/blockchain-fundamentals/chain-of-chains.svg)
 
 ### Testnet and Mainnet
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-dapps-transactions-foundations-of-blockchain.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx`

Related issues (from issues.normalized.md):
- [ ] **2976. Fix actor definition grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx?plain=1#L18-L22

Change to: “An actor is an independent entity with its own state and behavior.”

---

- [ ] **2977. Add descriptive alt text to all images**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx?plain=1#L24,L55,L61,L75,L90,L195,L265,L276,L293,L307

Replace empty alt text with concise, descriptive alt text for each image to improve accessibility.

---

- [ ] **2978. Standardize American English spelling**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx?plain=1#L38-L39,L199

Use consistent American English: “modelled” → “modeled” (L38); “fulfil” → “fulfill” (L199).

---

- [ ] **2979. Hyphenate “user-defined data”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx?plain=1#L46

Hyphenate the compound modifier: “user‑defined data”.

---

- [ ] **2980. Use canonical account state terms**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx?plain=1#L51,L67,L71

Replace noncanonical states to match TL‑B AccountStatus: “unexist” → “nonexist”; “inited” → “active” (or “initialized (active)” in explanatory text); update examples accordingly.

---

- [ ] **2981. Rename sections to “Messages” and “Transactions”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx?plain=1#L92-L101

Rename “Message feature” → “Messages” and “Transaction feature” → “Transactions” for consistency with related pages.

---

- [ ] **2982. Normalize capitalization: “In the TON blockchain”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx?plain=1#L94

Change “In TON Blockchain” to “In the TON blockchain” for consistent capitalization on this page.

---

- [ ] **2983. Correct statement about transactions on compute failure**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx?plain=1#L98-L101

Revise to reflect that a transaction is recorded even when compute fails (aborted/failed); a transaction is absent only if the message is never processed (e.g., dropped before inclusion).

---

- [x] **2984. Add summary and fix indentation in <details> block**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx?plain=1#L138-L165

Add a <summary> (e.g., “Full TL‑B account schema”) and remove leading indentation inside the fenced code block so it renders properly in MDX.

---

- [x] **2985. Fix inline-code spacing around AccountState**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx?plain=1#L173

Change “the state:` AccountState` field” to “the state: `AccountState` field”.

---

- [x] **2986. Fix subject–verb agreement in properties sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx?plain=1#L175

Change “the account properties and how it’s represented” to “the account properties and how they’re represented”.

---

- [x] **2987. Clarify “StateInit” terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx?plain=1#L185

Replace “which stands for State Initialized” with a clearer parenthetical, e.g., “StateInit (state initialization data)” or “StateInit (initial code and data)”.

---

- [x] **2988. Improve smart contract definition and bullet wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx?plain=1#L201-L205

Replace “In TON, typically by smart contract recognize:” with “In TON, a smart contract typically refers to:”; revise bullets to “Program code executed on the blockchain, written in FunC, Tact, or Tolk.” and “The account that contains the contract code and implements the business logic.”

---

- [x] **2989. Clarify address usage sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx?plain=1#L217-L219

Reword to: “Every account has an address. In practice, addresses are primarily used for smart contracts and can be determined from the initial StateInit even before deployment.”

---

- [ ] **2990. Align account_id definition and formula; fix “where:” formatting**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx?plain=1#L221-L223,L229-L235

Clarify that account_id is a 256‑bit value conventionally equal to the hash of the initial code and data at deployment; remove mention of library and the contradictory “arbitrary SliceData” wording; update the formula to “account_id := HASH(initial_code, initial_data)” and change the lead‑in to “where:” (no leading comma).

---

- [ ] **2991. Clarify validator/runtime handling of sender address**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx?plain=1#L242

Clarify that for internal messages the runtime sets src to the originating account, for external inbound messages src is typically null and certain fields are overwritten; validators do not “correct” arbitrary sender values provided by users.

---

- [x] **2992. Fix AccountChain grouping sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx?plain=1#L262-L263

Rewrite to: “This abstraction supports logical grouping of AccountChains across the physical infrastructure (ShardChain ↔ Validator).”

---

- [x] **2993. Rename last_tx to last_trans_lt**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx?plain=1

In the “Account properties” list, replace “last transaction (last_tx)” with “last transaction logical time (last_trans_lt)” and update references to match the TL‑B schema.

---

- [ ] **2994. Add missing nonexist state to status table**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx?plain=1

Include a row for the nonexist state (acc_state_nonexist$11) in the Account status table with a brief description consistent with canonical docs.

---

- [ ] **2995. Correct frozen state description and example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx?plain=1

Describe freezing as caused by storage‑fee debt exceeding limits (not “zero or negative balance”) and update the example to avoid negative Toncoin (e.g., “(ID3, 0 TON, frozen)”).

---

- [x] **2996. Soften or cite ordering/skipping claims in asynchrony section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx?plain=1

Provide a citation or rephrase to supported wording: contracts process one incoming message at a time, created_lt aids ordering, and compute may be skipped with explicit reasons; remove “skipped without delay” unless sourced.

---

- [ ] **2997. Cite or qualify SetCode edge-case note**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx?plain=1

Add a citation for the claim that an active account may have state_init.code = None after SetCode, or qualify/remove the note pending confirmation.

---

- [ ] **2998. Qualify ShardChain delivery-order guarantee**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/foundations-of-blockchain.mdx?plain=1

Either provide a citation for the asserted strict delivery/order guarantee in the ShardChain section or rephrase to avoid promising cross‑account ordering without sources.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.