### PR TITLE
Split: update docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-backup-restore.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-backup-restore.mdx
+++ b/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-backup-restore.mdx
@@ -12,25 +12,22 @@ MyTonCtrl will create a backup package in the user's home directory. The package
 
 The backup will include the following components:
 
-- Node configuration file located at (`/var/ton-work/db/config.json`)
-
-- Node keyring found in (`/var/ton-work/db/keyring`)
-
-- Node liteserver and console keys stored in (`/var/ton-work/keys`)
-
-- MyTonCtrl configuration database and related files located at (`~/.local/share/mytoncore`)
-
-- Wallet and pool data
+- Node configuration file located at `/var/ton-work/db/config.json`
+- Node keyring found in `/var/ton-work/db/keyring`
+- Node liteserver and console keys stored in `/var/ton-work/keys`
+- MyTonCtrl configuration database and related files located at `~/.local/share/mytoncore`
+- Wallets located at `~/.local/share/mytoncore/wallets/`
+- Pools located at `~/.local/share/mytoncore/pools/`
 
 ## Automated backup package creation
 
-If your node is involved in validation, you can set up automated backups of the node configuration. These backups will be performed immediately after your node participates in the elections, ensuring that all data needed for the upcoming validation cycle is preserved.
+If your node is involved in validation, you can set up automated backups of the node configuration. These backups will be performed after election-related operations, ensuring that all data needed for the upcoming validation cycle is preserved.
 
-To enable automated backups, set the parameter: `auto_backup` to `true` by issuing the command `set auto_backup true` on the MyTonCtrl console.
+To enable automated backups, set the `auto_backup` parameter to `true` by running `set auto_backup true` in the MyTonCtrl console.
 
 ### Automated backup location and lifecycle
 
-By default, automated backups are saved in the directory `/tmp/mytoncore/auto_backups/` located in the home folder of the user under which the **mytoncore** process is running. You can change this location by adjusting the `auto_backup_path` parameter in the MyTonCtrl console.
+By default, automated backups are saved under `/tmp/mytoncore/auto_backups/`. You can change this location by adjusting the `auto_backup_path` parameter in the MyTonCtrl console.
 
 **Note that automated backups that are older than 7 days will be automatically deleted.**
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-nodes-maintenance-guidelines-mytonctrl-backup-restore.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-backup-restore.mdx`

Related issues (from issues.normalized.md):
- [ ] **3309. Fix bullet list path formatting and add missing paths**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-backup-restore.mdx?plain=1#L15-L21

Remove parentheses around inline-code paths in the bullets and explicitly include wallet and pool directories (use paths like `/var/ton-work/db/config.json`, `/var/ton-work/db/keyring`, `/var/ton-work/keys`, `~/.local/share/mytoncore`, plus `~/.local/share/mytoncore/wallets/` and `~/.local/share/mytoncore/pools/`).

---

- [ ] **3310. Soften election phrasing and timing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-backup-restore.mdx?plain=1#L27

Replace “immediately after your node participates in the elections” with a neutral phrasing such as “after election-related operations,” avoiding “the elections” (use “elections” or “an election”).

---

- [ ] **3311. Simplify automated backup setting sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-backup-restore.mdx?plain=1#L29

Change to: “To enable automated backups, set the `auto_backup` parameter to `true` by running `set auto_backup true` in the MyTonCtrl console.”

---

- [ ] **3312. Correct automated backup location description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-backup-restore.mdx?plain=1#L33

Remove the “home folder” claim and state: “By default, automated backups are saved under `/tmp/mytoncore/auto_backups/`,” optionally noting the location is configurable via the `auto_backup_path` parameter.

---

- [ ] **3313. Use code formatting for service name**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-backup-restore.mdx?plain=1#L33

Change bold “mytoncore” to inline code formatting: `mytoncore`.

---

- [ ] **3314. Clarify retention and remove redundancy**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-backup-restore.mdx?plain=1#L35

Replace “automated backups that are older than 7 days will be automatically deleted” with a verified statement or a neutral version (e.g., “Backups are deleted automatically according to retention settings”); avoid repeating “automated/automatically.”

---

- [ ] **3315. Fix cross-reference anchor for automated backups section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-backup-restore.mdx?plain=1

Rename the heading to “Automated backup creation” (to produce `#automated-backup-creation`) or update the referring link to `#automated-backup-package-creation` so the anchor resolves.

---

- [ ] **3316. Document commands and settings with syntax examples**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-backup-restore.mdx?plain=1

Add brief syntax examples for `create_backup`, `restore_backup <file_name>`, `auto_backup`, and `auto_backup_path`, and link to the `set` command documentation for context.

---

- [ ] **3317. Specify manual backup archive output location**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-backup-restore.mdx?plain=1

Remove the claim that the manual backup archive is created in the user’s home directory or replace it with the exact default output path, if known.

---

- [ ] **3318. Add guidance to verify IP after restore**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-backup-restore.mdx?plain=1

Replace the definitive “IP will be updated” claim with an instruction to verify and update `/var/ton-work/db/config.json` (`addrs[0].ip`) after restore if needed.

---

- [ ] **3319. Promote “Restore backup package” heading to H2**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-backup-restore.mdx?plain=1

Change “### Restore backup package” to “## Restore backup package” to align with the section hierarchy.

---

- [ ] **3320. Include MyTonCtrl prompt in console examples**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-backup-restore.mdx?plain=1

Show console commands with the prompt for clarity, e.g., “MyTonCtrl> set auto_backup true” and “MyTonCtrl> restore_backup <file_name>.”

---

- [ ] **3321. Use an admonition for critical restore notes**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-backup-restore.mdx?plain=1

Convert the “Important notes” block into a Docusaurus admonition (e.g., `:::warning`) for consistency and emphasis.

---

- [ ] **3360. State backup archive output path**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-remote-controller.mdx?plain=1#setting-up

Explicitly state the full path where the backup archive is written in this flow (e.g., /tmp/mytoncore/backupv2/...) and update transfer instructions accordingly, optionally linking to docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-backup-restore.mdx#manual-backup-package-creation for context.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.