### PR TITLE
Split: update docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx
+++ b/docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx
@@ -2,7 +2,7 @@ import Feedback from "@site/src/components/Feedback";
 import ThemedImage from "@theme/ThemedImage";
 import Button from '@site/src/components/button'
 
-# Reading from the network
+# Reading from network
 
 ## Introduction
 
@@ -100,15 +100,15 @@ Create a new file `1-get-account-state.ts`:
 import { Address, TonClient } from "@ton/ton";
 
 async function main() {
-  // Initializaing TON HTTP API Client
+  // Initializaing TON HTTP API client
   const tonClient = new TonClient({
     endpoint: 'https://testnet.toncenter.com/api/v2/jsonRPC',
   });
 
-  // Replace with any address
+  // Replace with your Testnet address
   const accountAddress = Address.parse('0QD-SuoCHsCL2pIZfE8IAKsjc0aDpDUQAoo-ALHl2mje04A-');
 
-  // Calling method on http api
+  // Calling tonClient.getContractState(), which corresponds to TON Center’s getAddressInformation endpoint
   const state = await tonClient.getContractState(accountAddress);
 
 
@@ -165,7 +165,7 @@ Create a new file `2-call-get-method.ts`:
 import { Address, TonClient, TupleBuilder } from "@ton/ton";
 
 async function main() {
-  // Initializaing TON HTTP API Client
+  // Initializaing TON HTTP API client
   const tonClient = new TonClient({
     endpoint: 'https://testnet.toncenter.com/api/v2/jsonRPC',
   });
@@ -178,11 +178,11 @@ async function main() {
 
   const accountAddress = Address.parse('kQD0GKBM8ZbryVk2aESmzfU6b9b_8era_IkvBSELujFZPsyy')
 
-  // Calling http api to run get method on specific contract
+  // Calling HTTP API to run get method on specific contract
   const result = await tonClient.runMethod(
-    accountAddress, // address to call get method on
-    'get_wallet_address', // method name
-    builder.build(), // optional params list
+    accountAddress, // Address to call get method on
+    'get_wallet_address', // Method name
+    builder.build(), // Optional params list
   );
 
   // Deserializing get method result
@@ -233,7 +233,7 @@ Wrappers are classes that simplify interactions with smart contracts by turning 
 import { Address, JettonMaster, TonClient } from "@ton/ton";
 
 async function main() {
-  // Initializaing TON HTTP API Client
+  // Initializaing TON HTTP API client
   const tonClient = new TonClient({
     endpoint: 'https://testnet.toncenter.com/api/v2/jsonRPC',
   });
@@ -259,9 +259,9 @@ Interaction within an account on the blockchain happens due to [messages and tra
 
 A transaction in TON is the **result** of a smart contract successfully processing an incoming message. It consists of:
 
-* the **incoming message** that triggered the contract
-* the **state changes** performed by the contract during message processing (e.g. storage or balance updates)
-* any **outgoing messages** sent to other contracts (if applicable)
+- the **incoming message** that triggered the contract
+- the **state changes** performed by the contract during message processing (e.g. storage or balance updates)
+- any **outgoing messages** sent to other contracts (if applicable)
 
 <ThemedImage
   alt="Transaction diagram"
@@ -337,7 +337,7 @@ Let’s now try to fetch transactions for an account we control.
 
 Before running this code:
 
-- Go to [Tonviewer](https://testnet.tonviewer.com) and open your Testnet wallet address, which we created earlier in the [Getting Started](/v3/guidelines/quick-start/getting-started#interacting-with-the-ton-ecosystem) section.
+- Go to [Tonviewer](https://testnet.tonviewer.com) and open your Testnet wallet address, which we created earlier in the [Getting started](/v3/guidelines/quick-start/getting-started#interacting-with-the-ton-ecosystem) section.
 - Send some test TON to yourself using [Testgiver Ton Bot](https://t.me/testgiver_ton_bot/).
 - Wait a few seconds and make sure the transaction appears in Tonviewer.
 
@@ -353,19 +353,19 @@ Also, please note that the Testnet API may update data with some delay, so your 
 import { Address, TonClient } from "@ton/ton";
 
 async function main() {
-  // Initializaing TON HTTP API Client
+  // Initializaing TON HTTP API client
   const tonClient = new TonClient({
     endpoint: 'https://testnet.toncenter.com/api/v2/jsonRPC',
   });
 
-  // Calling method on http api
-  // full api: https://testnet.toncenter.com/api/v2/#/accounts/get_transactions_getTransactions_get
+  // Calling method on HTTP API
+  // Full API: https://testnet.toncenter.com/api/v2/#/accounts/get_transactions_getTransactions_get
   const transactions = await tonClient.getTransactions(
     // Replace with your Testnet address to fetch transactions
     Address.parse('0QD-SuoCHsCL2pIZfE8IAKsjc0aDpDUQAoo-ALHl2mje04A-'),
     {
-      limit: 10,      //maximum ammount of recieved transactions
-      archival: true, //search in all history
+      limit: 10,      // Maximum number of received transactions
+      archival: true, // Search the entire history
     },
   );
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-quick-start-blockchain-interaction-reading-from-network.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx`

Related issues (from issues.normalized.md):
- [x] **3602. Use “the” in page title**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx?plain=1

Change the page title to “Reading from the network” to match grammar and the sibling “Writing to the network,” updating any internal references if needed.

---

- [x] **3603. Replace “correspondingly” with “respectively”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx?plain=1

Update the versions sentence to: “Versions of node and npm should be at least v20 and v10, respectively.”

---

- [ ] **3604. Fix comment typos and capitalize “HTTP API”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx?plain=1

In all TypeScript snippets, change “Initializaing TON HTTP API Client” to “Initializing TON HTTP API client” and “http api” to “HTTP API.”

---

- [ ] **3605. Standardize to US “deserialize/deserialized”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx?plain=1

Replace all “deserialised” variants with “deserialize/deserialized” for consistent US English.

---

- [ ] **3606. Capitalize “Unix timestamp”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx?plain=1

In “Key transaction fields,” use “Unix timestamp” instead of “unix timestamp.”

---

- [ ] **3607. Correct getTransactions option comments**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx?plain=1

Change “//maximum ammount of recieved transactions” to “// Maximum number of received transactions” and “// search in all history” to “// Search the entire history.”

---

- [ ] **3608. Fix Getting Started anchor**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx?plain=1

Update the internal link to “/v3/guidelines/quick-start/getting-started#interacting-with-the-ton-ecosystem”.

---

- [x] **3609. Add descriptive alt text to images**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx?plain=1

Provide meaningful alt text for ThemedImage components, e.g., “Transaction diagram” and “Message diagram,” instead of empty alt attributes.

---

- [x] **3610. Use “transaction graph” phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx?plain=1

Change “transactions graph” to “the transaction graph.”

---

- [ ] **3611. Rename example file to plural**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx?plain=1

Rename “3-fetch-account-transaction.ts” to “3-fetch-account-transactions.ts” to match the section title.

---

- [x] **3612. Lowercase account state terms**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx?plain=1

Change “Nonexist/Uninit/Active/Frozen” to lowercase (preferably code-formatted) `nonexist`, `uninit`, `active`, `frozen` to align with canonical docs.

---

- [ ] **3613. Correct address prefix mapping**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx?plain=1

Rephrase to: “E/U: any network; k/0: testnet-only; E and k are bounceable; U and 0 are non-bounceable.”

---

- [x] **3614. Clarify address encoding wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx?plain=1

Change “base64url-encoded” to “base64 or base64url-encoded.”

---

- [ ] **3615. Import TupleBuilder from @ton/core**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx?plain=1

Adjust imports to `import { Address, TonClient } from "@ton/ton";` and `import { TupleBuilder } from "@ton/core";` for consistency with other docs.

---

- [x] **3616. Fix JSON5 placeholder syntax in schema examples**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx?plain=1

Replace raw “...” placeholders with JSON5 comments (e.g., `// ...`) or change the code block language to `text` in the Key transaction/message fields sections to keep examples valid.

---

- [x] **3617. Fix grammar in get methods bullet**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx?plain=1

Change “Do not charge any fees from contracts.” to “Does not charge any fees.”

---

- [ ] **3618. Align SDK method name with API link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx?plain=1

Clarify that `TonClient.getContractState` corresponds to TON Center’s `getAddressInformation` endpoint, adjusting the link text or surrounding wording accordingly.

---

- [ ] **3619. Unify address placeholder guidance**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx?plain=1

Standardize comments/prose to “Replace with your Testnet address” for consistency and reproducibility.

---

- [ ] **3620. Explain Node.js/npm version requirement**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx?plain=1

Either align the stated minimums with other pages or add a brief note explaining why this guide requires Node ≥ v20 and npm ≥ v10.

---

- [x] **3621. Format example address as code**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx?plain=1

Wrap the Tonviewer example address in backticks (inline code) instead of italics.

---

- [x] **3622. Remove unintended double spaces**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/reading-from-network.mdx?plain=1

Eliminate double spaces in sentences like “address for…” and “address is…” for clean formatting.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.