### PR TITLE
Split: update docs/v3/guidelines/nodes/nodes-troubleshooting.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/nodes/nodes-troubleshooting.mdx
+++ b/docs/v3/guidelines/nodes/nodes-troubleshooting.mdx
@@ -6,41 +6,41 @@ This section provides answers to the most common questions regarding how to run 
 
 ## Failed to get account state
 
-```
+```text
 Failed to get account state
 ```
 
-This error suggests that there are problems when trying to search for the account in the shard state. It likely means that the liteserver node is syncing too slowly, causing the MasterChain synchronization to advance faster than the ShardChain (BaseChain) synchronization. As a result, while the node is aware of the latest MasterChain block, it is unable to verify the account state in the most recent ShardChain block, leading to the error.
+This error suggests that there are problems when trying to search for the account in the shard state. It likely means that the liteserver node is syncing too slowly, causing the MasterChain synchronization to advance faster than the BaseChain shards (ShardChains) synchronization. As a result, while the node is aware of the latest MasterChain block, it is unable to verify the account state in the most recent ShardChain block, leading to the error.
 
 ## Failed to unpack account state
 
-```
+```text
 Failed to unpack account state
 ```
 
-This error means that the requested account doesn't exist in its current state. That means that this account is simultaneously not deployed AND has zero balance
+This error means the requested account does not exist in its current state: it is not deployed and has zero balance.
 
-## About no progress in node synchronization within 3 hours
+## No progress in node synchronization within 3 hours
 
 Try to perform the following checks:
 
 1. Is the process running without crashes? (Check `systemd` process status)
 
-2. Is there a firewall between the node and the internet? If so, will it pass incoming UDP traffic to the port specified in the field `addrs[0].port` of the `/var/ton-work/db/config.json` file?
+2. Is there a firewall between the node and the internet? If so, will it pass incoming UDP traffic to the port specified in the field `leaf.addrs[0].port` of the `/var/ton-work/db/config.json` file?
 
