### PR TITLE
Split: update docs/v3/guidelines/nodes/running-nodes/staking-with-nominator-pools.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/nodes/running-nodes/staking-with-nominator-pools.mdx
+++ b/docs/v3/guidelines/nodes/running-nodes/staking-with-nominator-pools.mdx
@@ -34,8 +34,6 @@ By contract design, nominator pools enforce the following limits:
 - Minimum stake per nominator: **10,000 TON**
 - Maximum number of nominators per pool: **40**
 
-Individual pools may set higher minimums, but they cannot go below these protocol-level limits.
-
 _From [TON Community post](https://t.me/toncoin/543)._
 
 There should always be **10 TON** on the pool balance - this is the minimum balance for the network storage fee.
@@ -46,14 +44,16 @@ Since validation round lasts ~18 hours, takes about 5 TON per validation round a
 
 ## How to participate?
 
-- [TON Validators website](https://tonvalidators.org/) lists active pools and explains how to join.
+- [TON Validators website](https://tonvalidators.org/) lists active pools.
 
 ## Source code
 
 - [Nominator pool smart contract source code](https://github.com/ton-blockchain/nominator-pool)
 
 :::info
+
 The theory of nominators is described in [TON Whitepaper](https://docs.ton.org/ton.pdf), chapters 2.6.3, 2.6.25.
+
 :::
 
 ## See also


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-nodes-running-nodes-staking-with-nominator-pools.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/nodes/running-nodes/staking-with-nominator-pools.mdx`

Related issues (from issues.normalized.md):
- [x] **3561. Use “mechanisms,” not “mechanics”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/staking-with-nominator-pools.mdx?plain=1#L7

“staking and deposit mechanics” is non-idiomatic; change to “staking and deposit mechanisms.”

---

- [x] **3562. Normalize “TON blockchain” and em dash**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/staking-with-nominator-pools.mdx?plain=1#L9

Lowercase “blockchain” and use an em dash without spaces: “However, there is native staking in the TON blockchain—you can lend Toncoin to validators for staking and share rewards for validation.”

---

- [x] **3563. Fix articles in nominator definition**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/staking-with-nominator-pools.mdx?plain=1#L11

Add missing articles: “The one who lends to a validator is called a nominator.”

---

- [x] **3564. Clarify nominator pool description and grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/staking-with-nominator-pools.mdx?plain=1#L13

Use correct prepositions/possessives and pluralize “rewards”: “A smart contract, called a nominator pool, enables one or more nominators to lend Toncoin to a validator’s stake and ensures that the validator can use that Toncoin only for validation; this smart contract guarantees the distribution of rewards.”

---

- [x] **3565. Normalize nominator pool link trailing slashes**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/staking-with-nominator-pools.mdx?plain=1#L13

Use a consistent trailing slash and casing for all “nominator pool” spec links on this page (including See also): “/v3/documentation/smart-contracts/contracts-specs/nominator-pool/”.

---

- [x] **3566. Neutralize intro tone on validators and nominators**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/staking-with-nominator-pools.mdx?plain=1#L15

Replace promotional phrasing with neutral wording, e.g., “If you are familiar with cryptocurrencies, you have likely heard of validators and nominators—two key participants in staking.”

---

- [ ] **3567. Qualify stake minimum and fix units; add citations**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/staking-with-nominator-pools.mdx?plain=1#L21

Change “obtain at least 300,000 Toncoins” to “meet hardware requirements and a stake meeting the current minimum (approximately 300K TON)” and cite validator-node.mdx#activate-the-wallets and documentation/infra/nodes/validation/staking-incentives.mdx#values-of-stakes-max-effective-stake.

---

- [x] **3568. Fix info callout grammar about new version**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/staking-with-nominator-pools.mdx?plain=1#L25-L27

Rewrite to: “A newer version of the nominator pool is available; read more on the Single nominator pool and Vesting contract pages.”

---

- [x] **3569. Use inclusive language and consistent asset terms**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/staking-with-nominator-pools.mdx?plain=1#L29

Replace “100,000s of Toncoin on their balance … lends his TON … it is distributed between the involved participants” with “hundreds of thousands of TON in their balance … lends their TON … the reward is distributed among the participants,” and use “Toncoin (TON)” consistently.

---

- [x] **3570. Fix possessive in “TON Foundation … pool”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/staking-with-nominator-pools.mdx?plain=1#L31

Change to “The TON Foundation’s open nominator pool allows …” (or “The TON Foundation open nominator pool …”), using correct article/possessive.

---

- [ ] **3571. Remove unsupported fixed 10 TON storage minimum**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/staking-with-nominator-pools.mdx?plain=1#L35

Replace “There should always be 10 TON on the pool’s balance—this is the minimum …” with non-numeric guidance such as “Ensure sufficient balance to cover network storage and transaction fees.”

---

- [ ] **3572. Correct monthly cost and parity details; add citations**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/staking-with-nominator-pools.mdx?plain=1#L39

Replace the single “~105 TON/month” claim with two cases per the spec (~101.25 TON/month if participating in only odd or only even rounds; ~202.50 TON/month if in both), and cite documentation/smart-contracts/contracts-specs/nominator-pool.mdx#fees, guidelines/smart-contracts/howto/nominator-pool.mdx#validator-pool-mode, and cycle duration from documentation/network/configs/blockchain-configs.mdx#param-15.

---

- [x] **3573. Remove trailing space in “See also” header**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/staking-with-nominator-pools.mdx?plain=1#L53

Delete the trailing space so the header reads exactly “## See also”.

---

- [x] **3574. Align external minimum deposit claims to spec limits**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/staking-with-nominator-pools.mdx?plain=1

Remove brand-specific minimums (e.g., TON Whales 50 TON; TON Foundation 10,000 TON) and instead state the contract’s limits (e.g., minimum nominator stake 10,000 TON; max nominators 40) per documentation/smart-contracts/contracts-specs/nominator-pool.mdx#limits.

---

- [x] **3575. Add internal how-to link in “How to participate?”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/staking-with-nominator-pools.mdx?plain=1

In addition to the external pool list, add an internal cross-reference to guidelines/smart-contracts/howto/nominator-pool.mdx for actionable steps.

---

- [x] **3576. Remove unsupported validator count claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/staking-with-nominator-pools.mdx?plain=1

Delete or generalize “At the time of writing, there are up to 400 validators per round on TON,” and instead point to validator configuration lists (documentation/network/configs/blockchain-configs.mdx#param-32-34-and-36).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.