### PR TITLE
Split: update docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx
+++ b/docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx
@@ -1,48 +1,53 @@
 import Feedback from '@site/src/components/Feedback';
 
-# Secure guidelines for nodes
+# Security Guidelines for Nodes
 
-Ensuring the security of nodes, particularly in decentralized networks such as blockchain or distributed systems, is essential for maintaining data integrity, confidentiality, and availability. The guidelines for securing nodes should cover several layers, including network communication, hardware, and software configurations. Below are a set of guidelines to enhance node security:
+Ensuring the security of nodes, particularly in decentralized networks such as blockchain or distributed systems, is essential for maintaining data integrity, confidentiality, and availability. The guidelines for securing nodes should cover several layers, including network communication, hardware, and software configurations. Below is a set of guidelines to enhance node security:
 
-### 1. Use the server exclusively to operate the TON node:
+### 1. Use the server exclusively to operate the node
 
 - Using the server for additional tasks presents a potential security risk.
 
-### 2. Update and patch regularly:
+### 2. Update and patch regularly
 
 - Keep your system updated with the latest security patches.
 
 - Regularly use package management tools like apt (Debian/Ubuntu) or yum/dnf (CentOS/Fedora) to perform updates.
 
   ```bash
-  #Debian/Ubuntu
-  sudo apt update && sudo  apt  upgrade  -y
+  # Debian/Ubuntu
+  sudo apt update && sudo apt upgrade -y
 
-  #CentOS
-  sudo yum update && sudo yum upgrade -y
+  # CentOS
+  sudo yum update -y
 
-  #Fedora
-  sudo dnf update && sudo dnf upgrade -y
+  # Fedora
+  sudo dnf upgrade -y
   ```
 
 - Consider automating security updates by enabling unattended upgrades for your system.
 
-### 3. Ensure a robust SSH configuration:
+### 3. Ensure a robust SSH configuration
 
 - **Disable root login:** Prevent root access through SSH by editing the `/etc/ssh/sshd_config` file.
 
-  ```bash
+  ```conf
   PermitRootLogin no
   ```
 - **Use SSH keys:** For a more secure connection, opt for SSH keys instead of password authentication.
-  ```bash
+  ```conf
   PasswordAuthentication no
   ```
 - **Modify the default SSH port:** Changing the default SSH port can help reduce automated brute-force attacks:
 
-  ```bash
+  ```conf
   Port 2222
   ```
+- After editing `/etc/ssh/sshd_config`, apply changes with `sudo systemctl reload ssh` (Debian/Ubuntu) or `sudo systemctl reload sshd` (RHEL/CentOS/Fedora).
+
+:::caution
+Before disabling password authentication or changing the SSH port, ensure you can sign in with SSH keys and that firewall rules allow the new port to avoid lockout.
+:::
 - **Restrict SSH access:** Allow SSH connections only from trusted IP addresses by implementing firewall rules.
 
 ### 4. Implement a firewall
@@ -53,41 +58,52 @@ Ensuring the security of nodes, particularly in decentralized networks such as b
   sudo ufw allow 22/tcp # Allow SSH
   sudo ufw allow 80/tcp # Allow HTTP
   sudo ufw allow 443/tcp # Allow HTTPS
+  sudo ufw default deny incoming
+  sudo ufw default allow outgoing
   sudo ufw enable # Enable firewall
   ```
+
+- Note: Replace `22` with your configured SSH port (e.g., `2222`). Also, if running a full node, ensure the required UDP port is allowed/forwarded. See `guidelines/nodes/running-nodes/full-node.mdx#port-forwarding`.
 
 ### 5. Monitor logs
 
 - Regularly monitor system logs to detect suspicious activities:
-  - `/var/log/auth.log` (for authentication attempts)
+  - `/var/log/auth.log` (authentication attempts on Debian/Ubuntu)
+  - `/var/log/secure` (authentication attempts on RHEL/CentOS)
   - `/var/log/syslog` or `/var/log/messages`
 - Consider implementing centralized logging.
 
 ### 6. Limit user privileges
 
-- Grant root or sudo privileges only to trusted users. Use the sudo command carefully and audit the `/etc/sudoers` file to limit access.
+- Grant root or sudo privileges only to trusted users. Use the sudo command carefully and use `visudo` to audit/edit the `/etc/sudoers` file to limit access.
 
 - Regularly review user accounts and remove any unnecessary or inactive users.
 
 ### 7. Utilize SELinux or AppArmor
 
