### PR TITLE
Split: update docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx
+++ b/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx
@@ -46,8 +46,8 @@ In the TON blockchain, a **message** is the fundamental unit of interaction betw
 
   If the task is successful, the person, as specified in the original message:
 
-  - send new messages to other residents, or
-  - store the resulting items safely in their home.
+  - sends new messages to other residents, or
+  - stores the resulting items safely in their home.
 
   After finishing, they return to their mailbox and retrieve the **next** incoming message.
 
@@ -62,7 +62,7 @@ In the TON blockchain, a **message** is the fundamental unit of interaction betw
   Messages delivered via the postal system between residents are called **internal messages**.
   Messages from the outside world also reach the city. These have a specified recipient, but their sender is unknown — they are known as **external incoming** or **external-in messages**.
 
-  While external-in and internal messages fulfil a similar role from the actor’s perspective, each actor may handle them differently. Some may process them normally, while others might completely ignore messages from the outside world — like someone who refuses to open letters from strangers.
+  While external-in and internal messages fulfill a similar role from the actor’s perspective, each actor may handle them differently. Some may process them normally, while others might completely ignore messages from the outside world — like someone who refuses to open letters from strangers.
 </details>
 
 #### Message structure: TL-B
@@ -76,7 +76,7 @@ To serialize data into a cell, TON relies on a well-established standard called 
 
 In TON, all messages adhere to a unified schema that defines their structure and serialization.
 
-```
+```tlb
 message$_ {X:Type} info:CommonMsgInfo
 init:(Maybe (Either StateInit ^StateInit))
 body:(Either X ^X) = Message X;
@@ -119,7 +119,7 @@ The term **message** is closely related to a **transaction**, but they serve dif
 
 An **external-in message** is a message whose `CommonMsgInfo` header uses the `ext_in_msg_info$10` structure.
 
-```
+```tlb
 message$_ {X:Type} info:CommonMsgInfo
 init:(Maybe (Either StateInit ^StateInit))
 body:(Either X ^X) = Message X;
@@ -127,7 +127,7 @@ body:(Either X ^X) = Message X;
 
 **TL-B:**
 
-```
+```tlb
 //external incoming message
 ext_in_msg_info$10 src:MsgAddressExt dest:MsgAddressInt
 import_fee:Grams = CommonMsgInfo;
