### PR TITLE
Split: update docs/v3/guidelines/smart-contracts/get-methods.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/smart-contracts/get-methods.mdx
+++ b/docs/v3/guidelines/smart-contracts/get-methods.mdx
@@ -3,7 +3,7 @@ import Feedback from '@site/src/components/Feedback';
 # Get methods
 
 :::note
-To fully benefit from this content, readers must understand the [FunC programming language](/v3/documentation/smart-contracts/func/overview/) on the TON Blockchain. This knowledge is crucial for grasping the information presented here.
+This guide assumes familiarity with the [FunC programming language](/v3/documentation/smart-contracts/func/overview/).
 :::
 
 ## Introduction
@@ -26,7 +26,7 @@ return get_data().begin_parse().preload_uint(64);
 }
 ```
 
-2. **Aggregate data retrieval**: Another common method is to create methods that gather multiple pieces of data from a contract's state in one call. This is useful when specific data points are often used together. You can see this approach frequently in [Jetton](#jettons) and [NFT](#nfts) contracts.
+2. **Aggregate data retrieval**: Another common method is to create methods that gather multiple pieces of data from a contract's state in one call. This is useful when specific data points are often used together. You can see this approach frequently in [Jetton](#jettons) ([overview](/v3/guidelines/dapps/asset-processing/jettons#overview)) and [NFT](#nfts) ([overview](/v3/guidelines/dapps/asset-processing/nft-processing/nfts#overview)) contracts.
 
 Example:
 
@@ -72,7 +72,7 @@ int seqno() method_id {
 }
 ```
 
-Returns the transaction's sequence number within a specific wallet. This method is primarily used for [replay protection](/v3/guidelines/smart-contracts/howto/wallet#replay-protection---seqno).
+Returns the wallet’s current outbound message sequence number (seqno).
 
 #### get_subwallet_id()
 
@@ -93,7 +93,7 @@ int get_public_key() method_id {
 }
 ```
 
-This method retrieves the public key associated with the wallet.
+Returns the stored public key.
 
 ### Jettons
 
@@ -108,8 +108,8 @@ This method retrieves the public key associated with the wallet.
 This method returns the complete set of data associated with a jetton wallet:
 
 - (int) balance
-- (slice) owner_address
-- (slice) jetton_master_address
+- (slice) owner address
+- (slice) jetton master (minter) address
 - (cell) jetton_wallet_code
 
 #### get_jetton_data()
@@ -121,7 +121,7 @@ This method returns the complete set of data associated with a jetton wallet:
 }
 ```
 
-Returns data of a jetton master, including its total supply, the address of its admin, the content of the jetton, and its wallet code.
+Returns total supply, mintable flag, admin address, content, and jetton wallet code. The mintable flag is −1 for mintable and 0 for non‑mintable.
 
 #### get_wallet_address(slice owner_address)
 
@@ -157,7 +157,7 @@ Returns the data associated with a non-fungible token, including whether it has 
 }
 ```
 
-Returns the data of an NFT collection, including the index of the next item available for minting, the content of the collection, and the owner's address.
+Returns the data of an NFT collection, including the index of the next item available for minting, the content of the collection, and the owner's address. The returned tuple order is (next_item_index, collection_content, owner_address).
 
 #### get_nft_address_by_index(int index)
 
@@ -377,4 +377,3 @@ Get methods are vital for querying data from smart contracts on the TON Blockcha
 - [Writing tests examples](/v3/guidelines/smart-contracts/testing/writing-test-examples)
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-smart-contracts-get-methods.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/smart-contracts/get-methods.mdx`

Related issues (from issues.normalized.md):
- [ ] **2606. Link "get-method" to canonical page**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/dapps/apis-sdks/ton-adnl-apis.mdx?plain=1

Link “get-method” to docs/v3/guidelines/smart-contracts/get-methods.mdx where the term first appears.

---

- [ ] **3739. Simplify prerequisite note**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/get-methods.mdx?plain=1#L5-L7

