### PR TITLE
Split: update docs/v3/guidelines/quick-start/blockchain-interaction/writing-to-network.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/quick-start/blockchain-interaction/writing-to-network.mdx
+++ b/docs/v3/guidelines/quick-start/blockchain-interaction/writing-to-network.mdx
@@ -2,7 +2,7 @@ import Feedback from "@site/src/components/Feedback";
 import ThemedImage from "@theme/ThemedImage";
 import Button from '@site/src/components/button'
 
-# Writing to the network
+# Writing to network
 
 In the previous section, you learned how to **read data** from the TON Blockchain. Now, let's explore how to **write data** to it.
 
@@ -21,7 +21,7 @@ node -v
 npm -v
 ```
 
-Versions of `node` and `npm` should be at least `v20` and `v10` correspondingly.
+Versions of `node` and `npm` should be at least `v20` and `v10` respectively.
 
 ## Project setup
 
@@ -30,7 +30,7 @@ Let's set up our project structure:
 1. Create a new directory for your project
 2. Initialize a Node.js project
 3. Install the required dependencies
-4. Initialize TypeScript configuration.
+4. Initialize TypeScript configuration
 
 Run these commands in your terminal:
 
@@ -56,7 +56,7 @@ A common transfer would look like this:
 <br></br>
 <div class="text--center">
   <ThemedImage
-    alt=""
+    alt="TON transfer diagram"
     sources={{
       light: '/img/docs/ecosystem-messages-layout/ecosystem_messages_layout_1.svg?raw=true',
       dark: '/img/docs/ecosystem-messages-layout/ecosystem_messages_layout_1_dark.svg?raw=true',
@@ -66,7 +66,7 @@ A common transfer would look like this:
 <br></br>
 
 :::caution
-Unlike in the [Reading from network](/v3/guidelines/quick-start/blockchain-interaction/reading-from-network) section, a Toncenter API key is mandatory in the following examples. It may be retrieved using [the following guide](/v3/guidelines/dapps/apis-sdks/api-keys).
+Unlike in the [Reading from network](/v3/guidelines/quick-start/blockchain-interaction/reading-from-network) section, a TON Center API key is recommended; some providers may require a key, and it removes request limits. You can obtain one using [the following guide](/v3/guidelines/dapps/apis-sdks/api-keys).
 :::
 
 #### Implementation
@@ -117,7 +117,7 @@ async function main() {
 main();
 ```
 
-Using `API_KEY` in this case, allows you to access TON functionality through the `endpoint`. By running this script, we authenticate to our wallet through a `public/private key` pair generated from the `mnemonic phrase`. After preparing a transaction, we send it to TON, resulting in a message that the wallet sends to itself with the *'Hello from wallet!'* message.
+Using an API key in this case allows you to access TON functionality through the `endpoint`. By running this script, we authenticate to our wallet through a `public/private key` pair generated from the `mnemonic phrase`. After preparing a transaction, we send it to TON, resulting in a message that the wallet sends to itself with the *'Hello from wallet!'* message.
 
 :::caution Advanced Level
 In most scenarios, `SendMode.PAY_GAS_SEPARATELY | SendMode.IGNORE_ERRORS` will work, but if you want a deeper understanding, continue reading in the [message modes cookbook](/v3/documentation/smart-contracts/message-management/message-modes-cookbook/).
@@ -225,7 +225,7 @@ Click the button below to get started:
 
 <Button href="/v3/guidelines/quick-start/developing-smart-contracts/setup-environment" colorType={'primary'} sizeType={'sm'}>
 
-  Setup development environment
+  Set up development environment
 
 </Button>
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-quick-start-blockchain-interaction-writing-to-network.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/quick-start/blockchain-interaction/writing-to-network.mdx`

Related issues (from issues.normalized.md):
- [ ] **3623. Change H1 to "Writing to network"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/writing-to-network.mdx?plain=1

The H1 says "Writing to the network"; change it to "Writing to network" to match the paired "Reading from network" page.

---

- [ ] **3624. Use "respectively" for version pairing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/writing-to-network.mdx?plain=1

Replace "correspondingly" with "respectively" in "Versions of node and npm should be at least v20 and v10 correspondingly" for correct English.

---

- [ ] **3625. Normalize list punctuation in Project setup**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/writing-to-network.mdx?plain=1

In the "Project setup" numbered list, remove the trailing period from item 4 ("Initialize TypeScript configuration.") to match items 1–3.

---

- [ ] **3626. Rephrase API key requirement**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/writing-to-network.mdx?plain=1

In the API key caution, change "Toncenter API key is mandatory" to "A TON Center API key is recommended; some providers may require a key, and it removes request limits" to align with the API-keys page.

---

- [ ] **3627. Fix API key term and comma**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/writing-to-network.mdx?plain=1

Replace "Using API_KEY in this case, allows you..." with "Using an API key in this case allows you..." to use the correct term and remove the unnecessary comma.

---

- [ ] **3628. Standardize provider casing to "TON Center"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/writing-to-network.mdx?plain=1

Change all occurrences of "Toncenter" to "TON Center" for consistent provider naming.

---

- [ ] **3629. Add descriptive alt text to transfer image**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/writing-to-network.mdx?plain=1

Set a descriptive alt on the ThemedImage (e.g., alt="TON transfer diagram") instead of alt="" because the image conveys information.

---

- [ ] **3630. Increase NFT forward amount to 0.01 TON**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/writing-to-network.mdx?plain=1

In 2-send-nft.ts, replace ".storeCoins(1)" with ".storeCoins(toNano('0.01'))" (ensure "import { toNano }") to use the typical 0.01 TON forward_amount recommended in the NFT docs.

---

- [ ] **3631. Clarify mnemonic replacement comment**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/writing-to-network.mdx?plain=1

Revise the comment to "Replace with your own 24-word mnemonic from your wallet app." for clarity.

---

- [ ] **3632. Clarify NFT address comment**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/writing-to-network.mdx?plain=1

Revise the comment to "Address of the NFT you created at https://ton-collection-edit.vercel.app/deploy-nft-single" for clarity.

---

- [ ] **3633. Use "Set up" in button label**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/blockchain-interaction/writing-to-network.mdx?plain=1

Change the button label to "Set up development environment" to match usage on this page (href unchanged).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.