### PR TITLE
Split: update docs/v3/guidelines/nodes/persistent-states.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/nodes/persistent-states.mdx
+++ b/docs/v3/guidelines/nodes/persistent-states.mdx
@@ -2,17 +2,17 @@ import Feedback from '@site/src/components/Feedback';
 
 # Persistent states
 
-Nodes periodically store snapshots of the blockchain's states. Each state is created at a specific MasterChain block and has a defined time-to-live (TTL). The selection of the block and TTL follows this algorithm:
+Nodes periodically store snapshots of the blockchain state. Each state is created at a specific Masterchain block and has a defined time-to-live (TTL). The selection of the block and TTL follows this algorithm:
 
-Only key blocks can be selected. A block has a timestamp marked as `ts`. Time is divided into periods of length `2^17` seconds (approximately 1.5 days). For a given block with timestamp `ts`, we calculate the period as `x = floor(ts / 2^17)`. The first key block from each period is chosen to create a persistent state.
+Only key blocks can be selected. Let `ts` denote the block’s timestamp. Time is divided into periods of length `2^17` seconds (approximately 1.5 days). For a given block with timestamp `ts`, we calculate the period as `x = floor(ts / 2^17)`. The first key block from each period is chosen to create a persistent state.
 
 The TTL of a state from period `x` is calculated as `2^(18 + ctz(x))`, where `ctz(x)` represents the number of trailing zeros in the binary representation of `x` (i.e., the largest integer `y` such that `x` is divisible by `2^y`).
 
-This means that persistent states are created every 1.5 days. Half of these states have a TTL of `2^18` seconds (3 days), while half of the remaining states have a TTL of `2^19` seconds (6 days), and so forth.
+This means that persistent states are created every `2^17` seconds (~1.52 days). Half of these states have a TTL of `2^18` seconds (~3 days), while half of the remaining states have a TTL of `2^19` seconds (~6 days), and so forth.
 
 In 2025, there will be several long-term persistent states, each lasting at least 3 months:
 
