### PR TITLE
Split: update docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-prometheus.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-prometheus.mdx
+++ b/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-prometheus.mdx
@@ -1,25 +1,24 @@
 import Feedback from '@site/src/components/Feedback';
 
-# MyTonCtrl prometheus metrics
+# MyTonCtrl Prometheus Metrics
 
 MyTonCtrl can be configured to expose Prometheus metrics for monitoring and alerting purposes. 
 This guide will walk you through the process of enabling Prometheus metrics in MyTonCtrl.
 
-### Metrics delivery method
+## Metrics delivery method
 
-Currently, MyTonCtrl can only push metrics to Prometheus because of security reasons. 
-So it should be used with the [Prometheus Pushgateway](https://github.com/prometheus/pushgateway) service.
+Currently, for security reasons, MyTonCtrl pushes metrics to a Prometheus Pushgateway, which Prometheus then scrapes.
 
 ## Setup
 
 :::caution
-For validators it's highly recommended to run Prometheus and Pushgateway on a separate server.
+For validators, it's highly recommended to run Prometheus and Pushgateway on a separate server.
 :::
 
 1. Install Pushgateway
 
-    You can install the Pushgateway service by following the instructions in the [official documentation](https://github.com/prometheus/pushgateway?tab=readme-ov-file#run-it).
-    The easiest way to do that is via docker:
+    You can install the Pushgateway service by following the instructions in the [official documentation](https://github.com/prometheus/pushgateway#run-it).
+    The easiest way to do that is via Docker:
   
       ```bash
       docker pull prom/pushgateway
@@ -28,7 +27,7 @@ For validators it's highly recommended to run Prometheus and Pushgateway on a se
 
 2. Configure Prometheus
 
-    Create `prometheus.yml` file adding the Pushgateway job to the scrape_configs section. Example of the configuration file:
+    Create a `prometheus.yml` file, adding the Pushgateway job to the `scrape_configs` section.
 
     ```yaml
     global:
@@ -44,12 +43,12 @@ For validators it's highly recommended to run Prometheus and Pushgateway on a se
         honor_labels: true
         static_configs:
           - targets: ["localhost:9091"]  # or "host.docker.internal:9091" if you are using Docker
-     ```
+    ```
 
 3. Install Prometheus
 
     You can install Prometheus by following the instructions in the [official documentation](https://prometheus.io/docs/prometheus/latest/installation/).
-    The easiest way to do that is via docker:
+    The easiest way to do that is via Docker:
   
       ```bash
     docker volume create prometheus-data
@@ -63,16 +62,16 @@ For validators it's highly recommended to run Prometheus and Pushgateway on a se
 
 4. Configure MyTonCtrl
 
-    Enable mode `prometheus` in MyTonCtrl:
+    Enable mode `prometheus` in MyTonCtrl (see the [MyTonCtrl enable_mode command](/v3/documentation/infra/nodes/mytonctrl/mytonctrl-overview#enable_mode)):
 
-    ```bash
+    ```text
     MyTonCtrl> enable_mode prometheus
     ```
 
-    Set the Pushgateway url:
+    Set the Pushgateway URL (see the [MyTonCtrl set command](/v3/documentation/infra/nodes/mytonctrl/mytonctrl-overview#set)):
 
-    ```bash
-    MyTonCtrl> set prometheus_url http://<host>:9091/metrics/job/<jobname>
+    ```text
+    MyTonCtrl> set prometheus_url http://<host>:9091/metrics/job/<job_name>
     ```
     :::warning
     Note that it is very important to use different job names for different nodes in case you want to monitor multiple nodes with the same Prometheus instance.
@@ -82,9 +81,8 @@ For validators it's highly recommended to run Prometheus and Pushgateway on a se
 
     You can check that Prometheus scrapes the metrics by opening the Prometheus web interface:
 
-    ```bash
+    ```text
     http://<host>:9090/targets
     ```
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-nodes-maintenance-guidelines-mytonctrl-prometheus.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-prometheus.mdx`

Related issues (from issues.normalized.md):
- [x] **3335. Capitalize page title**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-prometheus.mdx?plain=1#L3

Change the H1 from "# MyTonCtrl prometheus metrics" to "# MyTonCtrl Prometheus Metrics" to use proper noun and title case.

---

- [x] **3336. Use H2 for “Metrics delivery method”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-prometheus.mdx?plain=1#L8

Change "### Metrics delivery method" to "## Metrics delivery method" to maintain a consistent heading hierarchy.

---

- [x] **3337. Clarify security phrasing about metrics delivery**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-prometheus.mdx?plain=1#L10-L11

Replace the sentence with: "Currently, for security reasons, MyTonCtrl pushes metrics to a Prometheus Pushgateway, which Prometheus then scrapes."

---

- [x] **3338. Add comma after introductory phrase**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-prometheus.mdx?plain=1#L16

Add a comma: "For validators, it's highly recommended to run Prometheus and Pushgateway on a separate server."

---

- [x] **3339. Stabilize Pushgateway docs link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-prometheus.mdx?plain=1#L21

Replace "https://github.com/prometheus/pushgateway?tab=readme-ov-file#run-it" with the stable anchor "https://github.com/prometheus/pushgateway#run-it".

---

- [x] **3340. Capitalize “Docker”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-prometheus.mdx?plain=1#L22,L52

Change "via docker:" to "via Docker:" in both occurrences.

---

- [x] **3341. Clarify sentence and code‑format scrape_configs**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-prometheus.mdx?plain=1#L31

Change to: "Create a `prometheus.yml` file, adding the Pushgateway job to the `scrape_configs` section."

---

- [x] **3342. Align YAML code fence indentation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-prometheus.mdx?plain=1#L33-L47

De-indent the closing code fence by one space to align with the opening fence and avoid MDX list rendering issues.

---

- [x] **3343. Use neutral code fence for MyTonCtrl prompt**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-prometheus.mdx?plain=1#L68-L70,L74-L76

Change code block language from "bash" to "text" (or omit) for commands entered in the MyTonCtrl interactive prompt.

---

- [x] **3344. Cross-reference MyTonCtrl commands**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-prometheus.mdx?plain=1#L68-L76

Add links to the command references: docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-overview.mdx#enable_mode and docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-overview.mdx#set; verify the exact mode/setting names if a canonical definition exists.

---

- [x] **3345. Capitalize “URL”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-prometheus.mdx?plain=1#L72

Change "Set the Pushgateway url:" to "Set the Pushgateway URL:".

---

- [x] **3346. Standardize job name placeholder**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-prometheus.mdx?plain=1#L75

Change "http://<host>:9091/metrics/job/<jobname>" to "http://<host>:9091/metrics/job/<job_name>" (or "<JOB_NAME>") and use that style consistently.

---

- [x] **3347. Avoid bash fence for plain URL**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-prometheus.mdx?plain=1#L85-L87

Do not tag a plain URL as bash; use a plain link or a "text" code block, e.g., "Open http://<host>:9090/targets" or a clickable link.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.