### PR TITLE
Split: update docs/v3/guidelines/nodes/running-nodes/full-node.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/nodes/running-nodes/full-node.mdx
+++ b/docs/v3/guidelines/nodes/running-nodes/full-node.mdx
@@ -3,7 +3,7 @@ import Feedback from '@site/src/components/Feedback';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Full node
+# Full Node
 
 ## OS requirements
 
@@ -19,17 +19,17 @@ We highly recommend installing MyTonCtrl on the following supported operating sy
 You shouldn't run any type of node on your personal local machine for extended periods, even if it meets the requirements. Nodes actively use disks, which can lead to rapid wear and potential damage.
 :::
 
-### With validator
+### Validator hardware requirements
 
 - 16 cores CPU
 - 128 GB RAM
-- 1TB NVMe SSD _OR_ Provisioned 64+k IOPS storage
-- 1 Gbit/s network connectivity
-- Public IP address (_fixed IP address_)
-- 64 TB/month traffic (100 TB/month at a peak load)
+- 1TB NVMe SSD or provisioned 64k+ IOPS storage
+- 1 Gbps network connectivity
+- Public, static IP address
+- 64 TB/month traffic (100 TB/month at peak load)
 
 :::info Be ready for peak loads
-To reliably handle peak loads, a connection of at least 1 Gbit/s is typically required, while the average load is expected to be around 100 Mbit/s.
+To reliably handle peak loads, a connection of at least 1 Gbps is typically required, while the average load is expected to be around 100 Mbit/s.
 :::
 
 ### Port forwarding
