### PR TITLE
Split: update docs/v3/guidelines/nodes/running-nodes/validator-node.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx
+++ b/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx
@@ -19,7 +19,7 @@ Network validators confirm all user transactions. If all validators agree that a
 
 ## Port forwarding
 
-All types of nodes require a static external IP address, one UDP port forwarded for incoming connections, and all outgoing connections to be open—the node uses random ports for new outgoing connections. The node must also be visible to the outside world over the NAT.
+All types of nodes require a static external IP address, one UDP port forwarded for incoming connections, and all outgoing connections to be open—the node uses random ports for new outgoing connections. The node must also be reachable from the public internet when it is behind a NAT.
 
 You can work with your network provider or [rent a server](/v3/guidelines/nodes/running-nodes/full-node#recommended-providers) to run a node.
 
@@ -31,45 +31,45 @@ To determine which UDP ports are open, use the `netstat -tulpn` command.
 
 ### Learn slashing policy
 
-If a validator processes less than 90% of the expected blocks during a validation round, they will be fined by 101 TON.
+If a validator processes less than 90% of the expected blocks during a validation round, they will be fined 101 TON.
 
 Learn more about the [slashing policy](/v3/documentation/infra/nodes/validation/staking-incentives#decentralized-system-of-penalties).
 
-### Running a fullnode
+### Running a full node
 
-Launch the [Full Node](/v3/guidelines/nodes/running-nodes/full-node) before follow this article.
+Launch the [Full Node](/v3/guidelines/nodes/running-nodes/full-node) before following this article.
 
 Ensure that validator mode is enabled by using the `status_modes` command. If it is not enabled, refer to the [MyTonCtrl enable_mode command](/v3/documentation/infra/nodes/mytonctrl/mytonctrl-overview#enable_mode).
 
 ## Architecture
 
-![image](/img/nominator-pool/hot-wallet.png)
+![Validator node architecture diagram](/img/nominator-pool/hot-wallet.png)
 
 ## View the list of wallets
 
 Check out the list of available wallets in the `MyTonCtrl` console using the `wl` command:
 
-```sh
+```bash
 wl
 ```
 
-During the installation of `MyTonCtrl`, the installer creates a wallet named `validator_wallet_001`.
+You may see a wallet like `validator_wallet_001`; if none exists, create one.
 
 ![wallet list](/img/docs/nodes-validator/manual-ubuntu_mytonctrl-wl_ru.png)
 
-## Activate the wallets
+## Activate the wallet
 
-1. Send the necessary number of coins to the wallet and activate it. The minimum stake is approximately **300K TON**, and the maximum is about **1M** TON. To understand the required amount of coins, please check the current stakes at [tonscan.com](https://tonscan.com/validation). For  more information, see [how maximum and minimum stakes calculated](/v3/documentation/infra/nodes/validation/staking-incentives#values-of-stakes-max-effective-stake).
+1. Send the necessary number of coins to the wallet and activate it. The minimum stake is approximately **300K TON**, and the maximum is about **1M** TON. To understand the required amount of coins, please check the current stakes at [tonscan.com](https://tonscan.com/validation). For more information, see [how maximum and minimum stakes are calculated](/v3/documentation/infra/nodes/validation/staking-incentives#values-of-stakes-max-effective-stake).
 
 2. Use the `vas` command to view the history of transfers:
 
-```sh
+```bash
 vas [wallet name]
 ```
 
 3. Use the `aw` command to activate the wallet. The `wallet name` parameter is optional; if no arguments are provided, all available wallets will be activated.
 
-```sh
+```bash
 aw [wallet name]
 ```
 
@@ -79,7 +79,7 @@ aw [wallet name]
 
 **mytoncore** automatically participates in elections by dividing the wallet balance into two parts. These parts are then used as a stake for participation. Additionally, you can manually adjust the stake size:
 
-```sh
+```bash
 set  stake  50000
 ```
 
@@ -95,11 +95,11 @@ If a validator processes less than 90% of the expected number of blocks during a
 
 As a TON validator, make sure you follow these crucial steps to ensure network stability and avoid slashing penalties in the future.
 
-### Important measures:
+### Important measures
 
 1. Follow [@tonstatus](https://t.me/tonstatus), turn on notifications, and be prepared for urgent updates if needed.
 
-2. Make sure that your hardware meets or exceeds the [minimum system requirements](/v3/guidelines/nodes/running-nodes/validator-node#minimal-hardware-requirements).
+2. Make sure that your hardware meets or exceeds the [Minimal hardware requirements](/v3/guidelines/nodes/running-nodes/validator-node#minimal-hardware-requirements).
 
 3. We strongly urge you to utilize [MyTonCtrl](https://github.com/ton-blockchain/mytonctrl).
 
@@ -111,7 +111,7 @@ As a TON validator, make sure you follow these crucial steps to ensure network s
 
    - Please verify with `MyTonCtrl` using the `check_ef` command.
 
-   - Check [Build dashboard with APIs](/v3/guidelines/nodes/running-nodes/validator-node#validation-effectiveness-apis).
+   - See [Validation effectiveness APIs](/v3/guidelines/nodes/running-nodes/validator-node#validation-effectiveness-apis).
 
 :::info
 `MyTonCtrl` enables you to evaluate the performance of validators using the command `check_ef`. This command provides efficiency data for both the last round and the current round. The data is retrieved by calling the `checkloadall` utility. Make sure that your efficiency is above 90% for the entire round period.
@@ -129,11 +129,11 @@ Please set up dashboards to monitor your validators using the APIs provided belo
 
 ### Penalized validators tracker
 
-You can track penalized validators on each round with [@tonstatus_notifications](https://t.me/tonstatus_notifications).
+You can track penalized validators for each round with [@tonstatus_notifications](https://t.me/tonstatus_notifications).
 
 #### Validation API
 
-You can use this [API](https://elections.toncenter.com/docs) to obtain information about current and past validation rounds (cycles) - including the timing of rounds, which validators participated, their stakes, and more. Information regarding current and past elections for each validation round is also available.
+You can use this [API](https://elections.toncenter.com/docs) to obtain information about current and past validation rounds (cycles)—including the timing of rounds, which validators participated, their stakes, and more. Information regarding current and past elections for each validation round is also available.
 
 #### Efficiency API
 
@@ -155,7 +155,7 @@ Unlike `checkloadall`, which only works on validation rounds, this API allows yo
 
 Contact technical support [@mytonctrl_help_bot](https://t.me/mytonctrl_help_bot). This bot is for validators only and will not assist with questions for regular nodes.
 
-If you run a regular node, then contact the group: [@mytonctrl_help](https://t.me/mytonctrl_help).
+If you run a regular node, contact the group: [@mytonctrl_help](https://t.me/mytonctrl_help).
 
 ## See also
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-nodes-running-nodes-validator-node.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/nodes/running-nodes/validator-node.mdx`

Related issues (from issues.normalized.md):
- [ ] **1189. Clarify wallet path text and link label**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-errors.mdx?plain=1

Change “Check wallet name path” to “Check the wallet path” and replace the generic “validator article” link with “Validator node: View the list of wallets” linking to docs/v3/guidelines/nodes/running-nodes/validator-node.mdx#view-the-list-of-wallets.

---

- [ ] **1193. Update validator node anchor to "ready to use"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/infra/nodes/mytonctrl/mytonctrl-errors.mdx?plain=1

Fix the “Use `set stake …`” solution link to docs/v3/guidelines/nodes/running-nodes/validator-node.mdx#your-validator-is-ready-to-use (current link incorrectly targets “#your-validator-is-now-ready”).

---

- [ ] **1550. Update validator link and add internal guide**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/documentation/smart-contracts/contracts-specs/governance.mdx?plain=1#L9

Change https://ton.org/validator to https://ton.org/validators and add a link to the internal guide at docs/v3/guidelines/nodes/running-nodes/validator-node.mdx.

---

- [ ] **3389. Add link to minimal hardware requirements**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/monitoring/performance-monitoring.mdx?plain=1

Link “minimum requirements” to docs/v3/guidelines/nodes/running-nodes/validator-node.mdx#minimal-hardware-requirements.

---

- [ ] **3577. Fix prerequisites sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1#prerequisites

Change “Launch the Full Node before follow this article.” to “Launch the full node before following this article.” for correct grammar and capitalization.

---

- [ ] **3578. Use “full node” in header**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1

Rename the section header “Running a fullnode” to “Running a full node” for terminology consistency.

---

- [ ] **3579. Align minimal hardware requirements with Full node**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1#minimal-hardware-requirements

Mirror the Full node > With validator wording: include “64 TB/month traffic (100 TB/month at a peak load)”, use “16 cores CPU”, format “Public IP address (_fixed IP address_)”, standardize storage to “1TB NVMe SSD _OR_ Provisioned 64+k IOPS storage,” rephrase the IOPS sentence to “We draw validators’ attention to disk IOPS requirements; they are crucially important for smooth network operation,” and replace the two blockquotes with a single :::info callout about peak loads.

---

- [ ] **3580. Align port forwarding phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1#port-forwarding

Replace “The node must also be visible to the outside world over the NAT.” with “The node must also be reachable from the public internet when it is behind a NAT.” and align surrounding sentences with the Full node page.

---

- [ ] **3581. Fix hardware section link text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1

Where the page links to the hardware section, change “minimum system requirements” to “Minimal hardware requirements” to match the target section title.

---

- [ ] **3582. Replace/clarify architecture image and alt text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1#architecture

Replace the nominator‑pool graphic with a validator architecture diagram (or add a caption explaining its relevance) and change the alt text from “image” to a descriptive alt such as “Validator node architecture diagram.”

---

- [ ] **3583. Avoid asserting automatic wallet creation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1#view-the-list-of-wallets

Rephrase to avoid claiming the installer creates `validator_wallet_001` by default; e.g., “You may see a wallet like `validator_wallet_001`; if none exists, create one.”

---

- [ ] **3584. Use angle‑bracket placeholders consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1

Change square‑bracket placeholders to angle brackets to match MyTonCtrl docs (e.g., `<wallet-name>`, `<account-addr>`).

---

- [ ] **3585. Fix `vas` argument to account address**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1#activate-the-wallets

Change the example from `vas [wallet name]` to `vas <account-addr>` and note obtaining the address via `wl` if needed.

---

- [ ] **3586. Require explicit wallet name for `aw`**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1#activate-the-wallets

Remove the claim that `aw` without arguments activates all wallets; document `aw <wallet-name>` only.

---

- [ ] **3587. Fix stakes sentence and remove unsupported max**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1#activate-the-wallets

Correct to “For more information, see how maximum and minimum stakes are calculated,” and remove the unsupported “maximum is about 1M TON” claim, referring readers to the linked section for dynamic caps.

---

- [ ] **3588. Singularize “Activate the wallets” heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1#activate-the-wallets

Change the heading to “Activate the wallet” (or rewrite steps to consistently address multiple wallets); prefer the singular for clarity.

---

- [ ] **3589. Clarify automated election behavior**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1#your-validator-is-ready-to-use

Replace the undocumented claim that MyTonCtrl “divides the wallet balance into two parts” with a supported phrasing like “MyTonCtrl can automatically participate in elections using your configured stake.”

---

- [ ] **3590. Normalize `set stake` command spacing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1#your-validator-is-ready-to-use

Fix the example `set stake 50000` to `set stake 50000` (single spaces between tokens).

---

- [ ] **3591. Fix terminology and withdrawal rule**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1#your-validator-is-ready-to-use

Replace “bet” with “stake,” change “as per the electorate’s rules” to “as per the Elector contract’s rules,” and replace “the stake can only be withdrawn in the second election” with the documented rule that staked TON is held for ~9 hours after each round before it is released and can then be withdrawn.

---

- [ ] **3592. Remove undocumented telemetry setting**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1#adhere-to-rules

Delete the instruction `set sendTelemetry true` (or add a citation proving this setting); it is not documented in MyTonCtrl references.

---

- [ ] **3593. Remove colon from “Important measures” heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1

Change “### Important measures:” to “### Important measures” to follow heading punctuation style.

---

- [ ] **3594. Match link text to target section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1#adhere-to-rules

Change “Check Build dashboard with APIs” to “See Validation effectiveness APIs” while keeping the same anchor destination.

---

- [ ] **3595. Remove unsupported 80% efficiency threshold**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1#validation-effectiveness-apis

Delete the “below 80%” malfunction claim or align it with the documented per‑round <90% penalty context, citing `check_ef` guidance.

---

- [ ] **3596. Fix preposition in “each round” phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1

Change “track penalized validators on each round” to “track penalized validators for each round.”

---

- [ ] **3597. Use em dash or comma instead of spaced hyphen**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1

In the phrase “(cycles) - including…”, replace the spaced hyphen with an em dash “(cycles)—including …” or a comma “(cycles), including …” for stylistic consistency.

---

- [ ] **3598. Fix fine phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1

Change “they will be fined by 101 TON.” to “they will be fined 101 TON.”

---

- [ ] **3599. Use bash for shell code blocks**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1

Change fenced code languages from “```sh” to “```bash” for consistency with related pages.

---

- [ ] **3600. Prefix MyTonCtrl console commands**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1

Add the `MyTonCtrl>` prompt to examples (`wl`, `vas`, `aw`, `set stake 50000`) to clarify they are run inside the MyTonCtrl console, matching style used in its docs.

---

- [ ] **3601. Remove unnecessary “then”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/validator-node.mdx?plain=1

Change “If you run a regular node, then contact the group:” to “If you run a regular node, contact the group:”.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.