### PR TITLE
Split: update docs/v3/guidelines/nodes/custom-overlays.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/nodes/custom-overlays.mdx
+++ b/docs/v3/guidelines/nodes/custom-overlays.mdx
@@ -2,19 +2,19 @@ import Feedback from '@site/src/components/Feedback';
 
 # Custom overlays
 
-TON nodes communicate with each other by forming subnets called **overlay**. A few common overlay nodes participate, such as public overlays for each shard. Validators also participate in general validator overlays and overlays for specific validator sets.
+TON nodes communicate with each other by forming subnets called **overlays**. Nodes participate in several common overlays, such as public overlays for each shard. Validators also participate in general validator overlays and overlays for specific validator sets.
 
 Nodes can also be configured to join custom overlays for two primary purposes: broadcasting external messages and broadcasting block candidates.
 
-Participation in custom overlays allows for the avoidance of uncertainty of public overlays and improves delivery reliability and delays.
+Participation in custom overlays helps avoid uncertainties of public overlays and improves delivery reliability while reducing delays.
 
-Each custom overlay has a strictly determined list of participants with predefined permissions, particularly permission to send external messages and blocks. The overlay's configuration should be the same on all participating nodes.
+Each custom overlay has a strictly determined list of participants with predefined permissions, particularly permission to send external messages and block candidates. The overlay's configuration should be the same on all participating nodes.
 
-If you have multiple nodes under your control, it is expedient to unite them into a custom overlay, where all validators can send block candidates and all LS can send external messages. That way, LS will synchronize faster while simultaneously increasing the external message delivery rate (and delivery more robust in general). Note that additional overlay causes additional network traffic.
+If you have multiple nodes under your control, it is recommended to group them into a custom overlay, where all validators can send block candidates and all liteservers (LS) can send external messages. This helps LS synchronize faster while increasing the external message delivery rate and making delivery more robust. Note that an additional overlay causes additional network traffic.
 
 ## Default custom overlays
 
