### PR TITLE
Split: update docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-blueprint-sdk-overview.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-blueprint-sdk-overview.mdx
+++ b/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-blueprint-sdk-overview.mdx
@@ -78,14 +78,14 @@ npx blueprint test
 5. Update the deployment script in the `/scripts` folder and run it using this command:
 
 ```bash
-npx blueprint run
+npx blueprint run deployHelloWorld
 ```
 
 :::tip
 All examples in this guide follow the sequence of these **1-3 steps** with corresponding code samples. **Step 5**, the deployment process, is covered in the last section of the guide: [Deploying to network](/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network/).
 :::
 
-Also, you can always generate the same structure for another smart contract if, for example, you want to create multiple contracts interacting with each other by using the following command:
+Also, you can always generate the same structure for another smart contract if, for example, you want to create multiple contracts interacting with each other using the following command:
 
 ```bash
 npx blueprint create PascalCase # Don't forget to name the contract in PascalCase
@@ -95,7 +95,7 @@ npx blueprint create PascalCase # Don't forget to name the contract in PascalCas
 
 Now you're all set — it's time to start writing smart contracts. We'll begin with the basics: **storage** and **get methods**.
 
-<Button href="/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods/" colorType={'primary'} sizeType={'sm'}>
+<Button href="/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods" colorType={'primary'} sizeType={'sm'}>
 
   Storage and get methods
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-quick-start-developing-smart-contracts-tact-folder-tact-blueprint-sdk-overview.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-blueprint-sdk-overview.mdx`

Related issues (from issues.normalized.md):
- [ ] **1. Indent HelloWorld files under wrappers/**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-blueprint-sdk-overview.mdx?plain=1#project-structure

In the project structure tree, HelloWorld.ts and HelloWorld.compile.ts are shown as siblings of wrappers/; indent them so they are children of wrappers/ to reflect the actual layout and match the FunC/Tolk overview.

---

- [ ] **2. Specify script in deploy command**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-blueprint-sdk-overview.mdx?plain=1#development-flow

In Step 5, replace "npx blueprint run" with "npx blueprint run deployHelloWorld" (or note that omitting the script will prompt for selection) to match the deploy page and ensure reproducible instructions.

---

- [ ] **3. Use "and" instead of "&" in button label**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-blueprint-sdk-overview.mdx?plain=1#next-step

Change the CTA button text from "Storage & get methods" to "Storage and get methods" to match the destination page title.

---

- [ ] **4. Remove trailing slash from Next step link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-blueprint-sdk-overview.mdx?plain=1#next-step

The button URL includes a trailing slash; remove it for consistency with adjacent page links and repository style.

---

- [ ] **3678. Add missing semicolon in import**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-blueprint-sdk-overview.mdx?plain=1#L4

The import lacks a trailing semicolon; change to: import Button from '@site/src/components/button';

---

- [ ] **3679. Remove code styling from “Blueprint”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-blueprint-sdk-overview.mdx?plain=1#L14

Replace the overstyled **`Blueprint`** with plain text (or bold without backticks): Blueprint (or **Blueprint**).

---

- [ ] **3680. Use neutral code fence for project structure block**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-blueprint-sdk-overview.mdx?plain=1#L24

Change the code fence language from ```ls to a neutral option for Prism, e.g., ```text title="Project structure" (or omit the language).

---

- [ ] **3681. Fix wrappers tree indentation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-blueprint-sdk-overview.mdx?plain=1#L33-L35

Ensure HelloWorld.ts and HelloWorld.compile.ts are listed under wrappers/ in the tree: └── wrappers/ ├── HelloWorld.ts └── HelloWorld.compile.ts

---

- [ ] **3682. Lowercase “blockchain” in “TON blockchain”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-blueprint-sdk-overview.mdx?plain=1#L43

Change “TON Blockchain” to “TON blockchain” per style for the generic noun.

---

- [ ] **3683. Clarify network testing guidance and remove quotes**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-blueprint-sdk-overview.mdx?plain=1#L51

Rewrite to: “Testing contracts directly on the TON network is discouraged because deployment takes time and could result in loss of funds,” and use plain text “local network” (no quotes/bold).

---

- [ ] **3684. Use plain, lowercase “wrapper classes”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-blueprint-sdk-overview.mdx?plain=1#L55

Replace code-formatted/capitalized `Wrapper` with plain, lowercase “wrapper classes”.

---

- [ ] **3685. Simplify the development steps intro**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-blueprint-sdk-overview.mdx?plain=1#L60

Change “Almost any smart contract project development consists of five simple steps:” to “Most smart contract projects follow five simple steps:”.

---

- [ ] **3686. Tighten phrasing: “using” not “by using”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-blueprint-sdk-overview.mdx?plain=1#L88

Replace “by using the following command:” with “using the following command:”.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.