### PR TITLE
Split: update docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx
+++ b/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx
@@ -20,8 +20,8 @@ By the end of this tutorial, you'll be able to:
 
 Before you start, make sure you have the following:
 
-1. A [Tonhub](https://tonhub.com) / [Tonkeeper](https://ton.app/wallets/tonkeeper) wallet or any other TON-compatible wallet.
-   At least 0.25 TON in your wallet (plus extra for blockchain fees)
+1. A TON-compatible wallet (e.g., [Tonhub](https://ton.app/wallets/tonhub-wallet) / [Tonkeeper](https://ton.app/wallets/tonkeeper)).
+2. At least 0.25 TON to cover deployment and fees.
 
 :::tip starter tip
 \~0.5 TON should be enough for this tutorial.
@@ -29,9 +29,9 @@ Before you start, make sure you have the following:
 
 ## 🚀 Let's get started!
 
-Use your web browser to open the service [TON Minter](https://minter.ton.org/) / [TON Minter testnet](https://minter.ton.org/?testnet=true).
+Use your web browser to open the service [TON Minter](https://minter.ton.org/) or [TON Minter testnet](https://minter.ton.org/?testnet=true).
 
-![image](/img/tutorials/jetton/jetton-main-page.png)
+![TON Minter main page](/img/tutorials/jetton/jetton-main-page.png)
 
 ### Deploy a jetton using your browser
 
@@ -39,9 +39,9 @@ Use your web browser to open the service [TON Minter](https://minter.ton.org/) /
 
 Open [TON Minter](https://minter.ton.org/) or [TON Minter testnet](https://minter.ton.org/?testnet=true) in your web browser. Click "Connect Wallet" and link your Tonhub or another supported wallet.
 
-#### ![image](/img/tutorials/jetton/jetton-connect-wallet.png)
+![Connect wallet](/img/tutorials/jetton/jetton-connect-wallet.png)
 
-**Scan the QR-code** in a [Mobile wallet (Tonhub e.g.)](https://tonhub.com)
+**Scan the QR-code** in a [mobile wallet (Tonhub e.g.)](https://ton.app/wallets/tonhub-wallet)
 
 #### Fill in the blanks with relevant information
 
@@ -52,7 +52,7 @@ Open [TON Minter](https://minter.ton.org/) or [TON Minter testnet](https://minte
 
 #### Token logo URL (optional)
 
-![image](/img/tutorials/jetton/jetton-token-logo.png)
+![Token logo URL field](/img/tutorials/jetton/jetton-token-logo.png)
 
 If you want your token to stand out, you’ll need to host an attractive logo online.
 
@@ -61,10 +61,10 @@ If you want your token to stand out, you’ll need to host an attractive logo on
 :::info
 You can easily find out about the URL placement of the logo in the [repository](https://github.com/ton-blockchain/minter-contract#jetton-metadata-field-best-practices) in the 'Where is this metadata stored' paragraph.
 
-- On-chain.
-- Off-chain IPFS.
-- Off-chain website.
-  :::
+- On-chain
+- Off-chain IPFS
+- Off-chain website
+:::
 
 #### How to create your logo URL?
 
@@ -79,14 +79,14 @@ You can easily find out about the URL placement of the logo in the [repository](
 
 ## 💸 Send jettons
 
-On the right side of the screen, you can **send tokens** to multi-currency wallets such as [Tonkeeper](https://tonkeeper.com/) or [Tonhub](https://tonhub.com).
+On the right side of the screen, you can **send tokens** to multi-currency wallets such as [Tonkeeper](https://tonkeeper.com/) or [Tonhub](https://ton.app/wallets/tonhub-wallet).
 
-![image](/img/tutorials/jetton/jetton-send-tokens.png)
+![Send tokens panel](/img/tutorials/jetton/jetton-send-tokens.png)
 
 :::info
-You also can **burn** your tokens to reduce their amount.
+You can also **burn** your tokens to reduce their amount.
 
-![image](/img/tutorials/jetton/jetton-burn-tokens.png)
+![Burn tokens panel](/img/tutorials/jetton/jetton-burn-tokens.png)
 :::
 
 ### 📱 Send tokens from your phone using Tonkeeper
@@ -96,20 +96,18 @@ Prerequisites:
 1. You must have jettons in your wallet.
 2. You need at least 0.1 TON to cover transaction fees.
 
-#### Step-by-step guide
-
 Then, go to **your token**, set the **amount** to send, and enter the **recipient address.**
 
-![image](/img/tutorials/jetton/jetton-send-tutorial.png)
+![Tonkeeper send flow](/img/tutorials/jetton/jetton-send-tutorial.png)
 
 ## 📚 Using the token on the site
 
 You can manage your token by entering its address in the **search bar** at the top of the TON Minter site.
 
 :::info
-The address can be found on the right side if you are already in the owner panel, or you can find the token address when receiving an airdrop.
+The address can be found on the right side if you are already in the user panel, or you can find the token address when receiving an airdrop.
 
-![image](/img/tutorials/jetton/jetton-wallet-address.png)
+![Owner panel wallet address](/img/tutorials/jetton/jetton-wallet-address.png)
 :::
 
 ## ✏️ Jetton (token) customization

--- a/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx
+++ b/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx
@@ -20,10 +20,10 @@ By the end of this tutorial, you'll be able to:
 
 Before you start, make sure you have the following:
 
-1. A [Tonhub](https://ton.app/wallets/tonhub-wallet) / [Tonkeeper](https://ton.app/wallets/tonkeeper) wallet or any other TON-compatible wallet.
-   At least 0.25 Toncoin in your wallet (plus extra for blockchain fees)
+1. A [Tonhub](https://tonhub.com) / [Tonkeeper](https://ton.app/wallets/tonkeeper) wallet or any other TON-compatible wallet.
+   At least 0.25 TON in your wallet (plus extra for blockchain fees)
 
-:::tip Starter tip
+:::tip starter tip
 \~0.5 TON should be enough for this tutorial.
 :::
 
@@ -41,7 +41,7 @@ Open [TON Minter](https://minter.ton.org/) or [TON Minter testnet](https://minte
 
 #### ![image](/img/tutorials/jetton/jetton-connect-wallet.png)
 
-**Scan the QR-code** in a [Mobile wallet (Tonhub e.g.)](https://ton.app/wallets/tonhub-wallet)
+**Scan the QR-code** in a [Mobile wallet (Tonhub e.g.)](https://tonhub.com)
 
 #### Fill in the blanks with relevant information
 
@@ -74,12 +74,12 @@ You can easily find out about the URL placement of the logo in the [repository](
 4. Upload your prepared image to git and enable `GitHub Pages`.
    1. [Add GitHub Pages to your repository](https://docs.github.com/en/pages/getting-started-with-github-pages/creating-a-github-pages-site).
    2. [Upload your image and get a link](https://docs.github.com/en/repositories/working-with-files/managing-files/adding-a-file-to-a-repository).
-5. If possible, purchase a custom domain for your project. Use any domain seller like [Google Domains](https://domains.google/) or [GoDaddy](https://www.godaddy.com/). Then, connect your custom domain to the repository in the previous step, you can follow the instructions [here](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site).
+5. If possible, purchase a custom domain for your project. Use any domain seller like [Google Domains](https://domains.google/) or [GoDaddy](https://www.godaddy.com/). Then connect your custom domain to the repository from the previous step. You can follow the instructions [here](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site).
 6. If you have a custom domain, your image URL should be `https://bitcoincash.org/logo.png` instead of the `github.io` one. This prevents dependency on GitHub and gives you full control over hosting.
 
 ## 💸 Send jettons
 
-On the right side of the screen, you can **send tokens** to multi-currency wallets such as [Tonkeeper](https://tonkeeper.com/) or [Tonhub](https://ton.app/wallets/tonhub-wallet).
+On the right side of the screen, you can **send tokens** to multi-currency wallets such as [Tonkeeper](https://tonkeeper.com/) or [Tonhub](https://tonhub.com).
 
 ![image](/img/tutorials/jetton/jetton-send-tokens.png)
 
@@ -93,8 +93,8 @@ You also can **burn** your tokens to reduce their amount.
 
 Prerequisites:
 
-1. You must have Jettons in your wallet.
-2. You need at least 0.1 Toncoin to cover transaction fees.
+1. You must have jettons in your wallet.
+2. You need at least 0.1 TON to cover transaction fees.
 
 #### Step-by-step guide
 
@@ -132,16 +132,16 @@ npm install
 
 4. Edit the smart contract files. All contract files are in `contracts/*.fc`
 
-5. Build a project by using:
+5. Build the project by running:
 
 ```bash npm2yarn
 npm run build
 ```
 
-The result will describe the process of creating the necessary files and the search for smart contracts.
+The output will show file generation and contract discovery.
 
 :::info
-Read the console, there are a lot of tips!
+Read the console; it includes many tips!
 :::
 
 6. You can test your changes using:
@@ -150,7 +150,7 @@ Read the console, there are a lot of tips!
 npm run test
 ```
 
-7. Edit the **name** and other metadata of the token in `build/jetton-minter.deploy.ts` by changing the JettonParams object.
+7. Edit the **name** and other metadata of the token in `build/jetton-minter.deploy.ts` by changing the JettonParams object. Note: If this file is generated in your setup, ensure you update the corresponding source or configuration so your changes persist.
 
 ```js
 // This is example data - Modify these parameters for your jetton!
@@ -174,7 +174,7 @@ npm run deploy
 
 The result of running your project:
 
-```js
+```text
 > @ton-defi.org/jetton-deployer-contracts@0.0.2 deploy
 > ts-node ./build/_deploy.ts
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-dapps-tutorials-mint-your-first-token.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx`

Related issues (from issues.normalized.md):
- [ ] **3060. Capitalize "Jetton" in title and headings**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx?plain=1

Capitalize Jetton in the page title and section headings for consistency with cross-doc references; e.g., change "Mint your first jetton" → "Mint your first Jetton" and "Deploy a jetton" → "Deploy a Jetton" (see docs/v3/documentation/dapps/defi/tokens.mdx#tutorials and docs/v3/guidelines/dapps/asset-processing/jettons.mdx#jetton-processing).

---

- [ ] **3061. Split prerequisites items and use TON ticker**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx?plain=1

In "Prepare before you start," split the wallet and funding requirement into two numbered items and use the ticker for amounts: "1. A TON-compatible wallet (e.g., Tonkeeper or Tonhub). 2. At least 0.25 TON to cover deployment and fees."

---

- [ ] **3062. Fix admonition closing delimiter indentation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx?plain=1

In the ":::info" block under "Token logo URL (optional)," remove leading spaces from the closing delimiter so it is ":::'' on its own line to render correctly.

---

- [ ] **3063. Remove heading markup from image lines**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx?plain=1

Do not prefix images with heading hashes; e.g., change "#### ![...](.../jetton-connect-wallet.png)" to just the image (optionally add a caption beneath).

---

- [ ] **3064. Replace generic image alt text with descriptive text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx?plain=1

Replace "image" alts with concise descriptions, e.g., "TON Minter main page", "Connect wallet dialog", "Token logo URL field", "Send tokens panel", "Burn tokens panel", "Tonkeeper send flow", "Owner panel wallet address".

---

- [ ] **3065. Fix QR code sentence grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx?plain=1

Change "Scan the QR-code in a Mobile wallet (Tonhub e.g.)" to "Scan the QR code in a mobile wallet (e.g., Tonhub)."

---

- [ ] **3066. Use neutral example domains for logo URLs**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx?plain=1

Replace third-party logo URL examples with neutral placeholders, e.g., "https://<your-username>.github.io/website/logo.png" and "https://example.com/logo.png".

---

- [ ] **3067. Change "You also can" to "You can also"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx?plain=1

In the burn note, revise to "You can also burn your tokens..." for natural word order.

---

- [ ] **3068. Rename misleading "Step-by-step guide" heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx?plain=1

Under "Send tokens from your phone using Tonkeeper," rename the "Step-by-step guide" heading to "Send tokens" since the section contains a single descriptive paragraph rather than enumerated steps.

---

- [ ] **3069. Clarify undefined UI term "owner panel"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx?plain=1

Replace "owner panel" with the exact visible UI label used in TON Minter (quote it verbatim), avoiding undefined terminology.

---

- [ ] **3070. Use "or" instead of slash in service link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx?plain=1

Change "Open the service [TON Minter] / [TON Minter testnet]" to "Open TON Minter or TON Minter testnet."

---

- [x] **3071. Improve build instruction phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx?plain=1

Change "Build a project by using:" to "Build the project by running:" to match imperative style.

---

- [x] **3072. Fence deployment output as text, not JavaScript**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx?plain=1

Change the fenced code block for CLI output from ```js to ```text to avoid misleading syntax highlighting.

---

- [x] **3073. Lowercase generic "jettons" in prerequisites**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx?plain=1

In the Tonkeeper prerequisites, change "You must have Jettons in your wallet." to "You must have jettons in your wallet."

---

- [ ] **3074. Link Tonhub to the official site**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx?plain=1

Update the Tonhub link to https://tonhub.com to align with the Wallets overview page.

---

- [x] **3075. Standardize on TON ticker for amounts**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx?plain=1

Replace mixed "Toncoin"/"TON" usage in numeric amounts with the ticker, e.g., "0.25 TON" and "~0.5 TON," for consistency within the section.

---

- [ ] **3076. Clarify editing of generated build file**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx?plain=1

Do not instruct users to edit build/jetton-minter.deploy.ts if it is generated; instead point to the correct source/config file, or explicitly note that this build file is intended for manual edits and will not be overwritten.

---

- [x] **3077. Normalize tip title casing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx?plain=1

Change the tip title from "Starter tip" to lowercase "starter tip" to match site conventions.

---

- [x] **3078. Fix comma splice in custom domain step**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx?plain=1

Revise to: "Then connect your custom domain to the repository from the previous step. You can follow the instructions here ..."

---

- [x] **3079. Clarify sentence about build output**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx?plain=1

Replace "The result will describe the process of creating the necessary files and the search for smart contracts." with "The output will show file generation and contract discovery."

---

- [x] **3080. Improve info note grammar about console tips**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/tutorials/mint-your-first-token.mdx?plain=1

Change "Read the console, there are a lot of tips!" to "Read the console; it includes many tips!"

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.