-- **SELinux** (on RHEL/CentOS) and **AppArmor** (on Ubuntu/Debian) provide mandatory access control, adding an extra layer of security by restricting programs from accessing specific system resources.
+- **SELinux** (on RHEL/CentOS/Fedora) and **AppArmor** (on Ubuntu/Debian) provide mandatory access control, adding an extra layer of security by restricting programs from accessing specific system resources.
 
 ### 8. Install security tools
 
 - Utilize tools such as **Lynis** to conduct regular security audits and identify potential vulnerabilities:
 
   ```bash
-  sudo apt install lynis
+  # Debian/Ubuntu
+  sudo apt install lynis -y
+
+  # RHEL/CentOS/Fedora
+  sudo dnf install lynis -y
+
+  # Run audit
   sudo lynis audit system
   ```
 
 ### 9. Disable unnecessary services
 
-- To minimize the attack surface, disable or remove any unused services. For instance, if FTP or mail services are not needed, ensure to disable them:
+- To minimize the attack surface, disable or remove any unused services. For instance, if FTP or mail services are not needed, ensure you disable them:
 
   ```bash
-  sudo systemctl disable service_name
+  sudo systemctl disable <service_name>
   ```
 
 ### 10. Implement intrusion detection and prevention systems (IDS/IPS)
@@ -95,10 +111,19 @@ Ensuring the security of nodes, particularly in decentralized networks such as b
 - Use tools like **Fail2ban** to block IP addresses after multiple failed login attempts:
 
   ```bash
-  sudo apt install fail2ban
+  # Debian/Ubuntu
+  sudo apt install fail2ban -y
+
+  # RHEL/CentOS/Fedora
+  sudo dnf install fail2ban -y
   ```
 
 - Utilize **AIDE (Advanced Intrusion Detection Environment)** to monitor file integrity and identify any unauthorized changes.
+
+### Unattended updates
+
+- Debian/Ubuntu: `sudo apt install unattended-upgrades`
+- RHEL/Fedora: `sudo dnf install dnf-automatic -y && sudo systemctl enable --now dnf-automatic.timer`
 
 :::caution
 Please remain vigilant and ensure that your node is secure at all times.

--- a/docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx
+++ b/docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx
@@ -1,6 +1,6 @@
 import Feedback from '@site/src/components/Feedback';
 
-# Security Guidelines for Nodes
+# Security guidelines for nodes
 
 Ensuring the security of nodes, particularly in decentralized networks such as blockchain or distributed systems, is essential for maintaining data integrity, confidentiality, and availability. The guidelines for securing nodes should cover several layers, including network communication, hardware, and software configurations. Below is a set of guidelines to enhance node security:
 
@@ -31,16 +31,16 @@ Ensuring the security of nodes, particularly in decentralized networks such as b
 
 - **Disable root login:** Prevent root access through SSH by editing the `/etc/ssh/sshd_config` file.
 
-  ```conf
+  ```bash
   PermitRootLogin no
   ```
 - **Use SSH keys:** For a more secure connection, opt for SSH keys instead of password authentication.
-  ```conf
+  ```bash
   PasswordAuthentication no
   ```
 - **Modify the default SSH port:** Changing the default SSH port can help reduce automated brute-force attacks:
 
-  ```conf
+  ```bash
   Port 2222
   ```
 - After editing `/etc/ssh/sshd_config`, apply changes with `sudo systemctl reload ssh` (Debian/Ubuntu) or `sudo systemctl reload sshd` (RHEL/CentOS/Fedora).
@@ -63,7 +63,7 @@ Before disabling password authentication or changing the SSH port, ensure you ca
   sudo ufw enable # Enable firewall
   ```
 
