### PR TITLE
Split: update docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx
+++ b/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx
@@ -19,11 +19,11 @@ Before starting, ensure your system meets these requirements:
 #### Windows installation steps
 
 - Install Microsoft Visual C++ Redistributable 2015+ x64
-- Download the correct JAR file based on your system architecture:
+- Download the correct JAR file from the [MyLocalTon Releases page](https://github.com/neodix42/MyLocalTon/releases) based on your system architecture:
   - For x86-64 systems: `MyLocalTon-x86-64.jar`
-  - For ARM64 systems: `MyLocalTon-arm64.jar`
+  - For arm64 systems: `MyLocalTon-arm64.jar`
 
-#### Linux/MacOS Installation Steps
+#### Linux/macOS installation steps
 
 ```bash
 # For x86-64 systems
@@ -58,7 +58,7 @@ mvn clean package assembly:single
 After successful compilation, find your built artifacts in the `target` directory:
 
 - `MyLocalTon-x86_64.jar` for x86-64 systems
-- `MyLocalTon-arm64.jar` for ARM64 systems
+- `MyLocalTon-arm64.jar` for arm64 systems
 
 ### Basic operation
 
@@ -69,7 +69,7 @@ Launch MyLocalTon using Java:
 java -jar MyLocalTon-x86-64.jar
 
 # For ARM64 systems  
-java -jar MyLocalTon-arm64.jar`
+java -jar MyLocalTon-arm64.jar
 ```
 
 #### Command line options
@@ -79,18 +79,18 @@ MyLocalTon accepts several parameters to customize its operation:
 - `nogui`: Run without graphical interface
 - `ton-http-api`: Enable HTTP API functionality
 - `explorer`: Launch explorer interface
-- `ip.addr.xxx.xxx`: Set custom IP address
-- `with-validators-N`: Specify number of validators to start
-- `custom-binaries=absolute-path`: Use custom binaries
+- `ip.addr=<A.B.C.D>`: Set custom IP address
+- `with-validators=<N>`: Specify the number of validators to start
+- `custom-binaries=<absolute-path>`: Use custom binaries
 - `debug`: Enable debug mode
 
-For complete technical details, [see](https://github.com/neodix42/MyLocalTon?tab=readme-ov-file#parameters).
+For complete technical details, [see the full parameter list](https://github.com/neodix42/MyLocalTon?tab=readme-ov-file#parameters).
 
 MyLocalTon features a user-friendly interface:
-![](/img/docs/mylocalton.jpeg)
-![](/img/docs/mylocalton-demo.gif)
+![MyLocalTon UI screenshot](/img/docs/mylocalton.jpeg)
+![MyLocalTon demo animation](/img/docs/mylocalton-demo.gif)
 
-### Lite-client access setup
+### Lite client access setup
 
 MyLocalTon generates permanent private/public keys for secure lite-server and validator-engine-console connections:
 
@@ -131,58 +131,62 @@ Track MyLocalTon's operation through these log files:
    | ---------------- | ------------- | --------- |
    | Linux            | x86_64       | ✅         |
    | Linux            | arm64/aarch64 | ✅         |
-   | MacOS            | x86_64 (12+) | ✅         |
-   | MacOS            | arm64/aarch64 | ✅         |
-   | Windows          | x86_64.      | ✅         |
+   | macOS            | x86_64       | ✅         |
+   | macOS            | arm64/aarch64 | ✅         |
+   | Windows          | x86_64       | ✅         |
 
-2. MacOS users note
+2. macOS users note
 
    If you use MacPorts instead of Homebrew, execute these commands:
 
    ```bash
-   mkdir -p /usr/local/opt/readline/lib
-   ln -s /opt/local/lib/libreadline.8.dylib /usr/local/opt/readline/lib
+   sudo mkdir -p /usr/local/opt/readline/lib
+   sudo ln -s /opt/local/lib/libreadline.8.dylib /usr/local/opt/readline/lib
    ```
 
-3. Upgrade process :
+3. Upgrade process:
 
    Currently, upgrading requires these steps:
 
    - Download the latest version
-   - Replace the existing MyLocalTon file
-   - Remove the myLocalTon directory
+   - Replace the existing MyLocalTon JAR file
+   - Remove the `myLocalTon` directory
 
    Developers are planning to include direct upgrade functionality in future releases.
 
 4. HTTP API integration:
 
-   ```bash
-   # Linux Installation  
-   sudo  apt  install -y python3 
-   sudo  apt  install -y      
-   python3-pip pip3 install --user ton-http-api 
+  Linux/macOS:
 
-   # MacOS Installation  
-   brew install -q python3 
-   python3 -m ensurepip --upgrade
-   pip3 install --user ton-http-api 
+  ```bash
+  # Linux Installation  
+  sudo apt update && sudo apt install -y python3 python3-pip
+  pip3 install --user ton-http-api 
 
-   # Windows Installation  
-   wget https://www.python.org/ftp/python/3.12.0/python-3.12.0-amd64.exe    
-   python -m ensurepip --upgrade
-   start pip3 install -U ton-http-api`
-   ```
+  # MacOS Installation  
+  brew install -q python3 
+  python3 -m ensurepip --upgrade
+  pip3 install --user ton-http-api 
+  ```
+
+  Windows:
+
+  ```powershell
+  # Windows Installation  
+  winget install -e --id Python.Python.3
+  pip3 install -U ton-http-api
+  ```
 
 ### Important notice
 
 :::caution
-Developers currently classify MyLocalTon as alpha software, making it unsuitable for production environments. For containerized deployment, developers recommend using the  [dedicated Docker repository](https://github.com/neodix42/mylocalton-docker).
+Developers currently classify MyLocalTon as alpha software, making it unsuitable for production environments. For containerized deployment, developers recommend using the [dedicated Docker repository](https://github.com/neodix42/mylocalton-docker).
 :::
 
 ### Resources
 
-- [MyLocalTon binaries](https://github.com/neodiX42/MyLocalTon/releases)
+- [MyLocalTon binaries](https://github.com/neodix42/MyLocalTon/releases)
 
-- [MyLocalTon source code](https://github.com/neodiX42/MyLocalTon)
+- [MyLocalTon source code](https://github.com/neodix42/MyLocalTon)
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-nodes-running-nodes-running-a-local-ton.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx`

Related issues (from issues.normalized.md):
- [ ] **3519. Mark Python prerequisite optional**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx?plain=1#L14

Python is only needed for the HTTP API; label it as optional, e.g., “Python 3.x (optional) for HTTP API integration.”

---

- [ ] **3520. Use sentence case in headings**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx?plain=1#L19,#L26

Align headings to sentence case (e.g., “Windows installation steps”, “Linux/macOS installation steps”) for consistency.

---

- [ ] **3521. Normalize ARM64 casing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx?plain=1#L24,#L32,#L61,#L133,#L135

Use “arm64” in prose consistently, preserving exact casing only in filenames/artifacts.

---

- [ ] **3522. Use macOS capitalization consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx?plain=1#L26,#L134-L135,#L138,#L165

Replace all “MacOS” with “macOS” in headings, tables, and text.

---

- [ ] **3523. Require JDK 21 and remove unused Ant**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx?plain=1#L40-L45

Specify installing OpenJDK 21 (e.g., openjdk-21-jdk), keep Maven, and drop Ant unless explicitly used; advise verifying java -version reports 21+.

---

- [ ] **3524. Fix double spaces in prerequisite commands**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx?plain=1#L40-L45

Normalize shell lines to single spaces (e.g., “sudo apt install maven”) to prevent copy/paste errors.

---

- [ ] **3525. Standardize x86-64 JAR filename and arch suffix**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx?plain=1#L60

Use the released artifact name everywhere: “MyLocalTon-x86-64.jar” (hyphen, not underscore), and align any architecture suffix references accordingly.

---

- [ ] **3526. Remove stray backtick in ARM64 run command**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx?plain=1#L72

Delete the trailing backtick so the command reads “java -jar MyLocalTon-arm64.jar”.

---

- [ ] **3527. Make parameter link text descriptive**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx?plain=1#L87

Replace the bare “see” with descriptive text like “See the full parameter list,” linking to the same target.

---

- [ ] **3528. Remove trailing period in Windows architecture cell**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx?plain=1#L136

Delete the final period so the value is “x86_64”.

---

- [ ] **3529. Fix “Upgrade process” punctuation and clarify file names**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx?plain=1#L147

Change to “Upgrade process:” and clarify to replace the existing JAR (e.g., “MyLocalTon-….jar”) and wrap the myLocalTon directory name in code style where referenced.

---

- [ ] **3530. Split mixed-OS HTTP API commands into separate blocks**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx?plain=1#L159-L174

Separate Linux/macOS and Windows instructions into distinct code blocks with appropriate language tags (bash for Unix, powershell or bat for Windows).

---

- [ ] **3531. Fix Linux HTTP API commands**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx?plain=1#L160-L164

Provide valid, distinct commands, e.g., “sudo apt update && sudo apt install -y python3 python3-pip” followed by “pip3 install --user ton-http-api”.

---

- [ ] **3532. Correct Windows HTTP API steps (install Python, no wget/start, remove backtick)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx?plain=1#L171-L174

Show installing Python (e.g., “winget install Python.Python.3” or run the downloaded installer with “start /wait …”), then “pip3 install -U ton-http-api”; avoid wget (use a hyperlink or PowerShell Invoke-WebRequest), don’t prefix pip with start, and remove the stray backtick.

---

- [ ] **3533. Remove double space before link in caution**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx?plain=1#L179

Reduce the two spaces before the link to one to read “…recommend using the [dedicated Docker repository]…”.

---

- [ ] **3534. Standardize GitHub repo casing/targets**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx?plain=1#L184-L186

Use a single canonical owner/repo casing and path across all links (e.g., lowercase “neodix42” for MyLocalTon and Docker repos) and update the Resources links accordingly.

---

- [ ] **3535. Add alt text to images**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx?plain=1

Provide concise alt text for images (e.g., “MyLocalTon UI screenshot”, “MyLocalTon demo animation”) for accessibility.

---

- [ ] **3536. Clarify CLI placeholder syntax**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx?plain=1

Use consistent placeholders that reflect exact flag syntax, e.g., “with-validators=<N>”, “ip.addr=<A.B.C.D>”, “custom-binaries=<absolute-path>”.

---

- [ ] **3537. Fix lite client heading style**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx?plain=1

Use sentence case without a hyphen: change “Lite-client access setup” to “Lite client access setup”.

---

- [ ] **3538. Normalize casing in paths and filenames**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx?plain=1

Align examples to the actual on-disk names (e.g., directory vs JAR vs log) to avoid case-related errors on case-sensitive filesystems.

---

- [ ] **3539. Add sudo to macOS MacPorts note**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx?plain=1

Prefix commands creating directories or symlinks under /usr/local (e.g., mkdir, ln -s) with sudo to match typical permissions.

---

- [ ] **3540. Add explicit Releases link in Windows steps**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx?plain=1#L19

In “Windows installation steps,” include a direct link to the MyLocalTon Releases page and instruct users to download the matching JAR.

---

- [ ] **3541. Make macOS version notes consistent in table**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/running-a-local-ton.mdx?plain=1

Either provide OS version parentheticals consistently for all macOS rows (including arm64) or remove them for uniformity.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.