### PR TITLE
Split: update docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx
+++ b/docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx
@@ -69,11 +69,7 @@ The following list outlines the SAR commands that can be used to gather various 
 sar -rh
 ```
 
-The TON validator engine uses the **jemalloc** feature, which allows it to cache a significant amount of data. As a result, the `sar —rh` command often returns a low number in the `%memused` column.
-
-Meanwhile, you will typically see a high number in the `kbcached` column. Therefore, there is no need to worry about the low amount of free RAM indicated in the `kbmemfree` column. The key indicator to monitor is the value shown in the `%memused` column.
-
-If the percentage exceeds 90%, you should consider adding more RAM. Additionally, keep an eye on your validator engine to ensure it doesn't stop unexpectedly due to an out-of-memory (OOM) issue. The best way to check for this is to grep the `/var/ton-work/log` file for any **Signal** messages.
+The TON validator engine uses the **jemalloc** feature, which allows it to cache a significant amount of data. You will typically see a high value in the `kbcached` column. Linux counts page cache as used; low values in the `kbmemfree` column alone aren’t an issue—monitor swap activity (`sar -Sh`) and OOM events. Consider adding more RAM if `%memused` stays high (e.g., >90%) together with swap usage. Additionally, keep an eye on your validator engine to ensure it doesn't stop unexpectedly due to an out-of-memory (OOM) issue. The best way to check for this is to grep the `/var/ton-work/log` directory, for example: `grep -i "Signal" /var/ton-work/log/*`.
 
 **Swap usage:**
 
@@ -81,7 +77,7 @@ If the percentage exceeds 90%, you should consider adding more RAM. Additionally
 sar -Sh
 ```
 
-If you notice that a swap is used, you should consider adding more RAM. The general recommendation from the **TON Core team** is to disable the swap.
+If you notice that swap is in use, consider disabling swap for production validator nodes.
 
 ### CPU report
 
@@ -89,9 +85,9 @@ If you notice that a swap is used, you should consider adding more RAM. The gene
 sar -u
 ```
 
-If your server utilizes CPU on average up to 70% (see the `%user` column), this should be considered as good.
+If your server utilizes CPU on average up to 70% (see the `%user` column), this should be considered good for production validator nodes.
 
-### Disk Usage report
+### Disk usage report
 
 ```bash
 sar -dh
@@ -101,7 +97,7 @@ Watch the `%util` column and react accordingly if it stays above 90% for a parti
 
 ### Network report
 
-Use the commands :
+Use the following commands:
 
 ```bash
 sar -n DEV -h
@@ -115,23 +111,23 @@ sar -n DEV -h --iface=<interface name>
 
 if you want to filter results by network interface name.
 
-Check out the result of column `%ifutil` - it shows the usage of your interface considering its maximum link speed.
+Check the `%ifutil` column; it shows your interface utilization relative to its maximum link speed.
 
-You can check what speed is supported by your NIC by executing the command below:
+You can check which link speed your NIC supports by executing the command below:
 
 ```bash
 cat /sys/class/net/<interface>/speed
 ```
 
 :::info
-The speed you're experiencing is not what your provider promised you.
+Link speed reflects the negotiated NIC link rate; actual throughput may differ from your provider’s advertised bandwidth.
 :::
 
-Consider upgrading your link speed if `%ifutil` shows above 70% usage or columns `rxkB/s` and `txkB/s` reporting values close to a bandwidth provided by your provider.
+Consider upgrading your link if `%ifutil` is above 70% or if `rxkB/s` and `txkB/s` are close to your provisioned bandwidth, especially for production validator nodes.
 
 ### Reporting a performance issue
 
-Before reporting any performance issues, ensure that you meet the minimum requirements for the node. Then, execute the following commands:
+Before reporting any performance issues, ensure that you meet the [minimum requirements](/v3/guidelines/nodes/running-nodes/validator-node#minimal-hardware-requirements) for the node. Then, execute the following commands:
 
 To generate today's report, run:
 
@@ -151,7 +147,7 @@ Additionally, stop the TON node and measure your disk I/O and network speed with
 sudo fio --randrepeat=1 --ioengine=io_uring --direct=1 --gtod_reduce=1 --name=test --filename=/var/ton-work/testfile --bs=4096 --iodepth=1 --size=40G --readwrite=randread --numjobs=1 --group_reporting
 ```
 
-Look for the value at `read: IOPS=` and include it in your report. A value above **10K IOPS** is considered good.
+Look for the value at `read: IOPS=` and include it in your report. A value above **10K IOPS** is considered good for production validator nodes.
 
 Check your download and upload speeds using the following command:
 
@@ -159,11 +155,10 @@ Check your download and upload speeds using the following command:
 curl -s https://raw.githubusercontent.com/sivel/speedtest-cli/master/speedtest.py | python3 -
 ```
 
-Speeds exceeding **700 Mbit/s** are deemed satisfactory.
+Speeds exceeding **700 Mbit/s** are deemed satisfactory for production validator nodes.
 
 When reporting, please send the SAR report, IOPS, and network speed results to [@mytonctrl_help_bot](https://t.me/mytonctrl_help_bot).
 
 Initial version - _[@neodix](https://t.me/neodix) - TON Core team_, Sep 23, 2024
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-nodes-monitoring-performance-monitoring.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx`

Related issues (from issues.normalized.md):
- [ ] **3370. Fix intro wording, tone, and terms**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx?plain=1#L12

Change to: “This guide helps identify whether your server experiences a resource shortage, not whether the validator node performs poorly.”

---

- [ ] **3371. Use targeted sed to enable sysstat**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx?plain=1#L26

Replace the overbroad command with a safe match, for example: sudo sed -i 's/^ENABLED="false"/ENABLED="true"/' /etc/default/sysstat or sudo sed -i 's/^ENABLED=.*/ENABLED="true"/' /etc/default/sysstat.

