### PR TITLE
Split: update docs/v3/guidelines/nodes/node-maintenance-and-security.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/nodes/node-maintenance-and-security.mdx
+++ b/docs/v3/guidelines/nodes/node-maintenance-and-security.mdx
@@ -18,7 +18,7 @@ The current TTL values are in the node's service file, which is typically locate
 
 ### `archive-ttl`
 
-`archive-ttl` is a parameter that defines the TTL for the blocks. The default value is 604800 seconds (7 days). You can decrease this value to reduce the database size.
+`archive-ttl` is a parameter that defines the TTL for the blocks. The default value is 604800 seconds (7 days). You can decrease this value to reduce the database size. Note that these are validator-engine defaults and may be overridden by MyTonCtrl; check current values via MyTonCtrl.
 
 ```bash
 MyTonCtrl> installer  set_node_argument  --archive-ttl <value>
@@ -28,7 +28,7 @@ If you don't use MyTonCtrl, you can edit the node service file.
 
 ### `state-ttl`
 
-`state-ttl` is a parameter defining the block states' TTL. The default value is 86400 seconds (24 hours). You can decrease this value to reduce the database size, but for validators, it's highly recommended that the default value be used (keep the flag unset).
+`state-ttl` is a parameter defining the block states' TTL. The default value is 86400 seconds (24 hours). You can decrease this value to reduce the database size, but for validators, it's highly recommended that the default value be used (keep the flag unset). Note that these are validator-engine defaults and may be overridden by MyTonCtrl; check current values via MyTonCtrl.
 
 Also, this value should be more than the length of the validation period (check the value in [15th config param](/v3/documentation/network/configs/blockchain-configs#param-15)).
 
@@ -49,8 +49,8 @@ To efficiently back up your validator, it is essential to copy the key node conf
 3. **Node public keys**:  `/var/ton-work/keys`
 
 4. **MyTonCtrl configuration and wallets**:
-   - If you installed MyTonCtrl as a regular user: `$HOME/.local/share/myton*` (where `$HOME` is your home directory)
-   - If you installed MyTonCtrl as root: `/usr/local/bin/mytoncore`
+   - If you installed MyTonCtrl as a regular user: `~/.local/share/mytoncore/` (where `$HOME` is your home directory)
+   - If you installed MyTonCtrl as root: `/usr/local/bin/mytoncore/`
 
 Backing up this set of files will provide everything you need to recover your node from scratch.
 
@@ -60,7 +60,7 @@ Modern file systems such as ZFS offer snapshot functionality. Most cloud provide
 
 The problem with both methods is that you must stop the node before performing a snapshot. Failure to do so will most likely result in a corrupt database with unexpected consequences. Many cloud providers also require you to power down the machine before performing a snapshot.
 
-Such stops should not be performed often. If you snapshot your node once a week, then in the worst case scenario after recovery, you will have a node with a week-old database, and it will take your node more time to catch up with the network than to perform a new installation using the MyTonCtrl **install from dump** feature (`-d` flag added during invocation of `install.sh` script).
+Such stops should not be performed often. If you snapshot your node once a week, then in the worst-case scenario after recovery, you will have a node with a week-old database, and it will take your node more time to catch up with the network than to perform a new installation using the MyTonCtrl **install from dump** feature (`-d` flag added during invocation of `install.sh` script).
 
 ### Disaster recovery
 
@@ -83,7 +83,7 @@ systemctl  stop  validator
 systemctl  stop  mytoncore
 ```
 
-#### Apply backed up node configuration files
+#### Apply backed-up node configuration files
 
 - Node configuration file: `/var/ton-work/db/config.json`
 
@@ -93,7 +93,7 @@ systemctl  stop  mytoncore
 
 #### Set node IP address
 