-| Block seqno | Block time | TTL | Expires at |
+| Block seqno | Block time (UTC) | TTL (approx. days) | Expires at (UTC) |
 |--:|--:|--:|--:|
 | [8930706](https://explorer.toncoin.org/search?workchain=-1&shard=8000000000000000&seqno=8930706) | 2021-01-14 15:08:40 | 12427 days | 2055-01-24 08:45:44 |
 | [27747086](https://explorer.toncoin.org/search?workchain=-1&shard=8000000000000000&seqno=27747086) | 2023-03-02 05:08:11 | 1553 days | 2027-06-02 19:50:19 |
@@ -20,9 +20,8 @@ In 2025, there will be several long-term persistent states, each lasting at leas
 | [40821182](https://explorer.toncoin.org/search?workchain=-1&shard=8000000000000000&seqno=40821182) | 2024-10-04 18:08:08 | 388 days | 2025-10-28 02:48:40 |
 | [43792209](https://explorer.toncoin.org/search?workchain=-1&shard=8000000000000000&seqno=43792209) | 2025-01-09 20:18:17 | 194 days | 2025-07-23 00:38:33 |
 
-When the node starts for the first time, it must download a persistent state. This process is implemented in the file [validator/manager-init.cpp](https://github.com/ton-blockchain/ton/blob/master/validator/manager-init.cpp).
+When the node starts for the first time, it must download a persistent state. This process is implemented in the file [validator/manager-init.cpp](https://github.com/ton-blockchain/ton/blob/6c9de4626c4fdf73ff2d85e7ccd60c2c059e0a8a/validator/manager-init.cpp).
 
-Beginning with the initialization block, the node downloads all newer key blocks. It selects the most recent key block that has a persistent state still available (using the formula mentioned above) and subsequently downloads the corresponding MasterChain state, along with the states for all shards or only those shards that are necessary for this node.
+Beginning with the selected key block (the key block whose persistent state was downloaded), the node downloads all newer key blocks. It selects the most recent key block that has a persistent state still available (using the formula mentioned above) and subsequently downloads the corresponding Masterchain state, along with the states for all shards or only those shards that are necessary for this node.
 
 <Feedback />
-

--- a/docs/v3/guidelines/nodes/persistent-states.mdx
+++ b/docs/v3/guidelines/nodes/persistent-states.mdx
@@ -20,7 +20,7 @@ In 2025, there will be several long-term persistent states, each lasting at leas
 | [40821182](https://explorer.toncoin.org/search?workchain=-1&shard=8000000000000000&seqno=40821182) | 2024-10-04 18:08:08 | 388 days | 2025-10-28 02:48:40 |
 | [43792209](https://explorer.toncoin.org/search?workchain=-1&shard=8000000000000000&seqno=43792209) | 2025-01-09 20:18:17 | 194 days | 2025-07-23 00:38:33 |
 
-When the node starts for the first time, it must download a persistent state. This process is implemented in the file [validator/manager-init.cpp](https://github.com/ton-blockchain/ton/blob/6c9de4626c4fdf73ff2d85e7ccd60c2c059e0a8a/validator/manager-init.cpp).
+When the node starts for the first time, it must download a persistent state. This process is implemented in the file [validator/manager-init.cpp](https://github.com/ton-blockchain/ton/blob/master/validator/manager-init.cpp).
 
 It selects the most recent key block that has a persistent state still available (using the formula mentioned above) and subsequently downloads the corresponding Masterchain state, along with the states for all shards, or if partial shard monitoring is enabled, only the configured shards.
 

--- a/docs/v3/guidelines/nodes/persistent-states.mdx
+++ b/docs/v3/guidelines/nodes/persistent-states.mdx
@@ -22,6 +22,6 @@ In 2025, there will be several long-term persistent states, each lasting at leas
 
 When the node starts for the first time, it must download a persistent state. This process is implemented in the file [validator/manager-init.cpp](https://github.com/ton-blockchain/ton/blob/6c9de4626c4fdf73ff2d85e7ccd60c2c059e0a8a/validator/manager-init.cpp).
 
-Beginning with the selected key block (the key block whose persistent state was downloaded), the node downloads all newer key blocks. It selects the most recent key block that has a persistent state still available (using the formula mentioned above) and subsequently downloads the corresponding Masterchain state, along with the states for all shards or only those shards that are necessary for this node.
+It selects the most recent key block that has a persistent state still available (using the formula mentioned above) and subsequently downloads the corresponding Masterchain state, along with the states for all shards, or if partial shard monitoring is enabled, only the configured shards.
 
 <Feedback />

--- a/docs/v3/guidelines/nodes/persistent-states.mdx
+++ b/docs/v3/guidelines/nodes/persistent-states.mdx
@@ -2,7 +2,7 @@ import Feedback from '@site/src/components/Feedback';
 
 # Persistent states
 
-Nodes periodically store snapshots of the blockchain state. Each state is created at a specific Masterchain block and has a defined time-to-live (TTL). The selection of the block and TTL follows this algorithm:
+Nodes periodically store snapshots of the blockchain state. Each state is created at a specific MasterChain block and has a defined time-to-live (TTL). The selection of the block and TTL follows this algorithm:
 
 Only key blocks can be selected. Let `ts` denote the block’s timestamp. Time is divided into periods of length `2^17` seconds (approximately 1.5 days). For a given block with timestamp `ts`, we calculate the period as `x = floor(ts / 2^17)`. The first key block from each period is chosen to create a persistent state.
 
@@ -22,6 +22,6 @@ In 2025, there will be several long-term persistent states, each lasting at leas
 
 When the node starts for the first time, it must download a persistent state. This process is implemented in the file [validator/manager-init.cpp](https://github.com/ton-blockchain/ton/blob/master/validator/manager-init.cpp).
 
-It selects the most recent key block that has a persistent state still available (using the formula mentioned above) and subsequently downloads the corresponding Masterchain state, along with the states for all shards, or if partial shard monitoring is enabled, only the configured shards.
+It selects the most recent key block that has a persistent state still available (using the formula mentioned above) and subsequently downloads the corresponding MasterChain state, along with the states for all shards, or if partial shard monitoring is enabled, only the configured shards.
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-nodes-persistent-states.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/nodes/persistent-states.mdx`

Related issues (from issues.normalized.md):
- [x] **3429. Make 1.5‑day cadence approximate**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/persistent-states.mdx?plain=1

Change “every 1.5 days” to “every 2^17 seconds (~1.52 days)” to reflect an approximate day value.

---

- [x] **3430. Qualify TTL example day values**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/persistent-states.mdx?plain=1

Change “2^18 seconds (3 days)” and “2^19 seconds (6 days)” to “2^18 seconds (~3 days)” and “2^19 seconds (~6 days)”.

---

- [x] **3431. Clarify TTL units and approximation in table**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/persistent-states.mdx?plain=1

Rename the TTL column to “TTL (approx. days)” and format values as “2^n s (~X days)” to avoid implying exact day counts.

---

- [x] **3432. Specify UTC for timestamps**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/persistent-states.mdx?plain=1

Add “(UTC)” to the “Block time” and “Expires at” column headers to remove timezone ambiguity.

---

- [x] **3433. Use singular “blockchain state”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/persistent-states.mdx?plain=1

Replace “blockchain's states” with the idiomatic “blockchain state.”

---

- [x] **3434. Improve timestamp variable intro**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/persistent-states.mdx?plain=1

Replace “A block has a timestamp marked as `ts`.” with “Let `ts` denote the block’s timestamp.” and change “the block and TTL” to “the block and its TTL.”

---

- [x] **3435. Pin GitHub source link to a commit**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/persistent-states.mdx?plain=1

Replace the `https://github.com/ton-blockchain/ton/blob/master/validator/manager-init.cpp` link with a commit-pinned permalink to ensure long-term stability.

---

- [x] **3436. Normalize “Masterchain” capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/persistent-states.mdx?plain=1

Replace all occurrences of “MasterChain” with “Masterchain” for terminology consistency (see docs/v3/concepts/glossary.mdx#masterchain).

---

- [x] **3437. Clarify “initialization block” wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/persistent-states.mdx?plain=1

Replace “Beginning with the initialization block” with “Beginning with the selected key block (the key block whose persistent state was downloaded).”

---

- [x] **3438. Qualify partial shard monitoring scope**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/persistent-states.mdx?plain=1

Add a qualifier: “…along with the states for all shards, or—if partial monitoring is enabled—only the configured shards (see docs/v3/documentation/infra/nodes/validation/collators.mdx#accelerator-update; Testnet only).”

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.