### PR TITLE
Split: update docs/v3/guidelines/nodes/running-nodes/run-mytonctrl-docker.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/nodes/running-nodes/run-mytonctrl-docker.mdx
+++ b/docs/v3/guidelines/nodes/running-nodes/run-mytonctrl-docker.mdx
@@ -16,17 +16,17 @@ To ensure an optimal experience while running MyTonCtrl, here are the recommende
 - 16 TB/month traffic on peak load
 
 :::warning 
- This setup is primarily intended for testing purposes, so it may not be suitable for production environments. If you’d like to bypass hardware checks for any reason, you can easily do this by setting the variable ``IGNORE_MINIMAL_REQS=true``.
+ This setup is primarily intended for testing purposes, so it may not be suitable for production environments. If you’d like to bypass hardware checks for any reason, you can easily do this by setting the variable `IGNORE_MINIMAL_REQS=true`.
 :::
 ## Software requirements
 
 To get started, please ensure you have the following software installed:
 
-- Docker CE  
-- Docker CE CLI  
-- Containerd.io  
-- Docker Buildx Plugin  
-- Docker Compose Plugin  
+- Docker CE
+- Docker CE CLI
+- Containerd.io
+- Docker Buildx Plugin
+- Docker Compose Plugin
 
 For detailed installation instructions, see the official [Docker installation guide](https://docs.docker.com/engine/install/).
 
@@ -34,11 +34,11 @@ For detailed installation instructions, see the official [Docker installation gu
 
 We’ve successfully tested MyTonCtrl on these operating systems:
 
-- Ubuntu 20.04  
-- Ubuntu 22.04  
-- Ubuntu 24.04  
-- Debian 11  
-- Debian 12  
+- Ubuntu 20.04
+- Ubuntu 22.04
+- Ubuntu 24.04
+- Debian 11
+- Debian 12
 
 ## Running MyTonCtrl v2 using the official Docker image
 
@@ -99,11 +99,11 @@ ghcr.io/ton-blockchain/ton-docker-ctrl:latest
 
 In the `.env` file, you can configure the following variables:
 
-- ``GLOBAL_CONFIG_URL``: Points to the network configurations for the TON Blockchain (default: [Testnet](https://ton.org/testnet-global.config.json))  
-- ``MYTONCTRL_VERSION``: Indicates the Git branch used for assembling MyTonCtrl  
-- ``TELEMETRY``: Turn telemetry on or off  
-- ``MODE``: Define the mode for MyTonCtrl (either validator or liteserver)  
-- ``IGNORE_MINIMAL_REQS``: Option to bypass hardware requirements  
+- `GLOBAL_CONFIG_URL`: Points to the network configurations for the TON Blockchain (default: [Testnet](https://ton.org/testnet-global.config.json))
+- `MYTONCTRL_VERSION`: Indicates the Git branch used for assembling MyTonCtrl
+- `TELEMETRY`: Turn telemetry on or off
+- `MODE`: Define the mode for MyTonCtrl (either validator or liteserver)
+- `IGNORE_MINIMAL_REQS`: Option to bypass hardware requirements
 
 ## Stopping and deleting MyTonCtrl
 
@@ -137,14 +137,14 @@ docker compose exec -it ton-node bash -c "mytonctrl"
 
 Once connected, check the status with:
 
-```bash
+```text
 MyTonCtrl> status
 ```
-![](https://raw.githubusercontent.com/ton-blockchain/mytonctrl/master/screens/mytonctrl-status.png)
+![MyTonCtrl status screen](/img/docs/mytonctrl/status.png)
 
 And if you would like to see a list of commands you can use, simply enter:
 
-```bash
+```text
 MyTonCtrl> help
 ```
 
@@ -171,14 +171,13 @@ After that, restart Docker Compose:
 docker compose up -d
 ```
 
-When you’re connected to MyTonCtrl, it will automatically check for updates. If any are available, you’ll see a message saying, “``MyTonCtrl update available. Please update it with the `update` command``”.  To do the update, use the command below and specify the branch you want:
+When you’re connected to MyTonCtrl, it will automatically check for updates. If any are available, you’ll see a message: MyTonCtrl update available; please run the update command. To do the update, use the command below and specify the branch you want:
 
-```bash
+```text
 MyTonCtrl> update mytonctrl2
 ```
 
 ## Changing the data storage path
 
-TON and MyTonCore data is stored in ``/var/lib/docker/volumes/``by default. If you wish to change this storage path, update the required route in the ``volumes`` section of your `docker-compose.yml` file to fit your needs. 
+TON and MyTonCtrl data is stored in ``/var/lib/docker/volumes/`` by default. If you wish to change this storage path, update the required path in the ``volumes`` section of your `docker-compose.yml` file to fit your needs. 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-nodes-running-nodes-run-mytonctrl-docker.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/nodes/running-nodes/run-mytonctrl-docker.mdx`

Related issues (from issues.normalized.md):
- [ ] **3501. Fix NVMe storage phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/run-mytonctrl-docker.mdx?plain=1#L13

Use “1 TB NVMe SSD” and include the alternative “or storage provisioned for 64k+ IOPS” for consistency and correct capitalization/spacing.

---

- [ ] **3502. Simplify public IP wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/run-mytonctrl-docker.mdx?plain=1#L15

Replace “Public IP address (fixed IP address)” with “Public static IP address.”

---

- [ ] **3503. Update traffic figure and phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/run-mytonctrl-docker.mdx?plain=1#L16

Replace “16 TB/month traffic on peak load” with “64 TB/month traffic (100 TB/month at peak load)” for consistency and improved phrasing.

---

- [ ] **3504. Fix warning block marker and inline code style**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/run-mytonctrl-docker.mdx?plain=1#L18-L20

Remove the trailing space after “:::warning” and use single backticks for the variable (`IGNORE_MINIMAL_REQS=true`).

---

- [ ] **3505. Remove trailing double spaces in lists**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/run-mytonctrl-docker.mdx?plain=1#L25-L29, #L37-L41

Delete the trailing double spaces at the end of bullet items in “Software requirements” and “Tested operating systems.”

---

- [ ] **3506. Remove -it from detached docker run**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/run-mytonctrl-docker.mdx?plain=1#L47-L49

For a detached container, drop “-it” and use “docker run -d --name ton-node -v <YOUR_LOCAL_FOLDER>:/var/ton-work ghcr.io/ton-blockchain/ton-docker-ctrl:latest”.

---

- [ ] **3507. Correct migration volume mapping**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/run-mytonctrl-docker.mdx?plain=1#L90-L95

Replace the incorrect “-v /home/<USER>/.local/share:/usr/local/bin” with a mapping from the actual host TON binaries directory to “/usr/local/bin” (e.g., “/usr/local/bin:/usr/local/bin” or “/home/<USER>/.local/bin:/usr/local/bin”), or, if migrating MyTonCtrl data, map “~/.local/share/mytoncore” to the container’s MyTonCtrl data path (clarify the intended paths).

---

- [ ] **3508. Standardize inline code to single backticks**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/run-mytonctrl-docker.mdx?plain=1#L100-L106

Change double‑backticked variables to single backticks: `GLOBAL_CONFIG_URL`, `MYTONCTRL_VERSION`, `TELEMETRY`, `MODE`, `IGNORE_MINIMAL_REQS`.

---

- [ ] **3509. Simplify compose exec command**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/run-mytonctrl-docker.mdx?plain=1#L134-L136

Use “docker compose exec -it ton-node mytonctrl” instead of invoking a subshell with “bash -c”.

---

- [ ] **3510. Use text code fences for MyTonCtrl prompts**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/run-mytonctrl-docker.mdx?plain=1#L140-L149, #L176-L178

Mark blocks showing “MyTonCtrl>” prompts as “text” (or no language) rather than “bash” to avoid misleading highlighting.

---

- [ ] **3511. Add alt text and use internal image asset**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/run-mytonctrl-docker.mdx?plain=1#L143

Provide descriptive alt text (e.g., “MyTonCtrl status screen”) and replace the raw GitHub URL with the internal asset “/img/docs/mytonctrl/status.png”.

---

- [ ] **3512. Fix update message formatting and example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/run-mytonctrl-docker.mdx?plain=1#L174-L178

Replace the curly‑quoted, nested backtick sentence with a plain notice (e.g., “MyTonCtrl update available; please run the update command”) and show the command separately as a prompt block using “update” or “update <branch>”.

---

- [ ] **3513. Fix storage section typos and wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/run-mytonctrl-docker.mdx?plain=1#L180-L182

Change “MyTonCore” to “MyTonCtrl,” insert a space after “``/var/lib/docker/volumes/``” (“… volumes/ by …”), and use “path” (not “route”) when referring to the volumes mapping.

---

- [ ] **3514. Clarify production suitability of Docker setup**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/run-mytonctrl-docker.mdx?plain=1

Remove or qualify the claim that this setup is “primarily intended for testing” unless a policy citation is provided, while keeping the `IGNORE_MINIMAL_REQS=true` note.

---

- [ ] **3515. Align tested OS list with supported versions**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/run-mytonctrl-docker.mdx?plain=1

Either match the supported OS list (Ubuntu 20.04/22.04, Debian 11) or add a note/citation that Ubuntu 24.04 and Debian 12 are officially supported.

---

- [ ] **3516. Clarify “MyTonCtrl v2” references**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/run-mytonctrl-docker.mdx?plain=1

Remove “v2” from headings or link to documentation that defines version differences to avoid ambiguity.

---

- [ ] **3517. Correct GLOBAL_CONFIG_URL default**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/run-mytonctrl-docker.mdx?plain=1

Set the documented default to Mainnet (“https://ton-blockchain.github.io/global.config.json”) or remove the default claim if environment‑specific.

---

- [ ] **3518. Provide docker run equivalents to compose commands**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/run-mytonctrl-docker.mdx?plain=1

Add non‑Compose examples alongside Compose ones (e.g., connect: “docker exec -it ton-node mytonctrl”, stop: “docker stop ton-node”, logs: “docker logs -f ton-node”) to avoid ambiguity.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.