### PR TITLE
Split: update docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-remote-controller.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-remote-controller.mdx
+++ b/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-remote-controller.mdx
@@ -2,29 +2,28 @@ import Feedback from '@site/src/components/Feedback';
 
 # MyTonCtrl remote controller
 
-MyTonCtrl and TON Node can be used on separate machines. There are some advantages of using that:
+MyTonCtrl and TON node can be used on separate machines. There are several advantages to this setup:
 
-- To participate in elections, the validator wallet's private key is required by MyTonCtrl. If the Node server
+- To participate in elections, the validator wallet's private key is required by MyTonCtrl. If the node server
   is compromised, it could lead to unauthorized access to the wallet funds. As a security measure, MyTonCtrl can be hosted on a separate server.
-- MyTonCtrl continually expands its functionality, which may consume resources crucial for the Node.
-- Probably in future big validators will be able to host several instances of MyTonCtrl controlling several nodes on one server.
+- MyTonCtrl continually expands its functionality, which may consume resources crucial for the node.
 
 ## Setting up
 
-Prepare 2 servers: one is for running TON Node that meets the requirements and one is for running MyTonCtrl which does not require a lot of resources.
+Prepare two servers: one for running the TON node (meeting the [OS requirements](/v3/guidelines/nodes/running-nodes/full-node#os-requirements) and [hardware requirements](/v3/guidelines/nodes/running-nodes/full-node#hardware-requirements)) and one for running MyTonCtrl, which does not require many resources.
 
-1. Node server:
+1. node server:
 
 Install MyTonCtrl in `only-node` mode:
 
-```
+```bash
 wget https://raw.githubusercontent.com/ton-blockchain/mytonctrl/master/scripts/install.sh
 sudo bash install.sh -m validator -l
 ```
 
-It will install TON Node and create a backup file which you need to download and transfer to the Controller server:
+It will install the TON node and create a backup file which you need to download and transfer to the controller server:
 
-```log
+```text
 ...
 [debug]   01.01.2025, 00:00:00.000 (UTC)  <MainThread>  start CreateSymlinks fuction
 Local DB path: /home/user/.local/share/mytoncore/mytoncore.db
@@ -38,27 +37,30 @@ If you wish to use archive package to migrate node to different machine please m
 [5/5] Mytonctrl installation completed
 ```
 
-Note, that you still got access to MyTonCtrl console on this server, which you need to update the Node, watch Node metrics, etc.
+Note that you still have access to the MyTonCtrl console on this server, which you can use to update the node and monitor node metrics, etc.
 Also, it creates a `mytoncore` service which is used to send telemetry (if it was not disabled).
-If you want to return control of the node to this server, use command
+If you want to return control of the node to this server, use the following commands:
+
+```text
+MyTonCtrl> set onlyNode false
+```
 
 ```bash
-MyTonCtrl> set onlyNode false
 systemctl restart mytoncore
 ```
 
-2. Controller server
+2. controller server
 
 Install MyTonCtrl in `only-mtc` mode:
 
-```
+```bash
 wget https://raw.githubusercontent.com/ton-blockchain/mytonctrl/master/scripts/install.sh
 sudo bash install.sh -p /home/user/mytonctrl_backup_hostname_timestamp.tar.gz -o
 ```
 
 Check the `status` command, there should appear `Node IP address` field:
 
-```log
+```text
 MyTonCtrl> status
 [debug]   01.01.2025, 00:00:00.000 (UTC)  <MainThread>  start GetValidatorWallet function
 [debug]   01.01.2025, 00:00:00.000 (UTC)  <MainThread>  start GetLocalWallet function
@@ -73,6 +75,6 @@ Validator index: n/a
 
 ## Notes
 
-On updates, you need to `update` and `upgrade` both Node server and Controller server
+On updates, you need to `update` and `upgrade` both the node server and the controller server
 
 <Feedback />

--- a/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-remote-controller.mdx
+++ b/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-remote-controller.mdx
@@ -4,9 +4,9 @@ import Feedback from '@site/src/components/Feedback';
 
 MyTonCtrl and TON node can be used on separate machines. There are several advantages to this setup:
 
-- To participate in elections, the validator wallet's private key is required by MyTonCtrl. If the node server
+* To participate in elections, the validator wallet's private key is required by MyTonCtrl. If the node server
   is compromised, it could lead to unauthorized access to the wallet funds. As a security measure, MyTonCtrl can be hosted on a separate server.
-- MyTonCtrl continually expands its functionality, which may consume resources crucial for the node.
+* MyTonCtrl continually expands its functionality, which may consume resources crucial for the node.
 
 ## Setting up
 
@@ -21,11 +21,14 @@ wget https://raw.githubusercontent.com/ton-blockchain/mytonctrl/master/scripts/i
 sudo bash install.sh -m validator -l
 ```
 
-It will install the TON node and create a backup file which you need to download and transfer to the controller server:
+* `-m validator` — installs in validator mode.
+* `-l` — only-node mode: installs TON node only, no MyTonCtrl controller.
+
+It will install the TON node and create a backup file which you need to download and transfer to the controller server. The backup archive is saved under `/tmp/mytoncore/backupv2/` with a name like `mytonctrl_backup_hostname_timestamp.tar.gz`.
 
 ```text
 ...
-[debug]   01.01.2025, 00:00:00.000 (UTC)  <MainThread>  start CreateSymlinks fuction
+[debug]   01.01.2025, 00:00:00.000 (UTC)  <MainThread>  start CreateSymlinks function
 Local DB path: /home/user/.local/share/mytoncore/mytoncore.db
 [info]    01.01.2025, 00:00:00.000 (UTC)  <MainThread>  start ConfigureOnlyNode function
 [1/2] Copied files to /tmp/mytoncore/backupv2
@@ -34,7 +37,7 @@ If you wish to use archive package to migrate node to different machine please m
 [info]    01.01.2025, 00:00:00.000 (UTC)  <MainThread>  Backup successfully created. Use this file on the controller server with `--only-mtc` flag on installation.
 [debug]   01.01.2025, 00:00:00.000 (UTC)  <MainThread>  Start/restart mytoncore service
 [debug]   01.01.2025, 00:00:00.000 (UTC)  <MainThread>  sleep 1 sec
-[5/5] Mytonctrl installation completed
+[5/5] MytonCtrl installation completed
 ```
 
 Note that you still have access to the MyTonCtrl console on this server, which you can use to update the node and monitor node metrics, etc.
@@ -49,7 +52,7 @@ MyTonCtrl> set onlyNode false
 systemctl restart mytoncore
 ```
 
-2. controller server
+2. Controller server:
 
 Install MyTonCtrl in `only-mtc` mode:
 
@@ -58,7 +61,10 @@ wget https://raw.githubusercontent.com/ton-blockchain/mytonctrl/master/scripts/i
 sudo bash install.sh -p /home/user/mytonctrl_backup_hostname_timestamp.tar.gz -o
 ```
 
-Check the `status` command, there should appear `Node IP address` field:
+* `-p <path>` — specifies the path to the backup archive.
+* `-o` — only-mtc mode: installs MyTonCtrl only, no TON node.
+
+Run the `status` command; you should see the node’s IP address when configured:
 
 ```text
 MyTonCtrl> status
@@ -68,7 +74,7 @@ MyTonCtrl> status
 [debug]   01.01.2025, 00:00:00.000 (UTC)  <MainThread>  start WalletVersion2Wallet function
 [debug]   01.01.2025, 00:00:00.000 (UTC)  <MainThread>  start GetDbSize function
 ===[ Node status ]===
-Node IP address: 0.0.0.0
+Node IP address: <configured_ip>
 Validator index: n/a
 ...
 ```


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-nodes-maintenance-guidelines-mytonctrl-remote-controller.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-remote-controller.mdx`

Related issues (from issues.normalized.md):
- [x] **3348. Improve advantages intro phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-remote-controller.mdx?plain=1

Replace "There are some advantages of using that:" with "There are several advantages to this setup:" for natural wording.

---

- [x] **3349. Standardize node and server capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-remote-controller.mdx?plain=1

Use "TON node" for the product and lowercase "node" generically; use "node server" and "controller server" consistently in text and headings (e.g., change "the Node server" → "the node server", "crucial for the Node" → "crucial for the node", and "update the Node, watch Node metrics" → "update the node and monitor node metrics").

---

- [x] **3350. Remove speculative validators statement**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-remote-controller.mdx?plain=1

Delete the speculative bullet about future validators hosting several MyTonCtrl instances on one server.

---

- [x] **3351. Clarify setup sentence and link requirements**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-remote-controller.mdx?plain=1#setting-up

Replace with "Prepare two servers: one for running the TON node (meeting the OS and hardware requirements) and one for running MyTonCtrl, which does not require many resources," linking to docs/v3/guidelines/nodes/running-nodes/full-node.mdx#os-requirements and docs/v3/guidelines/nodes/running-nodes/full-node.mdx#hardware-requirements.

---

- [x] **3352. Add bash language to install commands**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-remote-controller.mdx?plain=1#setting-up

Add the "bash" language tag to both install command code fences under "Node server" and "Controller server" for proper syntax highlighting.

---

- [x] **3353. Use "text" for log/output code blocks**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-remote-controller.mdx?plain=1

Change all code fences labeled "log" (including the status/output examples) to "text" for plain-output highlighting supported by Prism.

---

- [x] **3354. Split console and system commands into separate blocks**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-remote-controller.mdx?plain=1#setting-up

Place "MyTonCtrl> set onlyNode false" in a 'text' fence and "systemctl restart mytoncore" in a 'bash' fence, and change the preceding line to "use the following commands:".

---

- [x] **3355. Fix typos in sample log**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-remote-controller.mdx?plain=1#setting-up

In the example log, correct "CreateSymlinks fuction" to "CreateSymlinks function" and "[5/5] Mytonctrl installation completed" to "[5/5] MyTonCtrl installation completed".

---

- [x] **3356. Fix note grammar and tone**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-remote-controller.mdx?plain=1

Replace "Note, that you still got access to MyTonCtrl console on this server, which you need to update the Node, watch Node metrics, etc." with "Note that you still have access to the MyTonCtrl console on this server, which you can use to update the node and monitor node metrics, etc.," and replace "On updates, you need to `update` and `upgrade` both Node server and Controller server" with "When updating, run `update` and `upgrade` on both the node server and the controller server."

---

- [x] **3357. Revise status section wording and IP example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-remote-controller.mdx?plain=1#controller-server

Change "Check the `status` command, there should appear `Node IP address` field:" to "Run the `status` command; you should see the node’s IP address when configured:" and replace "Node IP address: 0.0.0.0" with "Node IP address: <node-ip-address>", avoiding reliance on an undocumented field name.

---

- [x] **3358. Add colon to "2. Controller server"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-remote-controller.mdx?plain=1#setting-up

Add a trailing colon so the list header reads "2. Controller server:" to match "1. Node server:".

---

- [x] **3359. Document install modes and flags**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-remote-controller.mdx?plain=1#setting-up

Define what "only-node"/"only-mtc" modes and the -l, -o, and -p flags do (or replace them with documented equivalents) and use one consistent form (short or long) in both prose and commands.

---

- [ ] **3360. State backup archive output path**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-remote-controller.mdx?plain=1#setting-up

Explicitly state the full path where the backup archive is written in this flow (e.g., /tmp/mytoncore/backupv2/...) and update transfer instructions accordingly, optionally linking to docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-backup-restore.mdx#manual-backup-package-creation for context.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.