### PR TITLE
Split: update docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx
+++ b/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx
@@ -132,7 +132,7 @@ Contract deployed at address EQBrFHgzSwxVYBXjIYAM6g2RHbeFebJA8QUDwg4IX8CPDPug
 You can view it at https://testnet.tonscan.org/address/EQBrFHgzSwxVYBXjIYAM6g2RHbeFebJA8QUDwg4IX8CPDPug
 ```
 
-**Congratulations!** Your custom `smart contract` is ready to execute `get methods` the same way as your wallet in the [Getting started](/v3/guidelines/quick-start/getting-started#navigation-tabs) section and execute `transactions` the same as in the [Blockchain interaction](/v3/guidelines/quick-start/blockchain-interaction/writing-to-network) section — consider reading it to understand how to interact with `smart contracts` off-chain if you haven't already.
+**Congratulations!** Your custom *smart contract* is ready to execute *get methods* the same way as your wallet in the [Getting started](/v3/guidelines/quick-start/getting-started#navigation-tabs) section and execute *transactions* the same as in the [Blockchain interaction](/v3/guidelines/quick-start/blockchain-interaction/writing-to-network) section. Consider reading these sections to understand how to interact with **smart contracts** off-chain if you haven't already.
 
 :::tip
 Using `Blueprint` and wallet apps is not the only option. You can create a message with [state_init](/v3/documentation/smart-contracts/message-management/sending-messages#message-layout) by yourself. Moreover, you can do it even through a smart contract's [internal message](/v3/documentation/smart-contracts/message-management/sending-messages#types-of-messages).

--- a/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx
+++ b/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx
@@ -4,13 +4,13 @@ import Feedback from "@site/src/components/Feedback";
 
 > **Summary:** In previous steps, we developed and tested our smart contract, ensuring its correctness.
 
-In this part of the guide, we will proceed with the deployment of previously developed smart contracts and cover interaction with them on-chain.
+In this part of the guide, we will proceed with the deployment of the previously developed smart contract and cover interaction with it on-chain.
 
 ## Address and initial state
 
-We already know that [address](/v3/documentation/smart-contracts/addresses/address) is a unique identifier of a `smart contract` on the network, used to send transactions and verify the sender upon receiving. However, we still haven't discussed how it's created. The common formula for a smart contract address looks like this:
+We already know that [address](/v3/documentation/smart-contracts/addresses/address) is a unique identifier of a `smart contract` on the network, used to send transactions and verify the sender upon receiving a message. However, we still haven't discussed how it's created. The common formula for a smart contract address looks like this:
 
-***address = hash(state_init(code, data))***
+`address = hash(state_init(code, data))`
 
 The address of a smart contract is a hash of the aggregated initial code and data of the smart contract upon deployment. This simple mechanism has a few important consequences:
 
@@ -32,7 +32,7 @@ Since we can't deploy a smart contract with the same `state_init`, the only way 
 
 ### One to rule them all
 
-If you've already considered that the `ID` field is a must-have for any smart contract, there is another opportunity that could change your mind. Let's examine the previously developed `HelloWorld` smart contract's init section:
+If you've already considered that the `id` field is a must-have for any smart contract, there is another opportunity that could change your mind. Let's examine the previously developed `HelloWorld` smart contract's init section:
 
 ```tact
 init(id: Int) {
@@ -63,15 +63,15 @@ import { NetworkProvider } from '@ton/blueprint';
 
 export async function run(provider: NetworkProvider) {
     const sender = provider.sender();
-    
+
     const helloWorld = provider.open(
-      await HelloWorld.fromInit(0n)
+        await HelloWorld.fromInit(0n)
     );
 
     await helloWorld.send(
-      sender,
-      { value: toNano('0.05') },
-      null
+        sender,
+        { value: toNano('0.05') },
+        null
     );
 
     await provider.waitForDeploy(helloWorld.address);
@@ -92,7 +92,7 @@ npx blueprint run deployHelloWorld
 
 After that, you will see an interactive menu allowing you to choose a network:
 
-```bash
+```text
 ? Which network do you want to use? (Use arrow keys)
   mainnet
 ❯ testnet
@@ -107,7 +107,7 @@ Before deployment to the `Mainnet`, ensure that your smart contracts correspond 
 
 Next, choose the way to access your wallet. The easiest way to do that is using [TON Connect](/v3/guidelines/ton-connect/overview/) for the most popular wallet apps: `Tonkeeper`, `MyTonWallet`, or `Tonhub`.
 
-```bash
+```text
 ? Which wallet are you using? (Use arrow keys)
 ❯ TON Connect compatible mobile wallet (example: Tonkeeper)
   Create a ton:// deep link
@@ -135,7 +135,7 @@ You can view it at https://testnet.tonscan.org/address/EQBrFHgzSwxVYBXjIYAM6g2RH
 **Congratulations!** Your custom `smart contract` is ready to execute `get methods` the same way as your wallet in the [Getting started](/v3/guidelines/quick-start/getting-started#navigation-tabs) section and execute `transactions` the same as in the [Blockchain interaction](/v3/guidelines/quick-start/blockchain-interaction/writing-to-network) section — consider reading it to understand how to interact with `smart contracts` off-chain if you haven't already.
 
 :::tip
-Using `Blueprint` and wallet apps is not the only option. You can create a message with [state_init](/v3/documentation/smart-contracts/message-management/sending-messages#message-layout) by yourself. Moreover, you can do it even through a smart contract's [internal message](/v3/documentation/smart-contracts/message-management/sending-messages#message-layout).
+Using `Blueprint` and wallet apps is not the only option. You can create a message with [state_init](/v3/documentation/smart-contracts/message-management/sending-messages#message-layout) by yourself. Moreover, you can do it even through a smart contract's [internal message](/v3/documentation/smart-contracts/message-management/sending-messages#types-of-messages).
 :::
 
 
@@ -145,7 +145,7 @@ Now, it’s time to dive deeper and keep building. Here are some helpful resourc
 - [Official website](https://tact-lang.org) - overview, news, and ecosystem links
 - [Tact documentation](https://docs.tact-lang.org) — the go-to reference for language features
 - [Tact GitHub repo](https://github.com/tact-lang) — source code, issues, and contributions
-- [Tact by example](https://tact-by-example.org/all) — hands-on smart contract examples
+- [Tact By Example](https://tact-by-example.org/all) — hands-on smart contract examples
 - [Tact smart battle](https://github.com/ton-studio/tact-smart-battle) — coding challenges to sharpen your skills
 - [@tact_kitchen](https://t.me/tact_kitchen) — channel with the latest Tact updates
 - [@tactlang](https://t.me/tactlang) — chat for dev discussions and help


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-quick-start-developing-smart-contracts-tact-folder-tact-deploying-to-network.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx`

Related issues (from issues.normalized.md):
- [ ] **5. Use “nonexist” state term**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1#you-already-know-the-address

Replace the word "nonexistent" with the canonical term "nonexist" when describing an empty address state.

---

- [ ] **6. Remove undefined ctxID mention**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1#magic-storage-member

Replace "ctxID and ID" with just "id" to match the Tact HelloWorld storage members introduced earlier.

---

- [ ] **7. Align HelloWorld init to id only**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1#one-to-rule-them-all

Update the init example to take only id and initialize id and counter (remove owner) to match the earlier HelloWorld definition.

---

- [ ] **8. Fix fromInit arguments in deploy snippet**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1#step-1-update-the-deployment-script

Remove the sender.address guard and pass only the id to HelloWorld.fromInit, e.g., fromInit(0n).

---

- [ ] **9. Remove unused compile import**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1#step-1-update-the-deployment-script

Delete compile from the import list since it is not used in the deployment script.

---

- [ ] **10. Use singular “smart contract”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1#step-1-update-the-deployment-script

Change "one common script to deploy both of the previously deployed smart contracts" to "one script to deploy the previously developed smart contract."

---

- [ ] **11. Standardize Tonkeeper capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1#step-4-choose-wallet-app

Replace "TonKeeper" with the correct brand capitalization "Tonkeeper."

---

- [ ] **12. Add trailing slash to Security overview link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1#step-3-choose-network

Change the Security overview link to /v3/guidelines/smart-contracts/security/overview/.

---

- [ ] **13. Add trailing slash to Jetton processing link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1#one-to-rule-them-all

Change the Jetton processing link to /v3/guidelines/dapps/asset-processing/jettons/.

---

- [ ] **14. Fix heading to “on the network”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1#step-5-observe-your-smart-contract-in-network

Change "observe your smart contract in network" to "observe your smart contract on the network."

---

- [ ] **15. Make summary singular**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1

Update the summary and intro to use the singular "smart contract" instead of "smart contracts."

---

- [ ] **16. Point transactions link to writing-to-network**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1#step-5-observe-your-smart-contract-in-network

Change the transactions cross-reference to /v3/guidelines/quick-start/blockchain-interaction/writing-to-network and keep the reading link for get‑methods.

---

- [ ] **17. Capitalize resource names (GitHub, By Example)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1#whats-next

Use "Tact GitHub repo" and "Tact By Example" in the resources list.

---

- [ ] **3687. Use canonical address state term “nonexist”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1

Replace “nonexistent” with “nonexist,” and if a definition is given, state that it means the address has no code, data, and balance.

---

- [ ] **3688. Standardize storage field to lowercase id**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1

Remove references to ctxID/ID and standardize the storage field and getters to lowercase id (e.g., getId) to match the Tact HelloWorld.

---

- [ ] **3689. Correct phrasing about number of contracts**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1

Change “both of the previously deployed smart contracts” to “one script to deploy the previously developed HelloWorld smart contract,” or explicitly name both if two are intended.

---

- [ ] **3690. Remove unused compile import in deploy script**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1

In the deployHelloWorld.ts snippet, remove compile from the @ton/blueprint imports or use it meaningfully.

---

- [ ] **3691. Standardize brand casing to Tonkeeper**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1

Replace “TonKeeper” (and variants) with the correct brand form “Tonkeeper” throughout.

---

- [ ] **3692. Fix preposition in Step 5 heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1

Change “observe your smart contract in network” to “observe your smart contract on the network.”

---

- [x] **3693. Relabel interactive prompt code blocks**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1

Change code fences showing interactive network/wallet selection menus from bash to text (or no language), since they are prompts, not shell commands.

---

- [x] **3694. Render address formula as inline code**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1

Replace the bold-italic formula with inline code: `address = hash(state_init(code, data))`.

---

- [x] **3695. Complete the “verify the sender” phrase**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1

Replace “verify the sender upon receiving” with “verify the sender upon receiving a message” (or “upon receipt”).

---

- [ ] **3696. Clarify ambiguous “it” reference**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1

Replace “consider reading it” with “consider reading those sections” or name the specific section to avoid ambiguity.

---

- [x] **3697. Capitalize proper nouns (GitHub, By Example)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1

Change “Tact github repo” to “Tact GitHub repo” and “Tact by example” to “Tact by Example.”

---

- [ ] **3698. Fix link targets for message references**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network.mdx?plain=1

Keep state_init linked to the message layout anchor and link “internal message” to the message types section (e.g., /sending-messages#types-of-messages) instead of pointing both to the same anchor.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.