-If your new node has a different IP address, you need to update the node configuration file located at `/var/ton-work/db/config.json`. Change the value of `leaf.addrs[0].ip` to reflect the new IP address in decimal format. You can use **[this](https://github.com/sonofmom/ton-tools/blob/master/node/ip2dec.py)** Python script to convert your IP address to decimal.
+If your new node has a different IP address, you need to update the node configuration file located at `/var/ton-work/db/config.json`. Change the value of `addrs[0].ip` to reflect the new IP address, which is stored as a signed integer (decimal). You can use **[this](https://github.com/sonofmom/ton-tools/blob/master/node/ip2dec.py)** Python script to convert your IP address to decimal.
 
 #### Ensure proper database permissions
 
@@ -103,7 +103,7 @@ chown  -R  validator:validator  /var/ton-work/db
 
 #### Apply backed-up MyTonCtrl configuration files
 
-Replace `$HOME/.local/share/myton*` with `$ HOME/.local/share/myton*`, where $HOME is the home directory of the user who started the installation of MyTonCtrl with backed-up content. Make sure that the user is the owner of all files you copy.
+Restore your backup into `~/.local/share/mytoncore/` (or `/usr/local/bin/mytoncore/` if installed as root), where `$HOME` is the home directory of the user who installed MyTonCtrl. Make sure that the installing user owns all files you copy.
 
 #### Start mytoncore and validator processes
 
@@ -116,21 +116,21 @@ systemctl  start  mytoncore
 
 ### Host-level security
 
-Host-level security is a huge topic that is outside the scope of this document; however, we advise that you never install MyTonCtrl under the root user and use a service account to ensure privilege separation.
+Host-level security is a huge topic that is outside the scope of this document; however, never install MyTonCtrl as the root user; use a dedicated service account to ensure privilege separation.
 
 ### Network-level security
 
-TON validators are high-value assets that should be protected against external threats. One of the first steps is to make your node as invisible as possible, which means locking down all network connections. On a validator node, only a UDP Port used for node operations should be exposed to the internet.
+TON validators are high-value assets that should be protected against external threats. One of the first steps is to make your node as invisible as possible, which means locking down all network connections. On a validator node, only a UDP port used for node operations should be exposed to the internet.
 
 #### Tools
 
-We will utilize the **[ufw](https://help.ubuntu.com/community/UFW)** firewall interface along with the **[jq](https://github.com/stedolan/jq)** JSON command-line processor.
+We will utilize the **[ufw](https://help.ubuntu.com/community/UFW)** firewall interface along with the **[jq](https://github.com/jqlang/jq)** JSON command-line processor.
 
 #### Management networks
 
 As a node operator, you need to retain full control and access to the machine. To do this, you need at least one fixed IP address or range.
 
-We also advise you to set up a small **jumpstation** VPS with a fixed IP Address that can be used to access your locked-down machine(s) if you do not have a fixed IP at your home or office or to add an alternative way to access secured machines should you lose your primary IP address.
+We also advise you to set up a small **jump host (bastion)** VPS with a fixed IP address that can be used to access your locked-down machine(s) if you do not have a fixed IP at your home or office or to add an alternative way to access secured machines should you lose your primary IP address.
 
 #### Install ufw and jq
 
@@ -150,6 +150,8 @@ sudo  ufw  default  deny  incoming; sudo  ufw  default  allow  outgoing
 sudo  sed  -i  's/-A ufw-before-input -p icmp --icmp-type echo-request -j ACCEPT/#-A ufw-before-input -p icmp --icmp-type echo-request -j ACCEPT/g'  /etc/ufw/before.rules
 ```
 
+If UFW is already enabled, run `sudo ufw reload` so the changes take effect.
+
 #### Enable all access from management network(s)
 
 ```sh
@@ -158,15 +160,15 @@ sudo  ufw  insert  1  allow  from <MANAGEMENT_NETWORK>
 
 Repeat the above command for each management network/address.
 
-#### Expose node/validator UDP port to public
+#### Expose node/validator UDP port to the public
 
 ```sh
 sudo  ufw  allow  proto  udp  from  any  to  any  port  `sudo jq -r '.addrs[0].port' /var/ton-work/db/config.json`
 ```
 
-#### Doublecheck your management networks
+#### Double-check your management networks
 
-:::caution important
+:::caution Important
 **Before enabling a firewall,  double-check that you added the correct management addresses!**
 :::
 
@@ -178,7 +180,7 @@ sudo  ufw  enable
 
 #### Checking status
 
-To check the firewall status use the following command:
+To check the firewall status, use the following command:
 
 ```sh
 sudo  ufw  status  numbered
@@ -203,11 +205,11 @@ Status: active
 sudo  ufw  allow  proto  tcp  from  any  to  any  port  `sudo jq -r '.liteservers[0].port' /var/ton-work/db/config.json`
 ```
 
-Note that the liteserver port should not be exposed publicly on a validator.
+Note that the liteserver port should not be exposed publicly on a validator. Allow access only from trusted management networks, and only if a liteserver is enabled.
 
 #### More information on UFW
 
-See this excellent **[ufw tutorial](https://www.digitalocean.com/community/tutorials/ufw-essentials-common-firewall-rules-and-commands)** from the Digital Ocean for more ufw magic.
+See this **[UFW tutorial](https://www.digitalocean.com/community/tutorials/ufw-essentials-common-firewall-rules-and-commands)** from DigitalOcean for additional UFW examples.
 
 ### IP switch
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-nodes-node-maintenance-and-security.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/nodes/node-maintenance-and-security.mdx`

Related issues (from issues.normalized.md):
- [ ] **3391. Use explicit MyTonCtrl data paths; fix restore wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/node-maintenance-and-security.mdx?plain=1#L51-L54

Replace the ambiguous $HOME/.local/share/myton* with ~/.local/share/mytoncore/ (or /usr/local/bin/mytoncore/ when installed as root) in both backup and restore instructions, correct the stray "$ HOME" to "$HOME", and state to restore the backup into ~/.local/share/mytoncore/ ensuring ownership matches the installing user.

---

- [ ] **3392. Hyphenate “worst‑case scenario”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/node-maintenance-and-security.mdx?plain=1#L63

Use the hyphenated compound adjective: “worst‑case scenario.”

---

- [ ] **3393. Normalize double spaces in shell commands**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/node-maintenance-and-security.mdx?plain=1#L75-L84,L137-L145,L150,L156,L164,L176,L184

Remove duplicated spaces in command examples (e.g., change “sudo -s” to “sudo -s”) for readability and copy-paste reliability.

---

- [ ] **3394. Hyphenate “backed‑up” in headings**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/node-maintenance-and-security.mdx?plain=1#L86,L104

When used adjectivally before a noun, use “backed‑up” in both headings for consistency.

---

- [ ] **3395. Fix IP key path and note signed‑integer format**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/node-maintenance-and-security.mdx?plain=1#L96

Replace “leaf.addrs[0].ip” with “addrs[0].ip” and clarify that the value is stored as a signed integer (decimal).

---

- [ ] **3396. Clarify host-level security wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/node-maintenance-and-security.mdx?plain=1#L120-L124

Revise to “Never install MyTonCtrl as the root user; use a dedicated service account to ensure privilege separation.”

---

- [ ] **3397. Fix mid-sentence capitalization for “UDP port” and “IP address”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/node-maintenance-and-security.mdx?plain=1#L123-L124,L133

Use lowercase common nouns mid‑sentence: “UDP port” and “IP address.”

---

- [ ] **3398. Update jq repository URL to jqlang**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/node-maintenance-and-security.mdx?plain=1#L127

Change the link from https://github.com/stedolan/jq to the canonical https://github.com/jqlang/jq.

---

- [ ] **3399. Add article “the” to UDP port exposure heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/node-maintenance-and-security.mdx?plain=1#L161

Change “Expose node/validator UDP port to public” to “Expose node/validator UDP port to the public.”

---

- [ ] **3400. Hyphenate “Double‑check” in heading and body**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/node-maintenance-and-security.mdx?plain=1#L167-L171

Replace “Doublecheck” with the hyphenated form “Double‑check” in the heading and text.

---

- [ ] **3401. Capitalize admonition title “Important”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/node-maintenance-and-security.mdx?plain=1#L169-L171

Change “:::caution important” to “:::caution Important” (or remove the custom title).

---

- [ ] **3402. Add comma in firewall status sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/node-maintenance-and-security.mdx?plain=1#L181-L185

Add a comma after the introductory phrase: “To check the firewall status, use the following command:”.

---

- [ ] **3403. Use “DigitalOcean” and neutral tone in UFW reference**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/node-maintenance-and-security.mdx?plain=1#L210

Revise to “from DigitalOcean for additional UFW examples.”

---

- [ ] **3404. Restrict liteserver UFW rule to management networks**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/node-maintenance-and-security.mdx?plain=1#expose-liteserver-port

Do not open the liteserver port to the public; restrict the UFW allow rule to trusted management networks only and note this applies only if a liteserver is enabled.

---

- [ ] **3405. Note archive/state TTLs are validator-engine defaults**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/node-maintenance-and-security.mdx?plain=1#archive-ttl

Clarify that the stated archive-ttl and state-ttl are validator‑engine defaults and may be overridden by MyTonCtrl; advise checking current values via MyTonCtrl.

---

- [ ] **3406. Prefer term “jump host (bastion)”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/node-maintenance-and-security.mdx?plain=1#management-networks

Replace “jumpstation” with the clearer, standard term “jump host (bastion).”

---

- [ ] **3407. Add UFW reload note after editing before.rules**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/node-maintenance-and-security.mdx?plain=1#disable-automated-icmp-echo-request-accept

After editing /etc/ufw/before.rules, instruct users to run “sudo ufw reload” if UFW is already enabled so the changes take effect.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.