-MyTonCtrl utilizes default custom overlays, which can be found [here](https://ton-blockchain.github.io/fallback_custom_overlays.json). These overlays are typically not in use and are meant for emergency situations when there are connectivity issues with the public overlay.
+MyTonCtrl uses default custom overlays, which can be found [here](https://ton-blockchain.github.io/fallback_custom_overlays.json). These overlays are typically not in use and are meant for emergency situations when there are connectivity issues with the public overlay.
 
 If you wish to stop participating in default custom overlays, please run the following commands:
 
@@ -25,11 +25,11 @@ MyTonCtrl> delete_custom_overlay default
 
 ## Creating a custom overlay
 
-### Collect ADNL  addresses
+### Collect ADNL addresses
 
-To add validators to a custom overlay, you can use either their `fullnode adnl id` available with `validator-console -c getconfig` or `validator adnl id`, which can be found in MyTonCtrl's status.
+To add validators to a custom overlay, you can use either their `full node ADNL ID` available with `validator-engine-console` or `validator ADNL ID`, which can be found in MyTonCtrl's status.
 
-To add liteservers to a custom overlay, you must use their `fullnode adnl id`.
+To add liteservers to a custom overlay, you must use their `full node ADNL ID`.
 
 ### Create a config file
 
@@ -52,13 +52,13 @@ Create a config file in the following format:
 }
 ```
 
-`msg_sender_priority` determines the order of external message inclusion in blocks: messages from higher-priority sources are first processed. Messages from the public overlay and local LS have priority 0.
+`msg_sender_priority` determines the order of external message inclusion in blocks: messages from higher-priority sources are processed first. Messages from the public overlay and local LS have priority 0.
 
 :::caution
 All nodes listed in the configuration **must** participate in the overlay; if they do not add an overlay with the exact same configuration, connectivity will be poor and broadcasts may fail.
 :::
 
-There is a special word `@validators` to create a dynamic custom overlay that MyTonCtrl will generate automatically each round adding all current validators.
+There is a special keyword `@validators` that MyTonCtrl generates automatically each round, adding all current validators.
 
 ### Add custom overlay
 
@@ -69,22 +69,22 @@ MyTonCtrl> add_custom_overlay <name> <path_to_config>
 ```
 
 :::caution
-The name and config file **must** be the same on all overlay members. Check that the overlay has been created using MyTonCtrl's `list_custom_overlays` command.
+The name and configuration content **must** be the same on all overlay members. Check that the overlay has been created using MyTonCtrl's `list_custom_overlays` command.
 :::
 
 ### Debug
 
-You can set the node verbosity level equal to 4, and grep logs with the **CustomOverlay** word.
+Set the node verbosity level to 4 and grep the logs for `CustomOverlay`.
 
 ## Deleting a custom overlay
 
-To remove a custom overlay from a node, use the MyTonCtrl command `delete_custom_overlay <name>.`
+To remove a custom overlay from a node, use the MyTonCtrl command `delete_custom_overlay <name>`.
 
 If the overlay is dynamic (i.e., there is a `@validators` word in the config), it will be deleted within one minute; otherwise, it will be removed instantly.
 
-To make sure that the node has deleted the custom overlay, check MyTonCtrl's `list_custom_overlays`  and `showcustomoverlays` validator-console commands.
+To make sure that the node has deleted the custom overlay, check MyTonCtrl's `list_custom_overlays` and the validator‑engine‑console `showcustomoverlays` command.
 
-## Low level
+## Low‑level
 
 List of validator-console commands for managing custom overlays:
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-nodes-custom-overlays.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/nodes/custom-overlays.mdx`

Related issues (from issues.normalized.md):
- [ ] **3276. Fix intro pluralization and sentence clarity**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/custom-overlays.mdx?plain=1#L5-L6

Change “subnets called overlay” to “subnets called overlays” and rephrase the next sentence to “Nodes participate in several common overlays, such as public overlays for each shard.”

---

- [ ] **3277. Clarify reliability and delays sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/custom-overlays.mdx?plain=1#L9

Rewrite to “helps avoid uncertainties of public overlays and improves delivery reliability while reducing delays.”

---

- [ ] **3278. Define LS and improve synchronization paragraph**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/custom-overlays.mdx?plain=1#L13

Expand the acronym on first use as “liteservers (LS)”, rephrase to “This helps LS synchronize faster while increasing the external message delivery rate and making delivery more robust,” and correct to “an additional overlay causes additional network traffic.”

---

- [ ] **3279. Replace hardcoded overlay name in deletion example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/custom-overlays.mdx?plain=1#L21-L24

Use a placeholder command like “delete_custom_overlay <name>” (or explicitly state if the built‑in overlay is literally named “default”).

---

- [ ] **3280. Fix double space in “Collect ADNL addresses” heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/custom-overlays.mdx?plain=1#L28

Change “### Collect ADNL addresses” to “### Collect ADNL addresses.”

---

- [ ] **3281. Use correct console name and avoid undocumented flag**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/custom-overlays.mdx?plain=1#L30

Replace “validator-console -c getconfig” with “validator‑engine‑console” and avoid implying an undocumented “-c getconfig” flag (or document it).

---

- [ ] **3282. Standardize ADNL ID capitalization and “full node”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/custom-overlays.mdx?plain=1#L30-L32

Use “full node ADNL ID,” “validator ADNL ID,” and analogous casing for liteserver IDs (ADNL ID capitalized; “full node” spaced).

---

- [ ] **3283. Fix JSON and clarify block_sender in config example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/custom-overlays.mdx?plain=1#L38-L53

Provide valid JSON with unique keys and no ellipsis/trailing comma, and clarify that “block_sender: true” grants permission to send block candidates.

---

- [ ] **3284. Improve priority note wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/custom-overlays.mdx?plain=1#L55

Rephrase to “messages from higher‑priority sources are processed first,” and ensure acronym usage is consistent with the earlier LS definition.

---

- [ ] **3285. Clarify overlay consistency requirement**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/custom-overlays.mdx?plain=1#L71-L73

Change to “The name and configuration content must be the same on all overlay members.”

---

- [ ] **3286. Improve debugging guidance and format identifier**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/custom-overlays.mdx?plain=1#L75-L77

Rewrite to “Set the node verbosity level to 4 and grep the logs for `CustomOverlay`.”

---

- [ ] **3287. Move period outside inline code**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/custom-overlays.mdx?plain=1#L81

Change “`delete_custom_overlay <name>.`” to “`delete_custom_overlay <name>`.”

---

- [ ] **3288. Fix tool naming and spacing in commands sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/custom-overlays.mdx?plain=1#L85

Use “MyTonCtrl’s `list_custom_overlays` and the validator‑engine‑console `showcustomoverlays` command,” and remove the double space before “and.”

---

- [ ] **3289. Hyphenate “Low‑level” section title**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/custom-overlays.mdx?plain=1#L87

Change “Low level” to “Low‑level.”

---

- [ ] **3290. Provide valid JSON in low‑level example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/custom-overlays.mdx?plain=1#L93-L108

Remove the ellipsis and trailing comma and present a complete, valid JSON example.

---

- [ ] **3291. Use “block candidates” instead of “blocks”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/custom-overlays.mdx?plain=1

Replace “permission to send external messages and blocks” with “permission to send external messages and block candidates” for terminology consistency.

---

- [ ] **3292. Prefer natural phrasing over “expedient to unite them”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/custom-overlays.mdx?plain=1

Rewrite as “it is recommended to group them into a custom overlay.”

---

- [ ] **3293. Use “keyword” and fix generation phrasing for @validators**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/custom-overlays.mdx?plain=1

Change to “There is a special keyword `@validators` that MyTonCtrl generates automatically each round, adding all current validators.”

---

- [ ] **3294. Prefer “uses” over “utilizes”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/custom-overlays.mdx?plain=1

Change “MyTonCtrl utilizes default custom overlays …” to “MyTonCtrl uses default custom overlays …”.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.