---

- [ ] **3372. Correct -f option wording and date phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx?plain=1#L56

Change “use the f option” to “use the -f option,” and “Thus, for the September 23rd it would be:” to “For September 23:”.

---

- [ ] **3373. Replace em dash with hyphen in sar command**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx?plain=1#L72

Fix inline code: sar —rh → sar -rh.

---

- [ ] **3374. Clarify memory usage vs cache and swap guidance**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx?plain=1#L72-L76

Note that Linux counts page cache as used; low kbmemfree alone isn’t an issue—monitor swap activity (sar -Sh) and OOM events; recommend adding RAM if %memused stays high (e.g., >90%) together with swap usage.

---

- [ ] **3375. Treat log path as directory and give grep example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx?plain=1#L76

Clarify that /var/ton-work/log is a directory and suggest: grep -i "Signal" /var/ton-work/log/*.

---

- [ ] **3376. Improve swap sentence and scope recommendation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx?plain=1#L84

Change to “If you notice that swap is in use, consider disabling swap” and either cite the recommendation or scope it (e.g., “for production validator nodes”).

---

- [ ] **3377. Fix CPU sentence grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx?plain=1#L92

Change “should be considered as good” to “should be considered good”.

---

- [ ] **3378. Standardize heading capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx?plain=1#L94

Change “### Disk Usage report” to “### Disk usage report”.

---

- [ ] **3379. Remove extra space and improve phrasing before colon**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx?plain=1#L104

Change “Use the commands :” to “Use the following commands:”.

---

- [ ] **3380. Standardize interface placeholder**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx?plain=1#L113,L123

Use a single placeholder (e.g., <interface>) consistently across commands and examples (avoid mixing with <interface name> or hardcoded eno1).

---

- [ ] **3381. Clarify %ifutil explanation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx?plain=1#L118

Change to “Check the %ifutil column; it shows your interface utilization relative to its maximum link speed.”

---

- [ ] **3382. Fix NIC speed sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx?plain=1#L120

Change “what speed is supported by your NIC” to “which link speed your NIC supports”.

---

- [ ] **3383. Make info note about link speed neutral**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx?plain=1#L126-L128

Replace with: “Link speed reflects the negotiated NIC link rate; actual throughput may differ from your provider’s advertised bandwidth.”

---

- [ ] **3384. Improve network utilization sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx?plain=1#L130

Change to “Consider upgrading your link if %ifutil is above 70% or if rxkB/s and txkB/s are close to your provisioned bandwidth.”

---

- [ ] **3385. Group report commands and redirect once**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx?plain=1#L138-L146

Capture both sar outputs in one file and drop cat, e.g.: { sar -rudh; sar -n DEV -h --iface=<interface>; } > report_today.txt and { sar -rudh -1; sar -n DEV -h --iface=<interface> -1; } > report_yesterday.txt.

---

- [ ] **3386. Prefer portable interface filtering for sar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx?plain=1#L113

Avoid relying on --iface; show a portable filter instead, e.g.: sar -n DEV -h | grep -E '^<interface>\b'.

---

- [ ] **3387. Split sar activity flags for readability**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx?plain=1#L138-L146

For clarity/portability, split selectors and group outputs, e.g.: { sar -u; sar -rh; sar -dh; sar -n DEV -h | grep -E '^<interface>\b'; } > report_today.txt.

---

- [ ] **3388. Prefer explicit date selection over -1/-2**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx?plain=1#L138-L146

Use the -f option with the target sa file instead of -1/-2, e.g.: { sar -rudh -f /var/log/sysstat/sa23; sar -n DEV -h -f /var/log/sysstat/sa23 | grep -E '^<interface>\b'; } > report_23.txt.

---

- [ ] **3389. Add link to minimal hardware requirements**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx?plain=1

Link “minimum requirements” to docs/v3/guidelines/nodes/running-nodes/validator-node.mdx#minimal-hardware-requirements.

---

- [ ] **3390. Qualify or cite numeric thresholds**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx?plain=1

Provide citations within the docs or scope them (e.g., for production validator nodes) for thresholds like CPU ≤70%, %ifutil >70%, IOPS >10K, and ≥700 Mbit/s; otherwise revise or remove.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.