Replace the note with a single sentence: “This guide assumes familiarity with the FunC language.” keeping the existing link unchanged.

---

- [ ] **3740. Fix FunC example indentation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/get-methods.mdx?plain=1#L23-L27

Indent the return line in the get_balance() example by one space to match the page’s code style.

---

- [ ] **3741. Add external cross-links for Jettons and NFTs**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/get-methods.mdx?plain=1#L29-L37

Supplement the in-page anchors with secondary links to the overviews: docs/v3/guidelines/dapps/asset-processing/jettons.mdx#overview and docs/v3/guidelines/dapps/asset-processing/nft-processing/nfts.mdx#overview.

---

- [ ] **3742. Correct seqno description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/get-methods.mdx?plain=1#L75

Replace the sentence with: “Returns the wallet’s current outbound message sequence number (seqno).”

---

- [ ] **3743. Rephrase get_public_key description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/get-methods.mdx?plain=1#L87-L96

Change the prose to: “Returns the stored public key.”

---

- [ ] **3744. Standardize Jetton wallet data labels**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/get-methods.mdx?plain=1#L108-L114

Align bullet labels with the jetton docs using “owner address”, “jetton master (minter) address”, and “jetton_wallet_code” (or use code-style names consistently).

---

- [ ] **3745. Make bullet punctuation consistent**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/get-methods.mdx?plain=1#L110-L113

Ensure all items in this bullet list use no terminal periods to match the page’s style.

---

- [ ] **3746. Document mintable field in get_jetton_data**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/get-methods.mdx?plain=1#L115-L125

Update the description to list all five tuple fields and explain the mintable flag (−1 mintable, 0 non‑mintable), e.g., “Returns total supply, mintable flag, admin address, content, and jetton wallet code.”

---

- [ ] **3747. Clarify get_collection_data ordering**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/get-methods.mdx?plain=1#L152-L160

Add a brief note that the returned tuple order is (next_item_index, collection_content, owner_address) even if local variable naming order differs.

---

- [ ] **3748. Explain workchain() helper**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/get-methods.mdx?plain=1#L165-L169

Add a note that workchain() returns the current workchain ID and link to docs/v3/documentation/smart-contracts/func/cookbook.mdx#generate-an-internal-address.

---

- [ ] **3749. Fix link text for NFT content reference**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/get-methods.mdx?plain=1#L202

Change the link text to “get_nft_data()” to match the target anchor.

---

- [ ] **3750. Capitalize JavaScript correctly**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/get-methods.mdx?plain=1#L222

Replace “Javascript” with “JavaScript,” e.g., “We will use JavaScript libraries and tools for the examples below:”.

---

- [ ] **3751. Add Testnet endpoint hint**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/get-methods.mdx?plain=1#L239-L257

Add a comment in the code sample showing the Testnet endpoint: https://testnet.toncenter.com/api/v2/jsonRPC.

---

- [ ] **3752. Update Sandbox repository link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/get-methods.mdx?plain=1#L265

Change the link to https://github.com/ton-org/sandbox/ for consistency.

---

- [ ] **3753. Replace “pure functions” with “deterministic”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/get-methods.mdx?plain=1#L298

Rephrase to: “Smart contracts in TON are deterministic: for the same state and input, they produce the same output.”

---

- [ ] **3754. Link to sending messages page**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/get-methods.mdx?plain=1#L346

Add a link for “default message headers (see sending messages page)” to /v3/documentation/smart-contracts/message-management/sending-messages.

---

- [ ] **3755. Clarify get methods cannot mutate state**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/get-methods.mdx?plain=1#L364-L368

Replace the awkward sentence with: “Get methods must not change state; any attempted state changes have no effect.”

---

- [ ] **3756. Add ‘See also’ link to storage/get-methods tutorial**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/get-methods.mdx?plain=1#L376-L378

Augment the See also section with a link to docs/v3/guidelines/quick-start/developing-smart-contracts/func-tolk-folder/storage-and-get-methods/.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.