-- Note: Replace `22` with your configured SSH port (e.g., `2222`). Also, if running a full node, ensure the required UDP port is allowed/forwarded. See `guidelines/nodes/running-nodes/full-node.mdx#port-forwarding`.
+- Note: Replace `22` with your configured SSH port (e.g., `2222`). Also, if running a full node, ensure the required UDP port is allowed/forwarded. See [port forwarding](guidelines/nodes/running-nodes/full-node#port-forwarding).
 
 ### 5. Monitor logs
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-nodes-running-nodes-secure-guidelines.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx`

Related issues (from issues.normalized.md):
- [x] **3542. Fix H1 title to "Security Guidelines for Nodes"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx?plain=1

Change the H1 from "Secure guidelines for nodes" to "Security Guidelines for Nodes" for clarity and Title Case consistency.

---

- [x] **3543. Correct subject–verb agreement in intro sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx?plain=1

Replace "Below are a set of guidelines to enhance node security:" with either "Below is a set of guidelines to enhance node security:" or "Below are guidelines to enhance node security:".

---

- [x] **3544. Standardize product naming (TON vs generic)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx?plain=1

Change "Use the server exclusively to operate the TON node" to "Use the server exclusively to operate the node" (or make the page TON‑specific consistently).

---

- [x] **3545. Remove trailing colons from headings 1–3**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx?plain=1

Standardize section headings by removing trailing colons from items 1–3 to match the rest.

---

- [x] **3546. Align firewall SSH rule with configured SSH port**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx?plain=1

Update the UFW example to allow the configured SSH port (e.g., sudo ufw allow 2222/tcp) or note to replace with the chosen SSH port.

---

- [x] **3547. Normalize spacing and comment style in update commands block**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx?plain=1

Remove extra spaces in commands (e.g., use "sudo apt upgrade -y") and add a space after "#" in comments (e.g., "# Debian/Ubuntu") for readability.

---

- [x] **3548. Remove redundant yum/dnf update commands**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx?plain=1

Use a single command per platform (e.g., "sudo yum update -y" or "sudo dnf upgrade -y") instead of both update and upgrade.

---

- [x] **3549. Add RHEL/CentOS auth log path**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx?plain=1

Include "/var/log/secure" as the authentication log location for RHEL/CentOS alongside "/var/log/auth.log" for Debian/Ubuntu.

---

- [x] **3550. Provide cross-distro install commands for Lynis and Fail2ban**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx?plain=1

Add dnf/yum equivalents (e.g., "sudo dnf install lynis -y" and "sudo dnf install fail2ban -y") or prefix apt examples with "On Debian/Ubuntu:".

---

- [x] **3551. Improve phrasing "ensure to disable"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx?plain=1

Replace "ensure to disable them" with "ensure you disable them" or "ensure they are disabled" for natural phrasing.

---

- [x] **3552. Expand SELinux platform mention to include Fedora**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx?plain=1

Update to "SELinux (on RHEL/CentOS/Fedora) and AppArmor (on Ubuntu/Debian)..." for accuracy.

---

- [x] **3553. Label sshd_config snippets as config, not bash**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx?plain=1

Change code fences for sshd_config directives (e.g., PermitRootLogin, PasswordAuthentication, Port) from "bash" to a config-friendly language such as "conf" (or "text").

---

- [x] **3554. Recommend editing sudoers with visudo**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx?plain=1

Advise using "visudo" to audit/edit /etc/sudoers for validation and safety instead of editing the file directly.

---

- [x] **3555. Add UFW default policies before enabling**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx?plain=1

Set defaults prior to enabling UFW (e.g., "sudo ufw default deny incoming" and "sudo ufw default allow outgoing") to avoid unintended openings.

---

- [x] **3556. Add distro-specific steps for unattended updates**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx?plain=1

Provide commands such as "sudo apt install unattended-upgrades" (Debian/Ubuntu) and "sudo dnf install dnf-automatic -y && sudo systemctl enable --now dnf-automatic.timer" (RHEL/Fedora).

---

- [x] **3557. Add step to reload SSH after config changes**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx?plain=1

After editing /etc/ssh/sshd_config, instruct to apply changes with "sudo systemctl reload ssh" (Debian/Ubuntu) or "sudo systemctl reload sshd" (RHEL/CentOS/Fedora).

---

- [x] **3558. Add caution to avoid SSH lockout**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx?plain=1

Warn users to confirm key-based access and firewall rules for the new port before disabling password authentication or changing the SSH port.

---

- [x] **3559. Mention allowing node UDP port in firewall (TON)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx?plain=1

Note that full nodes require an allowed/forwarded UDP port and add guidance to permit it in the firewall, referencing docs/v3/guidelines/nodes/running-nodes/full-node.mdx#port-forwarding.

---

- [x] **3560. Use angle-bracket placeholder for service name**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/secure-guidelines.mdx?plain=1

Change "sudo systemctl disable service_name" to "sudo systemctl disable <service_name>" for placeholder style consistency.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.