### PR TITLE
Split: update docs/v3/guidelines/smart-contracts/fee-calculation.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/smart-contracts/fee-calculation.mdx
+++ b/docs/v3/guidelines/smart-contracts/fee-calculation.mdx
@@ -1,22 +1,22 @@
 import Feedback from '@site/src/components/Feedback';
 
-# Fees calculation
+# Fee calculation
 
 ## Introduction
 
-When your contract begins processing an incoming message, you should verify the number of TONs attached to the message to ensure it is sufficient to cover [all types of fees](/v3/documentation/smart-contracts/transaction-fees/fees#elements-of-transaction-fee). To achieve this, you need to calculate (or predict) the fee for the current transaction.
+When your contract begins processing an incoming message, you should verify the amount of Toncoin attached to the message to ensure it is sufficient to cover [all types of fees](/v3/documentation/smart-contracts/transaction-fees/fees#elements-of-the-transaction-fee). To achieve this, you need to calculate (or predict) the fee for the current transaction.
 
 This document explains how to calculate fees in FunC contracts using the latest TVM opcodes.
 
 :::info opcodes
-For a comprehensive list of TVM opcodes, including those mentioned below, refer to the [TVM instruction page](/v3/documentation/tvm/instructions).
+For a comprehensive list of TVM opcodes, including those mentioned below, refer to [TVM instructions](/v3/documentation/tvm/tvm-overview#tvm-instructions).
 :::
 
 ## Storage fee
 
 ### Overview
 
-In short, `storage fees` are the costs of storing a smart contract on the blockchain. You pay for every second the smart contract remains stored on the blockchain.
+In short, storage fees are the costs of storing a smart contract on the blockchain. You pay for every second the smart contract remains stored on the blockchain.
 
 Use the `GETSTORAGEFEE` opcode with the following parameters:
 
@@ -24,7 +24,8 @@ Use the `GETSTORAGEFEE` opcode with the following parameters:
 | :--------- | :------------------------------------------------------ |
 | cells      | Number of contract cells                                |
 | bits       | Number of contract bits                                 |
-| is_mc      | True if the source or destination is in the MasterChain |
+| seconds    | Duration in seconds for the estimate                    |
+| is_mc      | True if execution is in the masterchain; false if basechain |
 
 :::info 
 The system counts only unique hash cells for storage and forward fees. For example, it counts three identical hash cells as one. This mechanism deduplicates data by storing the content of multiple equivalent sub-cells only once, even if they are referenced across different branches. [Read more about deduplication](/v3/documentation/data-formats/tlb/library-cells). 
@@ -62,7 +63,7 @@ const int RESERVE_BOUNCE_ON_ACTION_FAIL = 16;
 }
 ```
 
-If `storage_fee` is hardcoded, **remember to update it** during the contract update process. Not all contracts support updates, so this is an optional requirement.
+If `min_storage_fee` is hardcoded, **remember to update it** during the contract update process. Not all contracts support updates, so this is an optional requirement.
 
 ## Computation fee
 
@@ -70,10 +71,10 @@ If `storage_fee` is hardcoded, **remember to update it** during the contract upd
 
 In most cases, use the `GETGASFEE` opcode with the following parameters:
 
-| Param      | Description                                             |
-| :--------- | :------------------------------------------------------ |
-| `gas_used` | Gas amount, calculated in tests and hardcoded           |
-| `is_mc`    | True if the source or destination is in the MasterChain |
+| Param      | Description                                                    |
+| :--------- | :------------------------------------------------------------- |
+| `gas_used` | Gas amount, calculated in tests and hardcoded                  |
+| `is_mc`    | True if execution is in the masterchain; false if basechain    |
 
 ### Calculation flow
 
@@ -207,14 +208,14 @@ The `SENDMSG` opcode is the least optimal way to calculate fees, but it is bette
 
 If even `GETORIGINALFWDFEE` cannot be used, one more option exists. Use the `SENDMSG` opcode with the following parameters:
 
-| Param name | Description     |
-| :--------- | :-------------- |
-| cells      | Number of cells |
-| mode       | Message mode    |
+| Param name | Description                   |
+| :--------- | :---------------------------- |
+| msg        | Serialized message cell       |
+| mode       | Message mode                  |
 
 Modes influence the fee calculation in the following ways:
 
-- **`+1024`**: This mode does not create an action but only estimates the fee. Other modes will send a message during the action phase.
+- **`+1024`**: Returns the estimated fee without creating an output action. Other modes will send a message during the action phase.
 - **`+128`**: This mode substitutes the value of the entire contract balance before the computation phase begins. This is slightly inaccurate because gas expenses, which cannot be estimated before the computation phase, are excluded.
 - **`+64`**: This mode substitutes the entire balance of the incoming message as the outgoing value. This is also slightly inaccurate, as gas expenses that cannot be estimated until the computation is completed are excluded.
 - Refer to the [message modes page](/v3/documentation/smart-contracts/message-management/sending-messages#message-modes) for additional modes.
@@ -241,4 +242,3 @@ int gas_consumed() asm "GASCONSUMED";
 - [Stablecoin contract with fees calculation](https://github.com/ton-blockchain/stablecoin-contract)
 
 <Feedback />
-

--- a/docs/v3/guidelines/smart-contracts/fee-calculation.mdx
+++ b/docs/v3/guidelines/smart-contracts/fee-calculation.mdx
@@ -56,10 +56,10 @@ const int RESERVE_AT_MOST = 2;
 ;;; In the case of action failure, the transaction is bounced. No effect if RESERVE_AT_MOST (+2) is used. TVM UPGRADE 2023-07. [/v3/documentation/tvm/changelog/tvm-upgrade-2023-07#sending-messages](/v3/documentation/tvm/changelog/tvm-upgrade-2023-07#sending-messages)
 const int RESERVE_BOUNCE_ON_ACTION_FAIL = 16;
 
-() calculate_and_reserve_at_most_storage_fee(int balance, int msg_value, int is_mc, int seconds, int bits, int cells) inline {
- int ton_balance_before_msg = balance - msg_value;
- int min_storage_fee = get_storage_fee(is_mc, seconds, bits, cells); ;; You can hardcode this value if the contract code will not be updated.
- raw_reserve(max(ton_balance_before_msg, min_storage_fee + my_storage_due()), RESERVE_AT_MOST);
+() calculate_and_reserve_at_most_storage_fee(int balance, int msg_value, int workchain, int seconds, int bits, int cells) inline {
+ int on_balance_before_msg = my_ton_balance - msg_value;
+ int min_storage_fee = get_storage_fee(workchain, seconds, bits, cells); ;; You can hardcode this value if the contract code will not be updated.
+ raw_reserve(max(on_balance_before_msg, min_storage_fee + my_storage_due()), RESERVE_AT_MOST);
 }
 ```
 

--- a/docs/v3/guidelines/smart-contracts/fee-calculation.mdx
+++ b/docs/v3/guidelines/smart-contracts/fee-calculation.mdx
@@ -36,30 +36,30 @@ The system counts only unique hash cells for storage and forward fees. For examp
 Each contract has its balance. You can calculate how many TONs your contract requires to remain valid for a specified `seconds` duration using the function:
 
 ```func
-int get_storage_fee(int workchain, int seconds, int bits, int cells) asm(cells bits seconds workchain) "GETSTORAGEFEE";
+int get_storage_fee(int is_mc, int seconds, int bits, int cells) asm(cells bits seconds is_mc) "GETSTORAGEFEE";
 ```
 
 You can then hardcode this value into the contract and calculate the current storage fee using:
 
 ```func
-;; functions from func stdlib (not available on mainnet)
+;; functions from the FunC stdlib
 () raw_reserve(int amount, int mode) impure asm "RAWRESERVE";
-int get_storage_fee(int workchain, int seconds, int bits, int cells) asm(cells bits seconds workchain) "GETSTORAGEFEE";
+int get_storage_fee(int is_mc, int seconds, int bits, int cells) asm(cells bits seconds is_mc) "GETSTORAGEFEE";
 int my_storage_due() asm "DUEPAYMENT";
 
 ;; constants from stdlib
-;;; Creates an output action which reserves exactly x nanoTONs (if y = 0).
+;;; Creates an output action which reserves exactly x nanotons (if y = 0).
 const int RESERVE_REGULAR = 0;
-;;; Creates an output action which reserves at most x nanoTONs (if y = 2).
+;;; Creates an output action which reserves at most x nanotons (if y = 2).
 ;;; Bit +2 in y ensures the external action does not fail if the specified amount cannot be reserved. Instead, it reserves all remaining balance.
 const int RESERVE_AT_MOST = 2;
-;;; In the case of action failure, the transaction is bounced. No effect if RESERVE_AT_MOST (+2) is used. TVM UPGRADE 2023-07. [v3/documentation/tvm/changelog/tvm-upgrade-2023-07#sending-messages](https://ton.org/docs/#/tvm/changelog/tvm-upgrade-2023-07#sending-messages)
+;;; In the case of action failure, the transaction is bounced. No effect if RESERVE_AT_MOST (+2) is used. TVM UPGRADE 2023-07. [/v3/documentation/tvm/changelog/tvm-upgrade-2023-07#sending-messages](/v3/documentation/tvm/changelog/tvm-upgrade-2023-07#sending-messages)
 const int RESERVE_BOUNCE_ON_ACTION_FAIL = 16;
 
-() calculate_and_reserve_at_most_storage_fee(int balance, int msg_value, int workchain, int seconds, int bits, int cells) inline {
- int on_balance_before_msg = my_ton_balance - msg_value;
- int min_storage_fee = get_storage_fee(workchain, seconds, bits, cells); ;; You can hardcode this value if the contract code will not be updated.
- raw_reserve(max(on_balance_before_msg, min_storage_fee + my_storage_due()), RESERVE_AT_MOST);
+() calculate_and_reserve_at_most_storage_fee(int balance, int msg_value, int is_mc, int seconds, int bits, int cells) inline {
+ int ton_balance_before_msg = balance - msg_value;
+ int min_storage_fee = get_storage_fee(is_mc, seconds, bits, cells); ;; You can hardcode this value if the contract code will not be updated.
+ raw_reserve(max(ton_balance_before_msg, min_storage_fee + my_storage_due()), RESERVE_AT_MOST);
 }
 ```
 
@@ -79,7 +79,7 @@ In most cases, use the `GETGASFEE` opcode with the following parameters:
 ### Calculation flow
 
 ```func
-int get_compute_fee(int workchain, int gas_used) asm(gas_used workchain) "GETGASFEE";
+int get_compute_fee(int is_mc, int gas_used) asm(gas_used is_mc) "GETGASFEE";
 ```
 
 But how do you determine `gas_used`? Through testing!
@@ -108,7 +108,7 @@ let customPayload = beginCell().storeUint(0xfedcba0987654321n, 128).endCell();
 // Embed the forward payload into the custom payload to ensure maximum gas usage during computation
 const sendResult = await deployerJettonWallet.sendTransfer(
   deployer.getSender(),
-  toNano("0.17"), // tons
+  toNano("0.17"), // TON
   sentAmount,
   notDeployer.address,
   deployer.address,
@@ -164,7 +164,7 @@ printTxGasStats = (name, transaction) => {
   return txComputed.gasFees;
 };
 
-send_gas_fee = printTxGasStats("Jetton transfer", transferTx);
+const send_gas_fee = printTxGasStats("Jetton transfer", transferTx);
 ```
 
 ## Forward fee
@@ -187,7 +187,7 @@ If the message structure is deterministic, use the `GETFORWARDFEE` opcode with t
 | :--------- | :------------------------------------------------------ |
 | cells      | Number of cells                                         |
 | bits       | Number of bits                                          |
-| is_mc      | True if the source or destination is in the MasterChain |
+| is_mc      | True if execution is in the masterchain; false if basechain |
 
 :::info 
 The system counts only unique hash cells for storage and forward fees. For example, it counts three identical hash cells as one. This mechanism deduplicates data by storing the content of multiple equivalent sub-cells only once, even if they are referenced across different branches. [Read more about deduplication](/v3/documentation/data-formats/tlb/library-cells). 
@@ -198,7 +198,7 @@ However, if the outgoing message depends significantly on the incoming structure
 | Param name | Description                                             |
 | :--------- | :------------------------------------------------------ |
 | fwd_fee    | Parsed from the incoming message                        |
-| is_mc      | True if the source or destination is in the MasterChain |
+| is_mc      | True if execution is in the masterchain; false if basechain |
 
 :::caution 
 Be careful with the `SENDMSG` opcode, as it uses an **unpredictable amount** of gas. Avoid using it unless necessary.
@@ -220,7 +220,7 @@ Modes influence the fee calculation in the following ways:
 - **`+64`**: This mode substitutes the entire balance of the incoming message as the outgoing value. This is also slightly inaccurate, as gas expenses that cannot be estimated until the computation is completed are excluded.
 - Refer to the [message modes page](/v3/documentation/smart-contracts/message-management/sending-messages#message-modes) for additional modes.
 
-It creates an output action and returns the fee for creating a message. However, it uses an unpredictable amount of gas, which cannot be calculated using formulas. To measure gas usage, use `GASCONSUMED`:
+With modes other than `+1024`, it creates an output action and returns the fee for creating a message. With `+1024`, it only returns the estimated fee and does not create an output action. In all cases, it uses an unpredictable amount of gas, which cannot be calculated using formulas. To measure gas usage, use `GASCONSUMED`:
 
 ```func
 int send_message(cell msg, int mode) impure asm "SENDMSG";


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-smart-contracts-fee-calculation.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/smart-contracts/fee-calculation.mdx`

Related issues (from issues.normalized.md):
- [x] **3723. Fix page title grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/fee-calculation.mdx?plain=1#L3

Change the H1 to "Fee calculation" (singular) instead of "Fees calculation".

---

- [x] **3724. Fix broken intro anchor to “Elements of the transaction fee”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/fee-calculation.mdx?plain=1#L7

Update the link to /v3/documentation/smart-contracts/transaction-fees/fees#elements-of-the-transaction-fee so it matches the target heading.

---

- [x] **3725. Use correct currency phrasing in intro**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/fee-calculation.mdx?plain=1#L7

Replace “verify the number of TONs attached” with “verify the amount of Toncoin attached”.

---

- [x] **3726. Update “TVM instruction page” link text and target**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/fee-calculation.mdx?plain=1#L11-L13

Change the link text to “TVM instructions” and point it to /v3/documentation/tvm/tvm-overview#tvm-instructions (the existing page).

---

- [x] **3727. Remove code formatting from general term**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/fee-calculation.mdx?plain=1#L19

Replace the inline code-styled “`storage fees`” with plain text “storage fees”.

---

- [x] **3728. Add missing `seconds` to GETSTORAGEFEE parameters table**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/fee-calculation.mdx?plain=1#L21-L27

Insert a `seconds` row (duration in seconds for the estimate) and keep the boolean named `is_mc` for consistency.

---

- [x] **3729. Rename boolean to `is_mc` in GETSTORAGEFEE signature**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/fee-calculation.mdx?plain=1#L37-L39

Change the FunC declaration to use `is_mc` and keep stack order as asm(cells bits seconds is_mc), e.g., int get_storage_fee(int is_mc, int seconds, int bits, int cells) asm(cells bits seconds is_mc) "GETSTORAGEFEE";

---

- [x] **3730. Remove misleading stdlib availability note**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/fee-calculation.mdx?plain=1#L43-L47

Delete “(not available on mainnet)” and rephrase to “functions from the FunC stdlib”.

---

- [x] **3731. Use “nanotons” unit consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/fee-calculation.mdx?plain=1#L50-L56

Replace “nanoTONs” with “nanotons” in all occurrences in this section.

---

- [x] **3732. Replace outdated absolute link with repo-relative link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/fee-calculation.mdx?plain=1#L55

Change https://ton.org/docs/#/tvm/changelog/tvm-upgrade-2023-07#sending-messages to /v3/documentation/tvm/changelog/tvm-upgrade-2023-07#sending-messages.

---

- [ ] **3733. Fix example: use passed balance and align variable names**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/fee-calculation.mdx?plain=1#L58-L62

Use the `balance` parameter (e.g., int ton_balance_before_msg = balance - msg_value;) instead of an undefined `my_ton_balance`, and rename `on_balance_before_msg` to `ton_balance_before_msg` (or `balance_before_msg`); also update nearby prose to refer to `min_storage_fee` (not `storage_fee`) to match the snippet.

---

- [x] **3734. Rename boolean to `is_mc` in GETGASFEE signature**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/fee-calculation.mdx?plain=1#L80-L82

Change the FunC declaration to use `is_mc` and stack order asm(gas_used is_mc), e.g., int get_compute_fee(int is_mc, int gas_used) asm(gas_used is_mc) "GETGASFEE";

---

- [x] **3735. Fix currency casing in comment**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/fee-calculation.mdx?plain=1#L118-L123

Change the inline comment “// tons” to “// TON”.

---

- [ ] **3736. Fix TypeScript snippet: declare variable and use gasUsed**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/fee-calculation.mdx?plain=1#L166-L167

Declare the variable and return gas used, e.g., const sendGasUsed = printTxGasStats(...).txComputed.gasUsed; and use camelCase naming.

---

- [x] **3737. Correct SENDMSG table and clarify +1024 behavior**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/fee-calculation.mdx?plain=1#L208-L214

Update the parameters to `msg` (serialized message cell) and `mode` (message mode), and clarify that with flag +1024 it returns the estimated fee without creating an output action.

---

- [x] **3738. Clarify `is_mc` meaning for fee opcodes**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/fee-calculation.mdx?plain=1

Rephrase the `is_mc` descriptions for GETSTORAGEFEE/GETGASFEE to indicate whether execution is in the masterchain (true) or basechain (false), rather than referring to source/destination of a message.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.