@@ -148,13 +148,13 @@ import { Address, beginCell } from '@ton/ton';
 import { NetworkProvider } from '@ton/blueprint';
 
 export async function run(provider: NetworkProvider, args: string[]) {
-    //Mainnet address : 'EQAyVZ2rDnEDliuaQJ3PJFKiqAS-9fOm9s7DG1y5Ta16zwU2'
+    // Mainnet address: 'EQAyVZ2rDnEDliuaQJ3PJFKiqAS-9fOm9s7DG1y5Ta16zwU2'
     const address = Address.parse('EQAyVZ2rDnEDliuaQJ3PJFKiqAS-9fOm9s7DG1y5Ta16zwU2');
 
-    //Switch address for the Testnet :
+    // Switch to Testnet address:
     //const address = Address.parse('kQAyVZ2rDnEDliuaQJ3PJFKiqAS-9fOm9s7DG1y5Ta16z768');
 
-    // Get current seqno using blueprint's provider
+    // Get current seqno using Blueprint's provider
     const contractProvider = provider.provider(address);
     const result = await contractProvider.get('seqno', []);
     const currentSeqno = result.stack.readNumber();
@@ -184,10 +184,10 @@ export async function run(provider: NetworkProvider, args: string[]) {
 An **internal message** is a message sent from one smart contract to another within the TON blockchain.
 When a contract receives an internal message, it can reliably determine:
 
-- how many TON coins are attached
+- how much Toncoin is attached
 - which contracts are the sender and the recipient
 
-The blockchain ensures the integrity of this information, allowing the contract to be trusted and used safely.
+The blockchain ensures the integrity of this information, allowing this information to be trusted and used safely.
 
 **TL-B:**
 
@@ -196,7 +196,7 @@ In other words, as the name implies, the sender of an internal message is always
 
 The most common way to send an internal message is by first sending an external message to a contract that contains the logic to forward the internal message to another contract.
 
-```
+```tlb
 //internal message
 int_msg_info$0 ihr_disabled:Bool bounce:Bool bounced:Bool
 src:MsgAddressInt dest:MsgAddressInt
@@ -218,13 +218,13 @@ created_lt:uint64 created_at:uint32 = CommonMsgInfo;
 | `created_lt`     | Logical time at which the message was created, used for ordering contract actions.          |
 | `created_at`     | Unix timestamp of when the message was created.                                             |
 
-The first thing a developer needs to specify is the amount of Toncoin attached to the internal message `value` and the destination address `dest`.
+The first thing a developer specifies is the amount of Toncoin attached to the internal message `value` and the destination address `dest`.
 
 In this example, an external message is sent to the wallet contract with additional instructions for sending an internal message. As a result of processing the transaction, the wallet contract sends an outgoing internal message with the specified `value` and recipient `address`.
 
 ```typescript title="internal.ts"
 //@ton/blueprint 0.36.1
-import { Address } from '@ton/ton';
+import { Address, toNano } from '@ton/ton';
 import { NetworkProvider } from '@ton/blueprint';
 
 export async function run(provider: NetworkProvider, args: string[]) {
@@ -232,7 +232,7 @@ export async function run(provider: NetworkProvider, args: string[]) {
     const contractProvider = provider.provider(address);
 
     return contractProvider.internal(provider.sender(), {
-        value: '0.01',
+        value: toNano('0.01'),
     });
 }
 ```
@@ -252,13 +252,13 @@ For example, a decentralized exchange (DEX) contract might emit an external outg
 
 **TL-B:**
 
-```
+```tlb
 //external outgoing message
 ext_out_msg_info$11 src:MsgAddressInt dest:MsgAddressExt
 created_lt:uint64 created_at:uint32 = CommonMsgInfo;
 ```
 
-## Bounce of messages
+## Message bounces
 
 A **bounce message** is automatically returned to the sender — but only if the following conditions are met:
 - the message is **internal**,


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-dapps-transactions-message-driven-execution.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx`

Related issues (from issues.normalized.md):
- [ ] **3017. Fix subject–verb agreement in analogy bullets**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx?plain=1#L26-L29

Change bullet verbs to third-person singular to match “the person”: “sends …” and “stores …”.

---

- [ ] **3018. Use American spelling “fulfill”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx?plain=1#L44

Replace “fulfil” with “fulfill” for consistency with US spelling used elsewhere.

---

- [ ] **3019. Add tlb language tags to TL‑B code blocks**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx?plain=1#L58-L62, #L109-L113, #L177-L183, #L233-L237

Label all TL‑B fenced blocks with “tlb” for correct syntax highlighting.

---

- [ ] **3020. Remove duplicate generic message schema under external‑in**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx?plain=1#L101-L105

Delete the repeated “Message X” TL‑B schema here and keep only the ext‑in‑specific TL‑B block, referring to the earlier “Native message structure” if needed.

---

- [ ] **3021. Clean up external‑in example comments and capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx?plain=1#L129-L136

Remove extra spaces before colons in comments and capitalize “Blueprint” (“Mainnet address:”, “Switch to Testnet address:”, “using Blueprint’s provider”).

---

- [ ] **3022. Use “Toncoin” terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx?plain=1#L166

Replace “how many TON coins are attached” with “how much Toncoin is attached” to use the canonical asset name and correct mass‑noun form.

---

- [ ] **3023. Clarify integrity sentence subject**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx?plain=1#L169

Change “allowing the contract to be trusted and used safely” to “allowing this information to be trusted and used safely.”

---

- [ ] **3024. Fix grammar in developer‑specification sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx?plain=1#L199

Replace “The first thing a developer needs to specify is …” with “The first thing a developer specifies is …” for proper agreement with the compound object.

---

- [ ] **3025. Use toNano for internal message value**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx?plain=1#L212-L214

Change value from a string to toNano('0.01') and import toNano for consistency and correctness.

---

- [ ] **3026. Improve bounce section heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx?plain=1#L239

Rename “Bounce of messages” to “Message bounces” for idiomatic phrasing.

---

- [ ] **3027. Qualify TON Connect bounce‑flag claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx?plain=1#L287-L288

Mark the claim that wallets always send bounceable messages as needing confirmation or add a reliable reference.

---

- [ ] **3028. Align expected output with script logs**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx?plain=1#L381-L389

Remove the “Connected to wallet at address: …” line from the expected output or add a matching log to the script.

---

- [ ] **3029. Remove stray backtick in TL‑B example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx?plain=1#L415-L418

Delete the trailing backtick so the line reads “= InternalMsgBody;”.

---

- [ ] **3030. Clarify comments in NFT transfer TL‑B example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx?plain=1#L422-L433

Add “// new owner” to the first .storeAddress and correct “lasts funds” to “excess funds” for the response destination comment.

---

- [ ] **3031. Add missing comment in NFT transfer builder example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx?plain=1#L461-L463

Append “// new owner” to the first .storeAddress(destinationAddress) for clarity and consistency.

---

- [ ] **3032. Fix receiving functions statement**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx?plain=1#L477-L481

Change to singular (“One commonly used receiving function is:”) or list both recv_internal and recv_external together.

---

- [ ] **3033. Capitalize “Blueprint” consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx?plain=1#L609-L612

Change “blueprint is designed …” to “Blueprint is designed …” for proper noun capitalization.

---

- [ ] **3034. Add bash language tags to shell blocks**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx?plain=1#L655-L657

Label “Then run:” shell snippets with bash, including this block and the earlier external message example.

---

- [ ] **3035. Standardize “dApp” capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx?plain=1

Use “dApps” consistently throughout (including headings) to match the path and house style.

---

- [ ] **3036. Correct external‑in initiator terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx?plain=1

Replace “wallet contract” with “wallet application or custom code interacting with blockchain API services” since external‑in initiators are off‑chain.

---

- [ ] **3037. Replace confusing path placeholder**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx?plain=1

Change “blueprintproject/scripts/yourscript.ts” to “your-project/scripts/yourscript.ts” for clarity.

---

- [ ] **3038. Shorten option headings wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx?plain=1

Change “Option 1: using environment variables in the command line” to “Option 1: use environment variables on the command line” (and adjust similar headings accordingly).

---

- [ ] **3039. Standardize SDK imports for core primitives**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/transactions/message-driven-execution.mdx?plain=1

Import beginCell and toNano from @ton/core consistently across examples to avoid confusion.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.