### PR TITLE
Split: update docs/v3/guidelines/nodes/faq.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/nodes/faq.mdx
+++ b/docs/v3/guidelines/nodes/faq.mdx
@@ -25,13 +25,13 @@ MyTonCtrl compiles the validator components into the following directory:
 
 MyTonCtrl creates a working directory for the validator here:
 
-1. `/var/ton/`
+1. `/var/ton-work/`
 
 ---
 
 ## If MyTonCtrl was installed as root
 
-The configurations will be stored differently:
+When installed as root, some MyTonCtrl files (e.g., logs) are under:
 
 1. `/usr/local/bin/mytonctrl/`
 2. `/usr/local/bin/mytoncore/`
@@ -44,7 +44,6 @@ Run the script as an administrator and remove the compiled TON components:
 
 ```bash
 sudo bash /usr/src/mytonctrl/scripts/uninstall.sh
-sudo rm -rf /usr/bin/ton
 ```
 
 Ensure you have the necessary permissions to delete or modify files and directories.
@@ -55,19 +54,19 @@ Ensure you have the necessary permissions to delete or modify files and director
 
 If you want to change the working directory of the validator before installation, you have two options:
 
-1. **Fork the project**: You can fork the project and make your modifications there. To learn how to fork a project, use the command `man git-fork`.
+1. **Fork the project**: You can fork the project and make your modifications there. Refer to your Git hosting provider's documentation on forking a repository.
 
 2. **Create a symbolic link**: Alternatively, you can create a symbolic link with the following command:
 
    ```bash
-   ln -s /opt/ton/var/ton /var/ton
+   ln -s /opt/ton /var/ton-work
    ```
 
-This command will create a link at `/var/ton` that points to `/opt/ton`.
+This command will create a link at `/var/ton-work` that points to `/opt/ton`.
 
 ### Changing validator working directory post-installation
 
-To change the working directory of the validator from `/var/ton/` after installation, follow these steps:
+To change the working directory of the validator from `/var/ton-work/` after installation, follow these steps:
 
 1. **Stop services**: First, stop the services using the following commands:
 
@@ -79,18 +78,24 @@ To change the working directory of the validator from `/var/ton/` after installa
 2. **Move validator files**: Next, move the validator files with this command:
 
    ```bash
-   mv /var/ton/* /opt/ton/
+   rsync -a /var/ton-work/ /opt/ton-work/
    ```
 
-3. **Update configuration paths**: Ensure you update the paths in the configuration file located at `~/.local/share/mytoncore/mytoncore.db`.
+3. **Update configuration paths**: After moving directories, update related paths and settings:
+   - Systemd unit files (e.g., `validator.service`) to point to the new directory.
+   - `~/.local/share/mytoncore/mytoncore.db` references.
+   - `/var/ton-work/db/config.json` if it contains absolute paths.
+   - Ownership and permissions of the moved files.
 
-4. **Consider experience**: Note that there might be limited experience with this type of transfer, so take this into account as you proceed.
+:::caution
+Back up data and verify service configuration before proceeding with directory changes.
+:::
 
 Make sure you have sufficient permissions to execute these commands and make these changes.
 
 ## Understanding validator status and restarting validator in MyTonCtrl
 
-This [document](/v3/guidelines/nodes/running-nodes/validator-node) will help you confirm if MyTonCtrl has become a full validator.
+This [guide](/v3/guidelines/nodes/running-nodes/validator-node) helps you confirm your node is acting as a validator.
 
 ## Restarting your validator
 
@@ -100,11 +105,14 @@ If you need to restart your validator, run this command:
 systemctl restart validator.service
 ```
 
-Please ensure you have the necessary permissions to execute these commands and make any needed adjustments. <u>**Remember to back up important data before performing operations that may affect your validator.**</u>
+Please ensure you have the necessary permissions to execute these commands and make any needed adjustments.
+
+:::caution
+Remember to back up important data before performing operations that may affect your validator.
+:::
 
 ## See also
 
 - [Troubleshooting](/v3/guidelines/nodes/nodes-troubleshooting)
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-nodes-faq.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/nodes/faq.mdx`

Related issues (from issues.normalized.md):
- [ ] **3295. Align block time and finality with comparison table**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

FAQ lists “Block time: 2–5 seconds” and “Time-to-finality: under 6 seconds,” but the comparison table shows “Block Time: < 1 sec” and “Time to Finalize Block: < 3 sec”; align these values to the comparison or remove hard numbers and defer to docs/v3/concepts/dive-into-ton/ton-blockchain/blockchain-comparison.mdx as the source of truth.

---

- [ ] **3296. Fix admonition closing fences**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

The info callouts under “Block time” and “Time-to-finality” close with “ :::”; remove the leading spaces so closing fences are “:::” for proper MDX admonition rendering.

---

- [ ] **3297. Use text fence for average block size snippet**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