@@ -39,7 +39,7 @@ All types of nodes require a static external IP address, one UDP port forwarded 
 You can accomplish this by contacting your network provider or [renting a server](/v3/guidelines/nodes/running-nodes/full-node#recommended-providers) to run a node.
 
 :::info
-You can find out which UDP ports are open using the `netstat -tulpn` command.
+`netstat` and `ss` list local listeners only. To list UDP listeners, use `ss -u -lpn` (or `netstat -u -lpn`). To confirm public reachability, verify firewall/NAT rules or use an external port check.
 :::
 
 ### Recommended providers
@@ -62,7 +62,7 @@ The TON Foundation recommends the following providers for running a validator:
 
 ## Run a node (video)
 
-[//]: # "<ReactPlayer controls={true} style={{borderRadius:'10pt', margin:'15pt auto', maxWidth: '100%'}} url='/docs/files/TON_nodes.mp4' />"
+[//]: # "<ReactPlayer controls={true} style={{borderRadius:'10pt', margin:'15pt auto', maxWidth: '100%'}} url='/files/TON_nodes.mp4' />"
 
 Please check this step-by-step video tutorial to get started quickly:
 
@@ -91,7 +91,7 @@ If you don't have a non-root user, you can create one with the following steps (
 1. Log in as root and create a new user:
 
 ```bash
-sudo adduser <username>
+adduser <username>
 ```
 
 2. Add your user to the sudo group:
@@ -100,7 +100,7 @@ sudo adduser <username>
 sudo usermod -aG sudo <username>
 ```
 
-3. Log in as the new user (if you are using ssh, **you will need to stop current session and reconnect with correct user**)
+3. Log in as the new user (If you use SSH, stop the current session and reconnect as the correct user.)
 
 ```bash
 ssh <username>@<server-ip-address>
@@ -123,26 +123,24 @@ sudo bash install.sh
 
 ```bash
 wget https://raw.githubusercontent.com/ton-blockchain/mytonctrl/master/scripts/install.sh
-su root -c 'bash install.sh'
+sudo bash install.sh
 ```
 
   </TabItem>
 </Tabs>
 
 - `-d` - **mytonctrl** will download a [dump](https://dump.ton.org/) of the latest blockchain state.
-  This will reduce synchronization time by several times.
+  This significantly reduces synchronization time.
 - `-c <path>` - If you want to use a non-public liteserver for synchronization. _(not required)_
 - `-i` - Ignore the minimum requirements, use it only if you want to check the compilation process without real node usage.
 - `-m` - Mode, can be `validator` or `liteserver`.
 - `-t` - Disable telemetry.
 
-**To use Testnet**, `-c` flag should be provided with `https://ton.org/testnet-global.config.json` value.
+To use testnet, provide the `-c` flag with `https://ton.org/testnet-global.config.json`. The default `-c` value is `https://ton-blockchain.github.io/global.config.json` (mainnet).
 
-Default `-c` flag value is `https://ton-blockchain.github.io/global.config.json`, which is default Mainnet config.
+### Run MyTonCtrl
 
-### Running the MyTonCtrl
-
-1. Run `MyTonCtrl` console **from the local user account used for installation**:
+1. Open the MyTonCtrl console **from the local user account used for installation**:
 
 ```sh
 mytonctrl
@@ -150,25 +148,25 @@ mytonctrl
 
 2. Check the `MyTonCtrl` status using the `status` command:
 
-```sh
+```
 status
 ```
 
-**In testnet** `status fast` command must be used instead of `status`.
+In testnet, use the `status fast` command instead of `status`.
 
 The following statuses should be displayed:
 
 - **mytoncore status**: should display in green.
 - **local validator status**: should also display in green.
-- **local validator out of sync**: initially, a `n/a` string is displayed. As soon as the newly created validator connects with other validators, the number will be around 250k. As synchronization progresses, this number decreases. When it falls below 20 seconds, the validator is synchronized.
+- **local validator out of sync**: initially, n/a is displayed. As synchronization progresses, this number decreases. When it falls below 20 seconds, the validator is synchronized.
 
 Example of the **status** command output:
 
 ![status](/img/docs/nodes-validator/mytonctrl-status.png)
 
 :::caution Make sure you have the same output for status
-For all nodes type **Local Validator status** section should appear.
-Otherwise, [check troubleshooting section](/v3/guidelines/nodes/nodes-troubleshooting#status-command-displays-without-local-node-section) and [check node logs](/v3/guidelines/nodes/running-nodes/full-node#check-the-node-logs).
+For all node types, the 'Local validator status' section should appear.
+Otherwise, [check the troubleshooting section](/v3/guidelines/nodes/nodes-troubleshooting#status-command-displays-without-local-node-section) and [check the node logs](/v3/guidelines/nodes/running-nodes/full-node#check-the-node-logs).
 :::
 
 Please wait until the `Local validator out of sync` status is less than 20 seconds.
@@ -177,13 +175,13 @@ When a new node is started, even from a dump, it is important to wait up to 3 ho
 
 ### Uninstall MyTonCtrl
 
-Download script and run it:
+Run the uninstall script:
 
 ```bash
 sudo bash /usr/src/mytonctrl/scripts/uninstall.sh
 ```
 
-### Check MyTonCtrl owner
+### Check MyTonCtrl ownership
 
 Run:
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-nodes-running-nodes-full-node.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/nodes/running-nodes/full-node.mdx`

Related issues (from issues.normalized.md):
- [ ] **3351. Clarify setup sentence and link requirements**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/maintenance-guidelines/mytonctrl-remote-controller.mdx?plain=1#setting-up

Replace with "Prepare two servers: one for running the TON node (meeting the OS and hardware requirements) and one for running MyTonCtrl, which does not require many resources," linking to docs/v3/guidelines/nodes/running-nodes/full-node.mdx#os-requirements and docs/v3/guidelines/nodes/running-nodes/full-node.mdx#hardware-requirements.

---

- [ ] **3456. Capitalize title to “Full Node”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#full-node

Change the H1 from “Full node” to “Full Node” to match the Glossary term; align any in‑page references for consistency.

---

- [ ] **3457. Rename “With validator” subheading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#L22

Replace the heading “With validator” with “Validator hardware requirements” for clarity.

---

- [ ] **3458. Normalize hardware bullets style and wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#L26-L29

Replace “_OR_” with “or,” remove italics from the parenthetical, use “Public, static IP address,” and change “(100 TB/month at a peak load)” to “(100 TB/month at peak load).”

---

- [ ] **3459. Use Gbps consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#with-validator

Replace “1 Gbit/s” with “1 Gbps” in the hardware list (and related callout) to match the table and other pages.

---

- [ ] **3460. Unify IOPS notation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#with-validator

Replace “64+k IOPS” with “64,000+ IOPS” for clearer, consistent notation.

---

- [ ] **3461. Lowercase “public internet”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#L37

Use lowercase “internet” per style (“public internet”).

---

- [ ] **3462. Clarify UDP port check instructions**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#L41-L43

Note that netstat shows local listeners only; suggest ss -u -lpn (or netstat -u -lpn) to list UDP listeners and recommend an external port check or firewall/NAT verification to confirm public reachability.

---

- [ ] **3463. Fix GCP instance specs mismatch**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#L51

Row lists “n2-standard-16” with 32 vCPUs/128GB; either change specs to 16 vCPUs/64GB or change the instance type to a 32‑vCPU variant (e.g., n2-standard-32) so the row is self‑consistent.

---

- [ ] **3464. Correct Alibaba/Tencent instance specs**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#L52-L53

ecs.g6.4xlarge and M5.4XLARGE are typically 16 vCPUs/64GB; verify and either correct to 16/64 or change the instance types to match a 32 vCPU/128GB profile.

---

- [ ] **3465. Correct Vultr E‑2388G core/thread count**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#L54

Change “16 Cores / 32 Threads” to “8 Cores / 16 Threads,” or update the instance label/spec to match actual hardware.

---

- [ ] **3466. Update or remove commented video path**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#L65

The commented ReactPlayer line points to “/docs/files/TON_nodes.mp4”; update to “/files/TON_nodes.mp4” if re‑enabled or remove the comment.

---

- [ ] **3467. Fix root/sudo mismatch when creating user**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#switch-to-non-root-user

If already root, remove sudo from the command (use “adduser <username>”), or reword the step to create the user from a non‑root account with sudo.

---

- [ ] **3468. Improve SSH reconnection sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#L103

Change to “(If you use SSH, stop the current session and reconnect as the correct user.)”

---

- [ ] **3469. Align Debian install with non‑root guidance**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#install-mytonctrl

Adjust the Debian tab to run the installer from a non‑root sudo user (drop “su root -c” and use sudo) or explicitly note the root exception.

---

- [ ] **3470. Tighten dump option description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#L132-L133

Replace “This will reduce synchronization time by several times.” with “This significantly reduces synchronization time.”

---

- [ ] **3471. Clarify testnet flag and standardize mainnet URL**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#L139-L141

Rewrite to “To use testnet, provide the -c flag with https://ton.org/testnet-global.config.json. The default -c value is https://ton-blockchain.github.io/global.config.json (mainnet).” Also use lowercase “testnet/mainnet” in running text.

---

- [ ] **3472. Retitle section to “Run MyTonCtrl”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#L143

Change the heading “Running the MyTonCtrl” to “Run MyTonCtrl” for consistency with imperative section titles.

---

- [ ] **3473. Say “Open the MyTonCtrl console”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#L145

Replace “Run MyTonCtrl console” with “Open the MyTonCtrl console.”

---

- [ ] **3474. Mark console commands appropriately**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#L151-L155

Console commands are entered inside MyTonCtrl, not a shell; change code fences from sh to plain text or include a “MyTonCtrl>” prompt to avoid confusion.

---

- [ ] **3475. Improve testnet status command wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#L157

Change to “In testnet, use the status fast command instead of status.”

---

- [ ] **3476. Simplify n/a phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#L163

Change “initially, a n/a string is displayed” to “initially, n/a is displayed.”

---

- [ ] **3477. Remove unverified initial value claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#running-the-mytonctrl

Delete the specific “around 250k” initial value for “Local validator out of sync,” or replace with a non‑specific description.

---

- [ ] **3478. Tidy status caution grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#L169-L171

Change to “For all node types, the ‘Local validator status’ section should appear. Otherwise, check the troubleshooting section and the node logs.”

---

- [ ] **3479. Reword uninstall lead‑in**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#L180

Replace “Download script and run it:” with “Run the uninstall script:”.

---

- [ ] **3480. Clarify ownership heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#L186

Change the heading “Check MyTonCtrl owner” to “Check MyTonCtrl ownership.”

---

- [ ] **3481. Remove duplicate “Help command” image**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#list-of-available-commands

Delete the second, duplicate help image that appears again before “Check the MyTonCtrl logs.”

---

- [ ] **3482. Clarify log path wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#check-the-mytonctrl-logs

Rephrase to “For a non‑root user: ~/.local/share/mytoncore/mytoncore.log; for the root user: /usr/local/bin/mytoncore/mytoncore.log.”

---

- [ ] **3483. Fix support preposition**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/full-node.mdx?plain=1#support

Change “Contact technical support with @ton_node_help” to “Contact technical support at @ton_node_help.”

---

- [ ] **3559. Mention allowing node UDP port in firewall (TON)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx?plain=1

Note that full nodes require an allowed/forwarded UDP port and add guidance to permit it in the firewall, referencing docs/v3/guidelines/nodes/running-nodes/full-node.mdx#port-forwarding.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.