### PR TITLE
Split: update docs/v3/guidelines/dapps/transactions/hash-based-tracking.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/dapps/transactions/hash-based-tracking.mdx
+++ b/docs/v3/guidelines/dapps/transactions/hash-based-tracking.mdx
@@ -308,7 +308,7 @@ This example shows a low-level construction of the message. For a higher-level, 
 
 **Practical example of calculating a non-normalized hash:**
 
-Historically, message hashes were not normalized across the ecosystem. If your code constructs messages without applying normalization, it may produce inconsistent hashes. In such cases, update the logic to follow the normalization rules described in [TEP-467](https://github.com/ton-blockchain/TEPs/pull/467).
+Before April 2025, message hashes were not normalized across the ecosystem. If your code constructs messages without applying normalization, it may produce inconsistent hashes. In such cases, update the logic to follow the normalization rules described in [TEP-467](https://github.com/ton-blockchain/TEPs/pull/467).
 
 Below is an example of non-normalized message construction — avoid using this approach:
 
@@ -400,6 +400,7 @@ import {
   Transaction,
   loadMessage,
   Cell,
+  toNano,
 } from "@ton/ton";
 
 export function getNormalizedExtMessageHash(message: Message) {
@@ -913,7 +914,7 @@ async function checkTransactionStatus(txHash: string, walletAddress: string) {
 
     if (data.result.length > 0) {
       console.log("Transaction found on the blockchain");
-      const viewerUrl = `https://testnet.tonviewer.com/transaction/${trxHash}`;
+      const viewerUrl = `https://testnet.tonviewer.com/transaction/${txHash}`;
       console.log("Transaction link:", viewerUrl);
       return data.result[0];
     } else {
@@ -979,7 +980,7 @@ async function getStateInit(
 
   const stateInitBase64 = stateInitCell.toBoc().toString("base64");
 
-  console.log("StateInit (base64):", stateInitBase64);
+  console.log("StateInit cell (base64):", stateInitBase64);
   console.log("StateInit (hash):  ", stateInitCell.hash().toString("base64"));
   console.log(
     "Wallet address:    ",


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-dapps-transactions-hash-based-tracking.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/dapps/transactions/hash-based-tracking.mdx`

Related issues (from issues.normalized.md):
- [x] **2999. Use 'the TON blockchain'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/hash-based-tracking.mdx?plain=1#L6

Replace “TON Blockchain” with “the TON blockchain” for style consistency.

---

- [x] **3000. Remove unsupported 'alternative algorithms' claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/hash-based-tracking.mdx?plain=1#L16-L18

Delete the clause “and in some cases, may rely on alternative algorithms” unless a cited exception is provided.

---

- [x] **3001. Describe hash as fingerprint, not signature**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/hash-based-tracking.mdx?plain=1#L16-L20

Replace “digital signature” with “cryptographic fingerprint or identifier.”

---

- [x] **3002. Align 'Hello TON!' string between prose and code**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/hash-based-tracking.mdx?plain=1#L51-L60

Change the prose to “Hello TON!” to match the code and expected hash; do not alter the code or hashes.

---

- [x] **3003. Standardize to 'opcode' in comments**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/hash-based-tracking.mdx?plain=1#L58-L59, #L102-L104, #L265, #L317-L320

Change “op code”/“op‑code” to “opcode” in these comment annotations.

---

- [x] **3004. Use 'full message hash' consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/hash-based-tracking.mdx?plain=1#L77, #L96-L139

Replace “complete message hash” with “full message hash” in headings, text, and comments.

---

- [x] **3005. Standardize Address import source**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/hash-based-tracking.mdx?plain=1#L98-L101, #L176-L179, #L242-L246, #L1042-L1045

Import Address from “@ton/core” consistently across all snippets.

---

- [ ] **3006. Standardize TON Center bot naming**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/hash-based-tracking.mdx?plain=1#L184, #L314, #L494

Use “@toncenter bot” consistently for the API key bot name.

---

- [x] **3007. Replace 'collisions' with 'inconsistent hashes'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/hash-based-tracking.mdx?plain=1#L221-L229

Reword to “can lead to inconsistent hashes across implementations” instead of “collisions.”

---

- [ ] **3008. Remove unsubstantiated 'Before April 2025' date**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/hash-based-tracking.mdx?plain=1#L291-L296

Rephrase to a timeless form (e.g., “Historically, …”) and drop the specific date.

---

- [x] **3009. Soften V5R1 Testnet walletId requirement**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/hash-based-tracking.mdx?plain=1#L501-L509

Change “must set walletId.networkGlobalId = -3” to “may need to set walletId.networkGlobalId = -3” to align with the commented code and provider variability.

---

- [ ] **3010. Use toNano for internal message value**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/hash-based-tracking.mdx?plain=1#L554-L566

Import toNano and set value to toNano("0.05") instead of the string "0.05".

---

- [ ] **3011. Align viewer URL with Testnet/Mainnet**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/hash-based-tracking.mdx?plain=1#L630-L635

If using a Testnet endpoint, change the link to https://testnet.tonviewer.com/transaction/${...}; otherwise switch endpoints to Mainnet for consistency.

---

- [x] **3012. Capitalize React in summary**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/hash-based-tracking.mdx?plain=1#L705-L708

Change to “Obtaining BoC and hash using a React example.”

---

- [x] **3013. Replace Buffer with Cell.fromBase64 in browser example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/hash-based-tracking.mdx?plain=1#L795-L799

Use const externalMessageCell = Cell.fromBase64(receivedBoc); and remove Buffer.from(receivedBoc, "base64").

---

- [x] **3014. Standardize to 'BoC' casing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/hash-based-tracking.mdx?plain=1#L830

Use “BoC” consistently (e.g., change the label to “BoC (base64)”).

---

- [ ] **3015. Fix txHash variable usage in viewer URL**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/hash-based-tracking.mdx?plain=1#L888-L916

Replace ${trxHash} with ${txHash} in viewerUrl to match the function parameter.

---

- [ ] **3016. Rename label to 'StateInit cell (base64)'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/hash-based-tracking.mdx?plain=1#L958-L968

Change the log label from “StateInit (base64)” to “StateInit cell (base64)” to avoid implying full TL‑B serialization.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.