### PR TITLE
Split: update docs/v3/guidelines/quick-start/getting-started.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/quick-start/getting-started.mdx
+++ b/docs/v3/guidelines/quick-start/getting-started.mdx
@@ -10,7 +10,7 @@ Welcome to the TON Quick Start guide! This guide will give you a starting point 
 ## Prerequisites
 
 - Basic programming knowledge.
-- Around __30 minutes__ of your time.
+- Around **30 minutes** of your time.
 
 :::note
 We will provide a short explanation of core concepts during the guide, but if you prefer a more theoretical approach, you can check out the core concepts of [TON Blockchain](/v3/concepts/dive-into-ton/ton-blockchain/blockchain-of-blockchains) first.
@@ -21,8 +21,8 @@ We will provide a short explanation of core concepts during the guide, but if yo
 - Understand the key principles of TON Blockchain, including _messages_, _smart contracts_, and _addresses_.
 - Interact with TON Ecosystem, including wallets and blockchain explorers.
 - Interact with TON Blockchain by reading from and writing data to it.
-- Set up a development environment using the _Blueprint_ for the _smart contract_ development.
-- Start writing smart contracts using the **FunC**, **Tolk**, and **Tact** programming languages in TON.
+- Set up a development environment using Blueprint for smart contract development.
+- Start writing smart contracts using the **FunC**, **Tolk**, and **Tact** programming languages on TON Blockchain.
 
 ## Concept of smart contracts
 
@@ -42,9 +42,9 @@ In contrast to other blockchains, where you can call other contract code synchro
 The available interfaces of a smart contract are:
 - Receiving **internal messages** from another smart contract.
 - Receiving **external messages** from outside the blockchain.
-- Processing **get-methods** requests from outside the blockchain.
+- Processing **get methods** requests from outside the blockchain.
 
-Unlike internal or external messages, **get methods** do not result in transactions. They are special functions of the smart contract that cannot change the contract's internal state or perform any other action except querying specific data from the contract's state.
+Unlike internal or external messages, `get methods` do not result in transactions. They are special functions of the smart contract that cannot change the contract's internal state or perform any other action except querying specific data from the contract's state.
 
 :::info
 Contrary to what might seem intuitive, invoking `get methods` from other contracts **is not possible**.
@@ -54,7 +54,7 @@ Contrary to what might seem intuitive, invoking `get methods` from other contrac
 
 Before we begin our journey to becoming TON developers, we should first become advanced users of TON. Let’s create our **wallet**, send a few transactions, and see how our actions are reflected on the blockchain using **explorers**.
 
-### Step 1: Create a New Wallet Using an App
+### Step 1: create a new wallet using an app
 
 The simplest way to create a **wallet** is to visit https://ton.org/wallets and choose one of the wallet apps from the list. They are all pretty similar, so let's choose [Tonkeeper](https://tonkeeper.com/). Go ahead, install it, and run it.
 
@@ -73,12 +73,12 @@ TON basic transactions are very cheap—about 1 cent per transaction. Getting th
 - For **Mainnet**, you can get Toncoin by simply pressing the buy button in the user interface or asking someone to send them to your **address**. You can copy the address from the wallet app, which is usually located near your balance.
 
 :::info
-Don't worry, sharing your address is **totally safe**, unless you don't want it to be associated with you.
+Don't worry, sharing your address is **totally safe** unless you don't want it to be associated with you.
 :::
 