-3. Is there a NAT between the machine and the internet? If so, ensure that the IP address defined in the `addrs[0].ip` field of the `/var/ton-work/db/config.json` file corresponds to the real public IP of the machine. Note that the value of this field is specified as a signed INT. The `ip2dec` and `dec2ip` scripts located in [ton-tools/node](https://github.com/sonofmom/ton-tools/tree/master/node) can be used to perform conversions.
+3. Is there a NAT between the machine and the internet? If so, ensure that the IP address defined in the `leaf.addrs[0].ip` field of the `/var/ton-work/db/config.json` file corresponds to the real public IP of the machine. Note that the value of this field is stored in decimal (signed 32-bit integer for IPv4). You can use the `ip2dec.py` (and `dec2ip`) scripts from [ton-tools/node](https://github.com/sonofmom/ton-tools/tree/master/node) to perform conversions.
 
 ## Archive node is out of sync even after 5 days of the syncing process
 
-Go through the checklist [from this section](/v3/guidelines/nodes/nodes-troubleshooting#about-no-progress-in-node-synchronization-within-3-hours).
+Go through the checklist [from this section](/v3/guidelines/nodes/nodes-troubleshooting#no-progress-in-node-synchronization-within-3-hours).
 
 ## Slow sync potential reasons
 
 The disk is relatively weak, so it’s advisable to check the IOPS, although hosting providers sometimes exaggerate these numbers.
 
-## Cannot apply external message to current state : External message was not accepted
+## Cannot apply external message to current state: External message was not accepted
 
-```
+```text
 Cannot apply external message to current state : External message was not accepted
 ```
 
@@ -64,12 +64,12 @@ You need to check the firewall settings, including any NAT settings if they exis
 It should allow incoming connections on one specific port and outgoing connections from any port.
 :::
 
-## Validator console is not settings
+## Validator console is not configured
 
 If you encounter the `Validator console is not settings` error, it indicates that you are running `MyTonCtrl` from a user other than the one you used for the installation.
 
 :::tip Solution
-Run `MyTonCtrl` from [the user you've installed](/v3/guidelines/nodes/running-nodes/full-node#switch-to-non-root-user) it (non-root sudo user).
+Run MyTonCtrl from the user account you installed it with (non-root sudo user).
 
 ```bash
 mytonctrl
@@ -77,11 +77,11 @@ mytonctrl
 
 :::
 
-### Running MyTonCtrl as different user
+### Running MyTonCtrl as a different user
 
 Running MyTonCtrl as a different user may trigger the following error:
 
-```bash
+```text
 Error:  expected  str,  bytes  or  os.PathLike  object,  not  NoneType
 ```
 
@@ -93,7 +93,7 @@ To resolve this issue, you need to run MyTonCtrl as the user who installed it.
 
 **A:** Yes, this is normal. Typically, it means that you tried to retrieve a block that has not yet reached the node you requested.
 
-**Q:** If comparative frequency appears, does it indicate there is a problem?
+**Q:** If this occurs frequently, does it indicate a problem?
 
 **A:** No, it does not. You should check the "Local validator out of sync" value in MyTonCtrl. If it is less than 20 seconds, then everything is functioning normally.
 
@@ -109,11 +109,11 @@ If you encounter an issue where the `out of sync` equals the timestamp after dow
 The recommended solution is to reinstall `MyTonCtrl` again with the new dump.
 :::
 
-If synchronization takes an unusually long time, there may be issues with the dump. Please [contact us](https://t.me/SwiftAdviser) for assistance.
+If synchronization takes an unusually long time, there may be issues with the dump. Please [contact us](https://t.me/ton_node_help) for assistance.
 
 Execute the `mytonctrl` command using the user account under which it was installed.
 
-## Error command... timed out after 3 seconds
+## Error: command timed out after 3 seconds
 
 This error indicates that the local node is not yet synchronized, has been out of sync for less than 20 seconds, and that public nodes are being utilized. Public nodes do not always respond, which can result in a timeout error.
 
@@ -121,9 +121,9 @@ This error indicates that the local node is not yet synchronized, has been out o
 The solution to the problem is to wait for the local node to synchronize or to execute the same command multiple times before proceeding.
 :::
 
-## Status command displays without local node section
+## Status command displays without Local validator section
 
-![](/img/docs/full-node/local-validator-status-absent.png)
+![Local validator section absent in status output](/img/docs/full-node/local-validator-status-absent.png)
 
 If there is no local node section in the node status, typically, this means something went wrong during installation, and the step of creating/assigning a validator wallet was skipped.
 
@@ -131,17 +131,17 @@ Also, check that the validator wallet is specified.
 
 Check directly the following:
 
-```bash
+```text
 MyTonCtrl> get  validatorWalletName
 ```
 
 If `validatorWalletName` is null then execute the following:
 
-```bash
+```text
 MyTonCtrl> set  validatorWalletName  validator_wallet_001
 ```
 
-## Transfer a validator on the new server
+## Transfer a validator to the new server
 
 :::info
 Transfer all keys and configs from the old to the working node and start it. In case something goes wrong on the new one, the source where everything is set up is still available.
@@ -168,7 +168,7 @@ The best way (while the penalty for temporary non-validation is small, it can be
 - 3.4 `/var/ton-work/db/keyring`
 - 3.5 `/var/ton-work/keys`
 
-4. In `/var/ton-work/db/config.json` edit `addrs[0].ip` to the current one, which was after installation (can be seen in the backup `/ton-work/db/config.json.backup`)
+4. In `/var/ton-work/db/config.json` edit `leaf.addrs[0].ip` to the IP assigned during installation (see the backup `/var/ton-work/db/config.json.backup`).
 
 5. Check the permissions on all replaced files.
 
@@ -177,22 +177,22 @@ The best way (while the penalty for temporary non-validation is small, it can be
 7. On the new one, make a backup:
 
 ```bash
-cp  var/ton-work/db/config.json  var/ton-work/db/config.json.backup
+cp /var/ton-work/db/config.json /var/ton-work/db/config.json.backup
 ```
 
-## MyTonCtrl was installed by another user. Probably you need to launch mtc with ... user
+## MyTonCtrl was installed by another user. Probably you need to launch MyTonCtrl with ... user
 
 Run MyTonCtrl with the user that used to install it.
 
 For example, the most common case is when someone tries to run MyTonCtrl as a root user, even though it was installed under a different user. In this case, you need to log in to the user who installed MyTonCtrl and run MyTonCtrl from that user.
 
-### MyTonCtrl was installed by another user. Probably you need to launch mtc with `validator` user
+### MyTonCtrl was installed by another user. Probably you need to launch MyTonCtrl with `validator` user
 
-Run command `sudo chown <user_name>:<user_name> /var/ton-work/keys/*` where `<user_name>` is user which installed MyTonCtrl.
+Run command `sudo chown <user_name>:<user_name> /var/ton-work/keys/*` where `<user_name>` is the user who installed MyTonCtrl.
 
-### MyTonCtrl was installed by another user. Probably you need to launch mtc with `ubuntu` user
+### MyTonCtrl was installed by another user. Probably you need to launch MyTonCtrl with `ubuntu` user
 
-Additionally `mytonctrl` command may not work properly with this error. For example, the `status` command may return empty result.
+Additionally `mytonctrl` command may not work properly with this error. For example, the `status` command may return an empty result.
 
 Check `MyTonCtrl` owner:
 
@@ -208,15 +208,15 @@ Otherwise, log out from the current user and log in as the correct user. If you 
 
 There are two known cases when this error appears:
 
-### Error after updating MytonCtrl
+### Error after updating MyTonCtrl
 
-- If MyTonCtrl was installed by the root user: Delete the file `/usr/local/bin/mytonctrl/VERSION.`
+- If MyTonCtrl was installed by the root user: Delete the file `/usr/local/bin/mytonctrl/VERSION`.
 
-- If MyTonCtrl was installed by a non-root user: Delete the file `~/.local/share/mytonctrl/VERSION.`
+- If MyTonCtrl was installed by a non-root user: Delete the file `~/.local/share/mytonctrl/VERSION`.
 
-### Error during MytonCtrl installation
+### Error during MyTonCtrl installation
 
-`MytonCtrl` may be running, but the node won't function properly. Remove `MytonCtrl` from your computer and reinstall it, making sure to address any previous errors encountered.
+`MyTonCtrl` may be running, but the node won't function properly. Remove `MyTonCtrl` from your computer and reinstall it, making sure to address any previous errors encountered.
 
 ## See also
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-nodes-nodes-troubleshooting.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/nodes/nodes-troubleshooting.mdx`

Related issues (from issues.normalized.md):
- [ ] **1192. Fix typo "troubleshooting" in sync link text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-errors.mdx?plain=1

Change the link text “sync troubleshouting” to “sync troubleshooting” while keeping the existing anchor docs/v3/guidelines/nodes/nodes-troubleshooting.mdx#about-no-progress-in-node-synchronization-within-3-hours.

---

- [ ] **1195. Backtick error text and use exact troubleshooting title**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-errors.mdx?plain=1

Wrap the exact error string in backticks and use the precise link label: “Troubleshooting: Validator console is not settings”, linking to docs/v3/guidelines/nodes/nodes-troubleshooting.mdx#validator-console-is-not-settings.

---

- [ ] **3408. Fix ShardChain/BaseChain terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/nodes-troubleshooting.mdx?plain=1#failed-to-get-account-state

Replace “ShardChain (BaseChain)” with “BaseChain shards (ShardChains)”, clarifying they are not synonyms and keeping capitalization consistent (MasterChain, BaseChain, ShardChain).

---

- [ ] **3409. Simplify and punctuate “Failed to unpack account state”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/nodes-troubleshooting.mdx?plain=1#failed-to-unpack-account-state

Change the text to “This error means the requested account does not exist in its current state: it is not deployed and has zero balance.”

---

- [ ] **3410. Rephrase stalled sync heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/nodes-troubleshooting.mdx?plain=1#about-no-progress-in-node-synchronization-within-3-hours

Rename the heading to “No progress in node synchronization within 3 hours.”

---

- [ ] **3411. Clarify IP field format and tool reference**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/nodes-troubleshooting.mdx?plain=1#about-no-progress-in-node-synchronization-within-3-hours

State that the IP is stored in decimal (signed 32‑bit integer for IPv4) and reference one canonical conversion tool (e.g., ip2dec.py) for consistency across docs.

---

- [ ] **3412. Remove stray space before colon in external message error**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/nodes-troubleshooting.mdx?plain=1#cannot-apply-external-message-to-current-state--external-message-was-not-accepted

Fix the section heading to “...state: External message was not accepted” (no space before the colon); keep the exact spacing only if quoting the raw error string.

---

- [ ] **3413. Standardize “MyTonCtrl” casing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/nodes-troubleshooting.mdx?plain=1#mytonctrls-console-launch-breaks-after-message-found-new-version-of-mytonctrl-migrating

Use “MyTonCtrl” consistently in headings and body text; preserve exact casing only inside quoted error strings.

---

- [ ] **3414. Fix validator console heading and sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/nodes-troubleshooting.mdx?plain=1#validator-console-is-not-settings

Rename the heading to “Validator console is not configured” (or “...not set”) and rewrite the line to “Run MyTonCtrl from the user account you installed it with (non‑root sudo user).”

---

- [ ] **3415. Add article to user-switching heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/nodes-troubleshooting.mdx?plain=1

Change the heading “Running MyTonCtrl as different user” to “Running MyTonCtrl as a different user.”

---

- [ ] **3416. Clarify frequent-occurrence question**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/nodes-troubleshooting.mdx?plain=1#what-does-block-is-not-applied-mean

Change the question to “If this occurs frequently, does it indicate a problem?”

---

- [ ] **3417. Standardize support contact**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/nodes-troubleshooting.mdx?plain=1#out-of-sync-issue-with--d-flag

Replace “https://t.me/SwiftAdviser” with the official channel “https://t.me/ton_node_help”.

---

- [ ] **3418. Correct timeout error heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/nodes-troubleshooting.mdx?plain=1#error-command-timed-out-after-3-seconds

Change the heading to “Error: command timed out after 3 seconds” (quote the exact message if reflecting the literal output).

---

- [ ] **3419. Fix backup and copy paths in transfer steps**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/nodes-troubleshooting.mdx?plain=1#transfer-a-validator-on-the-new-server

Use “/var/ton-work/db/config.json.backup” in Step 4 and “cp /var/ton-work/db/config.json /var/ton-work/db/config.json.backup” in Step 7.

---

- [ ] **3420. Improve preposition in transfer section title**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/nodes-troubleshooting.mdx?plain=1#transfer-a-validator-on-the-new-server

Rename the title to “Transfer a validator to the new server.”

---

- [ ] **3421. Correct grammar in user/ownership guidance**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/nodes-troubleshooting.mdx?plain=1#mytonctrl-was-installed-by-another-user-probably-you-need-to-launch-mtc-with--user

Replace “launch mtc” with “launch MyTonCtrl”, change “where <user_name> is user which installed MyTonCtrl” to “where <user_name> is the user who installed MyTonCtrl”, and “may return empty result” to “may return an empty result.”

---

- [ ] **3422. Remove trailing period from VERSION paths**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/nodes-troubleshooting.mdx?plain=1#error-after-updating-mytonctrl

Ensure inline code shows “/usr/local/bin/mytonctrl/VERSION” and “~/.local/share/mytonctrl/VERSION” without a trailing period (the period belongs outside the code spans).

---

- [ ] **3423. Tag error and console outputs as text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/nodes-troubleshooting.mdx?plain=1

Set the language to “text” for error-output snippets (“Failed to get account state”, “Failed to unpack account state”, “Cannot apply external message...”) and for MyTonCtrl interactive prompts instead of “bash.”

---

- [ ] **3424. Align config key for node IP**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/nodes-troubleshooting.mdx?plain=1#about-no-progress-in-node-synchronization-within-3-hours

Use a single canonical key path in /var/ton-work/db/config.json (e.g., “leaf.addrs[0].ip”) and update examples and instructions accordingly.

---

- [ ] **3425. Cite exit code meanings and confirm sign**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/nodes-troubleshooting.mdx?plain=1#cannot-apply-external-message-to-current-state--external-message-was-not-accepted

Add citations for codes 33, 34, 35 (wallet docs) and 13 (TVM exit codes/out-of-gas), and verify whether the node reports negative codes (−13) or positive 13; adjust the signage to match actual output.

---

- [ ] **3426. Clarify IP instruction in transfer Step 4**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/nodes-troubleshooting.mdx?plain=1#transfer-a-validator-on-the-new-server

Rephrase to “edit addrs[0].ip to the IP assigned during installation (see the backup /var/ton-work/db/config.json.backup).”

---

- [ ] **3427. Add alt text to status screenshot**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/nodes-troubleshooting.mdx?plain=1#status-command-displays-without-local-node-section

Provide descriptive alt text for the image, e.g., “Local validator section absent in status output.”

---

- [ ] **3428. Match section title to status label**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/nodes-troubleshooting.mdx?plain=1#status-command-displays-without-local-node-section

Rename the heading to “Status command displays without Local validator section” to match terminology used elsewhere.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.