### PR TITLE
Split: update docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx
+++ b/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx
@@ -109,7 +109,7 @@ To accept messages with an empty body, add a `receive` function with no argument
 
 ```tact title="/contracts/hello_world.tact"
 receive() {
-    cashback(sender())
+    cashback(sender());
 }
 ```
 
@@ -136,7 +136,7 @@ message(0x7e8764ef) Add {
     amount: Int as uint32;
 }
 
-// Contract defenition
+// Contract definition
 contract HelloWorld {
 
     // storage variables
@@ -149,9 +149,9 @@ contract HelloWorld {
         self.counter = 0;
     }
 
-    // default(null) receive for deploy
+    // // default (empty body) receiver for deploy
     receive() {
-        cashback(sender())
+        cashback(sender());
     }
 
     // function to receive messages from other contracts

--- a/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx
+++ b/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx
@@ -1,14 +1,12 @@
 import Feedback from "@site/src/components/Feedback";
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import Button from '@site/src/components/button'
 
 # Storage and get methods
 
-> **Summary:** In the previous steps, we learned how to use the `Blueprint SDK` and its project structure.
+> **Summary:** In the previous steps, we learned how to use `Blueprint` and its project structure.
 
 :::info
-For more details, refer to the [Tact documentation](https://docs.tact-lang.org/#start/) and [Tact By Example](https://tact-by-example.org/00-hello-world/).
+For more details, refer to the [Tact documentation](https://docs.tact-lang.org/#start/) and [Tact by example](https://tact-by-example.org/00-hello-world/).
 :::
 
 
@@ -63,7 +61,7 @@ message(0x7e8764ef) Add {
 
 
 
-#### Defining the contract
+### Defining the contract
 
 The [contract](https://docs.tact-lang.org/book/contracts/) definition in Tact follows an object-oriented programming style:
 
@@ -73,9 +71,9 @@ contract HelloWorld {
 }
 ```
 
-#### Contract storage
+### Contract storage
 
-A contract may store its state variables as follows. They may be accessed with [`Self reference`](https://docs.tact-lang.org/book/contracts/#self)
+A contract may store its state variables as follows. They may be accessed using the [`self` reference](https://docs.tact-lang.org/book/contracts/#self).
 
 ```tact
 id: Int as uint32;
@@ -85,7 +83,7 @@ These fields are serialized similarly to structures and stored in the contract's
 
 Use `self.id` and `self.counter` to access them within contract functions.
 
-#### Initializing the contract
+### Initializing the contract
 
 Define an [`init()`](https://docs.tact-lang.org/book/contracts/#init-function/) function to set initial values:
 
@@ -96,7 +94,7 @@ init(id: Int) {
 }
 ```
 
-#### Handling messages
+### Handling messages
 
 To accept messages from other contracts, use a [receiver](https://docs.tact-lang.org/book/functions/#receiver-functions) function. Receiver functions automatically match the message's opcode and invoke the corresponding function:
 
@@ -107,7 +105,7 @@ receive(msg: Add) {
 }
 ```
 
-For accepting messages with empty body you can add `receive` function with no arguments:
+To accept messages with an empty body, add a `receive` function with no arguments:
 
 ```tact title="/contracts/hello_world.tact"
 receive() {
@@ -115,12 +113,12 @@ receive() {
 }
 ```
 
-#### Getter functions
+### Getter functions
 
 Tact supports [getter functions](https://docs.tact-lang.org/book/functions/#getter-functions) for retrieving contract state off-chain:
 
 :::note
-Get function cannot be called from another contract.
+Getter functions cannot be called from another contract.
 :::
 
 ```tact title="/contracts/hello_world.tact"
@@ -129,7 +127,7 @@ get fun counter(): Int {
 }
 ```
 
-#### Complete contract
+### Complete contract
 
 ```tact title="/contracts/hello_world.tact"
 // message with opcode
@@ -160,11 +158,11 @@ contract HelloWorld {
     receive(msg: Add) {
         self.counter += msg.amount;
 
-        // Notify the caller that the receiver was executed and forward remaining value back
+        // Notify the caller that the receiver was executed
         self.notify("Cashback".asComment());
     }
 
-    // getter function to be called offchain
+    // getter function to be called off-chain
     get fun counter(): Int {
         return self.counter;
     }
@@ -175,7 +173,7 @@ contract HelloWorld {
 }
 ```
 
-Verify that smart contract code is correct by running build script:
+Verify that the smart contract code is correct by running the build script:
 
 ```bash
 npx blueprint build
@@ -197,7 +195,7 @@ Expected output should look like this:
 
 ## Step 2: update wrapper
 
-After building your contract, Tact automatically generates a special wrapper file. This [wrapper]((https://docs.tact-lang.org/book/compile/#wrap-ts)) simplifies interaction with your contract from TypeScript, such as calling its methods or sending messages.
+After building your contract, Tact automatically generates a special wrapper file. This [wrapper](https://docs.tact-lang.org/book/compile/#wrap-ts) simplifies interaction with your contract from TypeScript, such as calling its methods or sending messages.
 
 In the wrapper file, you'll find this line of code:
 
@@ -207,7 +205,7 @@ export * from '../build/HelloWorld/tact_HelloWorld';
 
 This code exports everything inside the `tact_HelloWorld.ts` file in the build folder, making it available for use in other files.
 
-## Step 3: updating tests
+## Step 3: update tests
 
 
 <details>
@@ -288,7 +286,7 @@ This code exports everything inside the `tact_HelloWorld.ts` file in the build f
 
   ```
 
-  Don't forget to verify the example is correct by running test script:
+  Don't forget to verify the example is correct by running the test script:
 
   ```bash
   npx blueprint test
@@ -320,7 +318,7 @@ You've written your first smart contract using Tact, tested it, and explored how
 
 Now, it's time to **deploy the contract** to TON Blockchain.
 
-<Button href="/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network" colorType={'primary'} sizeType={'sm'}>
+<Button href="/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network/" colorType={'primary'} sizeType={'sm'}>
 
   Deploy to the network
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-quick-start-developing-smart-contracts-tact-folder-tact-storage-and-get-methods.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx`

Related issues (from issues.normalized.md):
- [x] **3699. Remove unused Tabs/TabItem imports**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1#L2-L3

Tabs and TabItem are imported but never used; remove these imports to eliminate lint warnings and reduce bundle size.

---

- [x] **3700. Fix 'self reference' casing and article**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1#L78

Replace “They may be accessed with [Self reference](…)” with “They may be accessed with the [`self` reference](…)” (same link), using lower-case self and adding the article.

---

- [x] **3701. Clarify empty-body receive sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1#L110

Change “For accepting messages with empty body you can add `receive` function with no arguments:” to “For messages with an empty body, you can add a `receive` function with no arguments:”.

---

- [ ] **3702. Add semicolon in empty-body receive example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1#L112-L115

Add the missing semicolon after cashback(sender()); in the empty-body receive() example.

---

- [x] **3703. Clarify getter-call restriction grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1#L122-L124

Change “Get function cannot be called from another contract.” to “Getter functions cannot be called from another contract.”

---

- [ ] **3704. Fix typo 'defenition' to 'definition'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1#L141

Correct the comment spelling from “Contract defenition” to “Contract definition”.

---

- [ ] **3705. Add semicolon in contract receive**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1#L154-L157

In the complete contract snippet, add the missing semicolon after cashback(sender()); in the default receive().

---

- [x] **3706. Align 'forward remaining value back' comment**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1#L163-L165

Remove the misleading “and forward remaining value back” from the comment, or add an explicit cashback/send line to match the comment.

---

- [x] **3707. Hyphenate 'off-chain' in comment**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1#L167

Change “// getter function to be called offchain” to “// getter function to be called off-chain”.

---

- [x] **3708. Add article in build-script instruction**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1#L178-L182

Change to “Verify that the smart contract code is correct by running the build script:”.

---

- [x] **3709. Standardize Step 3 heading style**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1#L198-L210

Change the heading from “Step 3: updating tests” to “Step 3: update tests” to match the imperative style used in Step 2.

---

- [x] **3710. Fix broken wrapper link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1#L200

Correct the link formatting from “[wrapper]((https://docs.tact-lang.org/book/compile/#wrap-ts))” to “[wrapper](https://docs.tact-lang.org/book/compile/#wrap-ts)”.

---

- [x] **3711. Add article in test-script instruction**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1#L291-L295

Change to “Don’t forget to verify the example is correct by running the test script:”.

---

- [x] **4585. Fix broken Markdown link (double parentheses)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1

In “This [wrapper]((https://docs.tact-lang.org/book/compile/#wrap-ts))…”, remove the extra parentheses so it reads “This [wrapper](https://docs.tact-lang.org/book/compile/#wrap-ts)…”.

---

- [x] **4586. Align term: use “Blueprint” instead of “Blueprint SDK”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1

Replace “Blueprint SDK” with “Blueprint” to match terminology used across related pages.

---

- [x] **4587. Normalize heading levels under Step 1 (use H3)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1

Change “#### Defining the contract”, “#### Contract storage”, “#### Initializing the contract”, “#### Handling messages”, “#### Getter functions”, and “#### Complete contract” to “### …” to avoid skipping heading levels.

---

- [x] **4588. Fix grammar: pluralize getters note**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1

Change “Get function cannot be called from another contract.” to “Getter functions cannot be called from another contract.”

---

- [x] **4589. Clarify storage access sentence and link text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1

Change “They may be accessed with [Self reference]” to “They may be accessed using the [‘self’ reference](https://docs.tact-lang.org/book/contracts/#self).”

---

- [x] **4590. Add missing semicolons in receive() examples**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1

Add a trailing semicolon to both occurrences of “cashback(sender())” to be consistent with surrounding statements and avoid copy/paste errors.

---

- [ ] **4591. Fix typos and clarify comments in complete contract**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1

Change “// Contract defenition” to “// Contract definition”, and replace “// default(null) receive for deploy” with “// default (empty body) receiver for deploy”.

---

- [x] **4592. Use imperative in Step 3 heading (“update tests”)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1

Rename “Step 3: updating tests” to “Step 3: update tests” for consistency with other step headings.

---

- [x] **4593. Add missing articles in procedure text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1

Update to “Verify that the smart contract code is correct by running the build script:” and “Don’t forget to verify the example is correct by running the test script:”.

---

- [x] **4594. Improve grammar for empty-body receive sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1

Change “For accepting messages with empty body you can add `receive` function with no arguments:” to “To accept messages with an empty body, add a `receive` function with no arguments:”.

---

- [x] **4595. Hyphenate off-chain consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1

Change the comment “getter function to be called offchain” to “getter function to be called off-chain”.

---

- [x] **4596. Fix capitalization: “Tact by example”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1

Update link text from “Tact By Example” to “Tact by example” to match prevailing usage.

---

- [x] **4597. Add trailing slash to “Deploy to the network” link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-storage-and-get-methods.mdx?plain=1

Change the button href to “/v3/guidelines/quick-start/developing-smart-contracts/tact-folder/tact-deploying-to-network/” for consistency with neighboring pages.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.