-- For the **Testnet** version, you can request funds from the [Testgiver Ton Bot](https://t.me/testgiver_ton_bot/) **completely for free**! After a short wait, you will receive 2 Toncoin that will appear in your wallet app.
+- For the **Testnet** version, you can request funds from the [Testgiver Ton Bot](https://t.me/testgiver_ton_bot/) **completely for free**! After a short wait, you will receive test Toncoin that will appear in your wallet app.
 
-### Step 3: Creating a Testnet Wallet
+### Step 3: creating a Testnet wallet
 
 If you decide to use the **Testnet** version, you can do so by following the guide below.
 
@@ -90,14 +90,13 @@ To create your first Testnet wallet in Tonkeeper, you should obtain a mnemonic u
 
 #### Creating a wallet
 
-To create a Testnet wallet, click *Wallet* → *Add Wallet* → *TestnetAccount*. Then, import the seed phrase generated in the previous step.
-
+To create a Testnet wallet, click `Wallet` → `Add Wallet` → `Testnet Account`. Then, import the seed phrase generated in the previous step.
 
 <div style={{display: 'flex', justifyContent: 'center', gap: '20px', flexWrap: 'wrap', marginBottom: '30px'}}>
   <br/>
   <ThemedImage
     height='600px'
-    alt="Creating a Tonkeeper Testnet account"
+    alt="Tonkeeper: adding a Testnet wallet and importing a mnemonic"
     sources={{
       light: '/img/tutorials/quick-start/tonkeeper-light.jpg?raw=true',
       dark: '/img/tutorials/quick-start/tonkeeper-dark.jpg?raw=true',
@@ -107,7 +106,7 @@ To create a Testnet wallet, click *Wallet* → *Add Wallet* → *TestnetAccount*
 </div>
 
 
-### Step 4: Exploring TON Blockchain
+### Step 4: exploring TON Blockchain
 
 Congratulations! We’ve created our first wallet and received some funds in it. Now, let's take a look at how our actions are reflected in the blockchain. We can do this by using various [explorers](https://ton.app/explorers/).
 
@@ -117,7 +116,7 @@ An **explorer** is a tool that allows you to query data from the chain, investig
 Note that when using the **Testnet**, you should manually change the explorer mode to the **Testnet** version. Don't forget that these are different networks that do not share any transactions or smart contracts. Therefore, your **Testnet** wallet will not be visible in **Mainnet** mode and vice versa.
 :::
 
-Let's take a look at our newly created wallet using the `explorer`: copy your wallet address from the app and insert it into the search bar of the explorer like this:
+Let's take a look at our newly created wallet using the explorer: copy your wallet address from the app and insert it into the search bar of the explorer like this:
 
 <div style={{marginBottom: '30px'}}>
   <img src="/img/tutorials/quick-start/explorer1.png" alt="Screenshot of explorer search interface"/>
@@ -127,13 +126,13 @@ Let's take a look at our newly created wallet using the `explorer`: copy your wa
 
 First, let's examine the common [address state](/v3/documentation/smart-contracts/addresses/address-states) of our smart contract:
 
-- `Nonexist`: suppose you haven't received funds to your address yet. In that case, it will be in the **nonexistent** state — the initial state for all potential addresses. In this state, the address has **no** associated code, data, or balance.
+- `nonexist`: suppose you haven't received funds to your address yet. In that case, it will be in the **nonexistent** state — the initial state for all potential addresses. In this state, the address has **no** associated code, data, or balance.
 
 <div style={{marginBottom: '30px'}}>
   <img src="/img/tutorials/quick-start/nonexist.png" alt="Screenshot of nonexistent wallet state"/>
 </div>
 
-- `Uninit`: stands for an address that holds a balance and metadata but contains _no code or persistent data_. An address enters this state when it receives funds.
+- `uninit`: stands for an address that holds a balance and metadata but contains _no code or persistent data_. An address enters this state when it receives funds.
 
 <div style={{marginBottom: '30px'}}>
   <img src="/img/tutorials/quick-start/uninit.png" alt="Screenshot of uninitialized wallet state"/>
@@ -146,7 +145,7 @@ This might seem unintuitive: why is your wallet in the `uninit` state when you�
 - The `wallet smart contract` is the contract itself. Since its deployment requires some fees, most `wallet apps` don’t actually deploy the wallet `smart contract` until you receive funds to your address and try to make your first transaction.
 :::
 
-- `Active`: the state of a _deployed_ smart contract that contains code, data, and balance.
+- `active`: the state of a _deployed_ smart contract that contains code, data, and balance.
 
 To deploy our wallet, let's send the first transaction to someone special—**ourselves**—and see how it looks on the **blockchain**. Enter the **send menu** in your wallet app and transfer some funds to your own address that you’ve copied before. In the explorer, our contract should start looking something like this:
 
@@ -162,8 +161,8 @@ And here we are — our wallet contract is deployed and ready to use. Let's exam
 
 #### Metadata section
 - **Address**: Your account's unique ID (e.g., `QQB...1g6VdFEg`).
-- **Balance**: Current TON amount.
-- **Type**: Contract version (e.g., `wallet_v5r1` – detected automatically by code).
+- **Balance**: Current Toncoin amount.
+- **Type**: Contract version (e.g., `walletv5r1` – detected automatically by code).
 - **State**: Address state. It may be `nonexist`, `uninit`, `active`, or `frozen`.
 
 #### Navigation tabs
@@ -173,7 +172,7 @@ And here we are — our wallet contract is deployed and ready to use. Let's exam
 
 ## Next steps
 
-- Now that you’ve tried the *wallet app*, take a moment to explore further: create another *wallet account*, try sending some TON between them, and observe how the transactions appear in the explorer.
+- Now that you’ve tried the *wallet app*, take a moment to explore further: create another *wallet account*, try sending some Toncoin between them, and observe how the transactions appear in the explorer.
 - When you're ready, move on to the next step:
 
 <Button href="/v3/guidelines/quick-start/blockchain-interaction/reading-from-network" colorType={'primary'} sizeType={'sm'}>


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-quick-start-getting-started.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/quick-start/getting-started.mdx`

Related issues (from issues.normalized.md):
- [ ] **3712. Standardize "get methods" term formatting**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/getting-started.mdx?plain=1

Use consistent non-hyphenated, code-formatted "get methods": replace "**get-method**" and "**get methods**" with "`get methods`" and leave existing code-formatted instances as-is.

---

- [ ] **3713. Remove comma before "unless"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/getting-started.mdx?plain=1

Delete the comma in “Don’t worry, sharing your address is totally safe, unless you don’t want it to be associated with you.” so it reads “Don’t worry, sharing your address is totally safe unless you don’t want it to be associated with you.”

---

- [ ] **3714. Add descriptive alt text to ThemedImage**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/getting-started.mdx?plain=1

Replace the empty alt attribute (alt="") under “Creating a wallet” with a concise description, e.g., alt="Tonkeeper UI showing Testnet account creation".

---

- [ ] **3715. Normalize address state term to `nonexist`**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/getting-started.mdx?plain=1

Use the canonical code term `nonexist` (lowercase) in lists/code (fix “`Nonexist`” and “`nonexisting`”), and use “nonexistent” only in explanatory prose.

---

- [ ] **3716. Use "Toncoin" for currency unit**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/getting-started.mdx?plain=1

Replace “TON” used as the currency (e.g., “try sending some TON between them”) with “Toncoin” (“try sending some Toncoin between them”).

---

- [ ] **3717. Simplify Blueprint sentence and remove italics**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/getting-started.mdx?plain=1

Change “Set up a development environment using the _Blueprint_ for the _smart contract_ development.” to “Set up a development environment using Blueprint for smart contract development.”

---

- [ ] **3718. Remove code formatting from "explorer"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/getting-started.mdx?plain=1

Change the common noun formatted as code (“using the `explorer`”) to plain text (“using the explorer”).

---

- [ ] **3719. Use consistent bold syntax for time estimate**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/getting-started.mdx?plain=1

Change “__30 minutes__” to “**30 minutes**” to match the page’s bold formatting style.

---

- [ ] **3720. Fix preposition: "on your address" → "to your address"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/getting-started.mdx?plain=1

Update “until you receive funds on your address and try to make your first transaction” to “until you receive funds to your address and try to make your first transaction.”

---

- [ ] **3721. Align heading capitalization style**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/getting-started.mdx?plain=1

Choose a single capitalization style for all headings and apply it consistently; use sentence case across the page to match the H1 “Getting started.”

---

- [ ] **3722. Prefer "on TON Blockchain" phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/getting-started.mdx?plain=1

Revise “Start writing smart contracts using the FunC, Tolk, and Tact programming languages in TON.” to “Start writing smart contracts using the FunC, Tolk, and Tact programming languages on TON Blockchain.”

---

- [ ] **4484. Use “get methods” consistently (no hyphen)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/getting-started.mdx?plain=1

Replace every “get-method” with “get methods”; e.g., change “Processing get-method requests…” to “Processing get methods requests…”.

---

- [ ] **4485. State name in metadata: use `nonexist` (not `nonexisting`)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/getting-started.mdx?plain=1

In the Metadata section list, replace the token `nonexisting` with the canonical `nonexist`.

---

- [ ] **4486. Contract type label: use `walletv5r1` (no underscore)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/getting-started.mdx?plain=1

In the Metadata example, change `wallet_v5r1` to `walletv5r1`.

---

- [ ] **4487. Remove hard-coded faucet amount**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/getting-started.mdx?plain=1

In the Testnet section, remove the exact “2 Toncoin” amount and state that you will receive test Toncoin in your wallet.

---

- [ ] **4488. Tonkeeper UI label: “Testnet Account”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/getting-started.mdx?plain=1

Update the instruction to use the exact UI label with spacing and capitalization: Wallet → Add Wallet → `Testnet Account`.

---

- [ ] **4489. Add descriptive alt text for Tonkeeper screenshots**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/getting-started.mdx?plain=1

Set a meaningful alt attribute for the ThemedImage (e.g., alt="Tonkeeper: adding a Testnet wallet and importing a mnemonic") instead of empty alt.

---

- [ ] **4490. Fix awkward phrasing in learning goals**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/getting-started.mdx?plain=1

Change “using the Blueprint for the smart contract development” to “using Blueprint for smart contract development.”

---

- [ ] **4491. Lowercase address state tokens in list**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/quick-start/getting-started.mdx?plain=1

In the Address states section, render tokens in lowercase code style: `nonexist`, `uninit`, `active`, `frozen`.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.