### PR TITLE
Split: update docs/v3/guidelines/overview.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/overview.mdx
+++ b/docs/v3/guidelines/overview.mdx
@@ -2,6 +2,14 @@ import Feedback from '@site/src/components/Feedback';
 
 # Overview
 
-// TODO: need to be written
-<Feedback />
+{/* TODO: need to be written */}
 
+This section provides high-level guidelines for building on TON, with links to development, infrastructure, and best-practice resources.
+
+## See also
+
+- [/v3/guidelines/get-started-with-ton](/v3/guidelines/get-started-with-ton)
+- [/v3/guidelines/web3/overview](/v3/guidelines/web3/overview)
+- [/v3/guidelines/nodes/overview](/v3/guidelines/nodes/overview)
+- [/v3/guidelines/dapps/apis-sdks/overview](/v3/guidelines/dapps/apis-sdks/overview)
+<Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-overview.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/overview.mdx`

Related issues (from issues.normalized.md):
- [ ] **4536. Hide visible TODO comment**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/overview.mdx?plain=1

The line `// TODO: need to be written` renders as text; replace it with an MDX comment `{/* TODO: need to be written */}` or remove it. If a public placeholder is needed, use an admonition like `:::info This page is under construction. :::` instead.

---

- [ ] **4537. Add minimal overview and see-also links**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/overview.mdx?plain=1

The page has only a heading and feedback widget; add a one‑sentence scope and a short “See also” list linking to existing pages: `/v3/guidelines/get-started-with-ton`, `/v3/guidelines/web3/overview`, `/v3/guidelines/nodes/overview`, and `/v3/guidelines/dapps/apis-sdks/overview`.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.