A code block tagged as bash contains non-executable config values; change the fence to “text” and rephrase to “From config Param 29:” then include “max_block_bytes: 2097152” (see docs/v3/documentation/network/configs/blockchain-configs.mdx#param-29).

---

- [ ] **3298. Add question mark to ENS heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Heading “Is it possible to have a named account similar to ENS” is missing a question mark; change to “Is it possible to have a named account similar to ENS?”.

---

- [ ] **3299. Soften MEV claims and fix fee wording and typo**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Replace “eliminates” with “significantly limits,” change “Commissions are fixed” to “Gas price is protocol-defined (no fee market); users can’t bid for priority,” and add the missing space in “ordering,front‑running” (see docs/v3/documentation/smart-contracts/transaction-fees/fees.mdx).

---

- [ ] **3300. Correct cross-reference in RPC transactions section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

The “See answer above” link in “RPC method to get transactions data” points to an unrelated token standards section; update it to the API types page at /v3/guidelines/dapps/apis-sdks/api-types or to this page’s “Recommended node providers for data extraction” section instead.

---

- [ ] **3301. Remove unsupported ‘-1 TON’ deletion threshold**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Delete the hard “-1 TON” value and state that contracts can be deleted when accumulated storage fees exceed the configured delete limits, citing docs/v3/documentation/network/configs/blockchain-configs.mdx#param-20-and-21 and docs/v3/documentation/smart-contracts/addresses/address-states.mdx.

---

- [ ] **3302. Capitalize ‘TON Virtual Machine’ in heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Change “Ton Virtual Machine (TVM)” to “TON Virtual Machine (TVM)” for consistency with the rest of the docs.

---

- [ ] **3303. Rephrase transaction sync heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Change “Is the TON transaction asynchronous or synchronous?” to “Are TON transactions asynchronous or synchronous?”.

---

- [ ] **3304. Add article in ‘Can a smart contract be deleted?’**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Add the article to read “Can a smart contract be deleted?”.

---

- [ ] **3305. Capitalize ‘WorkChains’ in L2 heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Use “Why are WorkChains better than L1 → L2?” to match capitalization used elsewhere.

---

- [ ] **3306. Use ‘on TON’ preposition**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Replace “on the TON” with “on TON” for consistent style across the docs.

---

- [ ] **3307. Simplify ‘Node providers partners’ phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Change the phrase to “Node providers:” (or “Node provider partners:”) for clarity.

---

- [ ] **3308. Clarify Toncoin decimals and jetton precision**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Replace “Mainnet supports a 9-digit accuracy for currencies” with “Toncoin uses 9 decimals; jettons define decimals per token (often 9),” and add citations to docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx and docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx#properties.

---

- [ ] **4472. Use canonical working directory path (/var/ton-work)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Replace every occurrence of /var/ton/ with the canonical /var/ton-work/ to align with paths used across the docs (e.g., db and logs locations).

---

- [ ] **4473. Fix symlink command target and link name**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Update the symlink example to correctly point the link to /opt/ton and use the canonical link name: ln -s /opt/ton /var/ton-work.

---

- [ ] **4474. Correct MyTonCtrl vs MyToncore log locations**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Change the statement about logs in ~/.local/share/mytonctrl/ to: “~/.local/share/mytonctrl/: MyTonCtrl metadata (e.g., VERSION); logs are in ~/.local/share/mytoncore/mytoncore.log (or /usr/local/bin/mytoncore/mytoncore.log when run as root).”

---

- [ ] **4475. Refer to mytoncore as a service, not a script**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Reword to: “MyTonCtrl includes the mytoncore background service, which stores files in …” to match systemd usage elsewhere.

---

- [ ] **4476. Remove non-canonical uninstall rm command**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Delete the extra step sudo rm -rf /usr/bin/ton and keep the uninstall flow as only sudo bash /usr/src/mytonctrl/scripts/uninstall.sh.

---

- [ ] **4477. Clarify root install section: logs vs configs**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Change “The configurations will be stored differently” to “When installed as root, some MyTonCtrl files (e.g., logs) are under: 1) /usr/local/bin/mytonctrl/ 2) /usr/local/bin/mytoncore/.”

---

- [ ] **4478. Remove bogus “man git-fork” instruction**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Delete the man git-fork line and instead say “Refer to your Git hosting provider’s documentation on forking a repository.”

---

- [ ] **4479. Fix post-install move: avoid glob; use canonical path**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Replace mv /var/ton/* /opt/ton/ with a safe, canonical move that preserves dotfiles (e.g., mv /var/ton-work /opt/ton-work or rsync -a /var/ton-work/ /opt/ton-work/).

---

- [ ] **4480. Add checklist for path changes after directory move**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Expand the note beyond mytoncore.db to instruct updating the systemd unit (e.g., validator.service), /var/ton-work/db/config.json, and file ownership/permissions after changing directories.

---

- [ ] **4481. Replace vague experience note with actionable caution**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Swap the “Consider experience…” sentence for a docs-style caution admonition advising to back up data and verify service configuration before proceeding.

---

- [ ] **4482. Rephrase validator wording (tool vs node)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Change “…confirm if MyTonCtrl has become a full validator” to “This guide helps you confirm your node is acting as a validator,” using “validator” consistently and not “full validator.”

---

- [ ] **4483. Replace underline+bold with an admonition**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Remove the <u>**...**</u> backup reminder and present it as a proper admonition block (e.g., :::caution) per docs style.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.