### PR TITLE
Split: update docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx
+++ b/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx
@@ -10,12 +10,12 @@ In this article, we'll explore an imaginary claim solution, identify its perform
 How does a typical claim solution work? Let's break it down.
 :::
 
-The user submits some form of proof to demonstrate eligibility for the claim. The solution verifies the proof and sends jettons to the user. In this case, `proof` refers to a [merkle proof](/v3/documentation/data-formats/tlb/exotic-cells#merkle-proof), but it could also be signed data or any other authorization method. To send jettons, we'll need a jetton wallet and minter. Additionally, we must prevent users from claiming twice—this requires a double-spend protection contract. And, of course, we'd like to monetize this, right? So, we'll need at least one fee wallet. Let's summarize:
+The user submits some form of proof to demonstrate eligibility for the claim. The solution verifies the proof and sends jettons to the user. In this case, `proof` refers to a [merkle proof](/v3/documentation/data-formats/tlb/exotic-cells#merkle-proof), but it could also be signed data or any other authorization method. To send jettons, we'll need a jetton wallet and minter. Additionally, we must prevent users from claiming twice—this requires a double-spend protection contract. And, of course, we'd like to monetize this, right? So, we'll need at least one claim wallet. Let's summarize:
 
 ### Distributor
 
-Takes the proof from the user, checks it, and releases jettons.
-StateInit: `(merkle_root, admin, fee_wallet_address)`.
+Takes the proof from the user, checks it, and releases the jettons.
+State init: `(merkle_root, admin, fee_wallet_address)`.
 
 ### Double spend
 
@@ -44,18 +44,18 @@ The initial design that comes to mind is as follows:
 6. The distributor releases jettons to the user.
 
 What's wrong with that?
-The round-trip from the double-spend contract back to the distributor is unnecessary; use a linear design.
+Looks like a loop is redundant here.
 
 ### V2
 
 A linear design is more effective:
 
 1. The user deploys the `double spend` contract, which proxies the proof to the distributor.
-2. The distributor verifies the `double spend` contract's address using the StateInit `(distributor_address, user_address?)`.
-3. The distributor checks the proof (with the user index included as part of the proof) and releases jettons.
+2. The distributor verifies the `double spend` contract's address using the state init `(distributor_address, user_address?)`.
+3. The distributor checks the proof (with the user index included as part of the proof) and releases the jettons.
 4. The distributor sends the fee to the fee wallet.
 
- 
+**More naive art**
 
 ## Shard optimizations
 
@@ -69,7 +69,7 @@ To build a fundamental understanding, refer to [wallet creation for different sh
 
 #### Distributor address
 
-We have full control over the distributor's data and can place it in any shard. How? Remember, a contract address is [derived from the hash of its initial code and initial data (StateInit)](/v3/documentation/smart-contracts/addresses#account-id). We can use one of the contract's data fields as a nonce and keep trying until we achieve the desired result. A good example of a nonce in actual contracts is the `subwalletId` or `publicKey` for a wallet contract. Any field that can be modified after deployment or doesn't impact the contract logic (like `subwalletId`) will work. You could even create an unused field explicitly for this purpose, as demonstrated by [vanity-contract](https://github.com/ton-community/vanity-contract).
+We have full control over the distributor's data and can place it in any shard. How? Remember, the contract address is [defined by its state](/v3/documentation/smart-contracts/addresses#account-id). We can use one of the contract's data fields as a nonce and keep trying until we achieve the desired result. A good example of a nonce in actual contracts is the `subwalletId` or `publicKey` for a wallet contract. Any field that can be modified after deployment or doesn't impact the contract logic (like `subwalletId`) will work. You could even create an unused field explicitly for this purpose, as demonstrated by [vanity-contract](https://github.com/ton-community/vanity-contract).
 
 #### Distributor jetton wallet
 
@@ -111,7 +111,7 @@ Here's the improved and more polished version of your text:
 
 #### Summary
 
-We can place the `double‑spend -> distributor -> distributor jetton wallet` chain in the same shard. What remains for other shards is the `distributor jetton wallet -> user jetton wallet -> user wallet` path.
+We can place the `double_spend -> dist -> dist_jetton` chain in the same shard. What remains for other shards is the `dist_jetton -> user_jetton -> user_wallet` path.
 
 ### How to deploy such a setup
 
@@ -128,11 +128,11 @@ Now, everything should be ready to go!
 ### V3
 
 1. Index tuning enables users to deploy the _double spend_ contract in the same shard.
-2. The distributor in the user's shard verifies the sending `double spend` address by checking the StateInit `(distributor_address, index)`.
+2. The distributor in the user's shard verifies the sending `double spend` address by checking the state init `(distributor_address, index)`.
 3. The distributor sends the fee to the fee wallet.
 4. The distributor checks the proof (with the user index included) and releases jettons via the jetton wallet in the same shard.
 
- 
+**More naive art**
 
 Is there anything wrong with this approach? Let's take a closer look.  
 ...  
@@ -143,12 +143,12 @@ Yes, there is! There's only one fee wallet, and fees queue up to a single shard.
 1. It's the same as V3, but now there are 16 fee wallets, each in the same shard as its _distributor_.
 2. Make the _fee wallet_ address updatable.
 
- 
+**A bit more art**
 
 How about now? LGTM.
 
 ## What's next?
 
-We can always push further. For example, consider a custom [jetton wallet](https://github.com/ton-community/mintless-jetton/blob/main/contracts/jetton-utils.fc#L142) with built-in shard optimization. This ensures the user's jetton wallet ends up in the same shard as the user with high probability. However, this is relatively uncharted territory, so you'll need to explore it on your own. Good luck with your TGE!
+We can always push further. For example, consider a custom [jetton wallet](https://github.com/ton-community/mintless-jetton/blob/main/contracts/jetton-utils.fc#L142) with built-in shard optimization. This ensures the user's jetton wallet ends up in the same shard as the user with an 87% probability. However, this is relatively uncharted territory, so you'll need to explore it on your own. Good luck with your TGE!
 
 <Feedback />

--- a/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx
+++ b/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx
@@ -10,12 +10,12 @@ In this article, we'll explore an imaginary claim solution, identify its perform
 How does a typical claim solution work? Let's break it down.
 :::
 
-The user submits some form of proof to demonstrate eligibility for the claim. The solution verifies the proof and sends jettons to the user. In this case, `proof` refers to a [merkle proof](/v3/documentation/data-formats/tlb/exotic-cells#merkle-proof), but it could also be signed data or any other authorization method. To send jettons, we'll need a jetton wallet and minter. Additionally, we must prevent users from claiming twice—this requires a double-spend protection contract. And, of course, we'd like to monetize this, right? So, we'll need at least one claim wallet. Let's summarize:
+The user submits some form of proof to demonstrate eligibility for the claim. The solution verifies the proof and sends jettons to the user. In this case, `proof` refers to a [merkle proof](/v3/documentation/data-formats/tlb/exotic-cells#merkle-proof), but it could also be signed data or any other authorization method. To send jettons, we'll need a jetton wallet and minter. Additionally, we must prevent users from claiming twice—this requires a double-spend protection contract. And, of course, we'd like to monetize this, right? So, we'll need at least one fee wallet. Let's summarize:
 
 ### Distributor
 
-Takes the proof from the user, checks it, and releases the jettons.
-State init: `(merkle_root, admin, fee_wallet_address)`.
+Takes the proof from the user, checks it, and releases jettons.
+StateInit: `(merkle_root, admin, fee_wallet_address)`.
 
 ### Double spend
 
@@ -41,23 +41,21 @@ The initial design that comes to mind is as follows:
 3. The distributor sends a message to the double spend contract.
 4. If the double spend contract has not been deployed previously, it sends a `claim_ok` message to the distributor.
 5. The distributor sends the claim fee to the fee wallet.
-6. The distributor releases the jettons to the user.
-
-**NAIVE ART AHEAD!**
+6. The distributor releases jettons to the user.
 
 What's wrong with that?
-Looks like a loop is redundant here.
+The round-trip from the double-spend contract back to the distributor is unnecessary; use a linear design.
 
 ### V2
 
 A linear design is more effective:
 
 1. The user deploys the `double spend` contract, which proxies the proof to the distributor.
-2. The distributor verifies the `double spend` contract's address using the state init `(distributor_address, user_address?)`.
-3. The distributor checks the proof (with the user index included as part of the proof) and releases the jettons.
+2. The distributor verifies the `double spend` contract's address using the StateInit `(distributor_address, user_address?)`.
+3. The distributor checks the proof (with the user index included as part of the proof) and releases jettons.
 4. The distributor sends the fee to the fee wallet.
 
-**More naive art**
+ 
 
 ## Shard optimizations
 
@@ -71,7 +69,7 @@ To build a fundamental understanding, refer to [wallet creation for different sh
 
 #### Distributor address
 
-We have full control over the distributor's data and can place it in any shard. How? Remember, the contract address is [defined by its state](/v3/documentation/smart-contracts/addresses#account-id). We can use one of the contract's data fields as a nonce and keep trying until we achieve the desired result. A good example of a nonce in actual contracts is the `subwalletId` or `publicKey` for a wallet contract. Any field that can be modified after deployment or doesn't impact the contract logic (like `subwalletId`) will work. You could even create an unused field explicitly for this purpose, as demonstrated by [vanity-contract](https://github.com/ton-community/vanity-contract).
+We have full control over the distributor's data and can place it in any shard. How? Remember, a contract address is [derived from the hash of its initial code and initial data (StateInit)](/v3/documentation/smart-contracts/addresses#account-id). We can use one of the contract's data fields as a nonce and keep trying until we achieve the desired result. A good example of a nonce in actual contracts is the `subwalletId` or `publicKey` for a wallet contract. Any field that can be modified after deployment or doesn't impact the contract logic (like `subwalletId`) will work. You could even create an unused field explicitly for this purpose, as demonstrated by [vanity-contract](https://github.com/ton-community/vanity-contract).
 
 #### Distributor jetton wallet
 
@@ -113,7 +111,7 @@ Here's the improved and more polished version of your text:
 
 #### Summary
 
-We can place the `double_spend -> dist -> dist_jetton` chain in the same shard. What remains for other shards is the `dist_jetton -> user_jetton -> user_wallet` path.
+We can place the `double‑spend -> distributor -> distributor jetton wallet` chain in the same shard. What remains for other shards is the `distributor jetton wallet -> user jetton wallet -> user wallet` path.
 
 ### How to deploy such a setup
 
@@ -130,11 +128,11 @@ Now, everything should be ready to go!
 ### V3
 
 1. Index tuning enables users to deploy the _double spend_ contract in the same shard.
-2. The distributor in the user's shard verifies the sending `double spend` address by checking the state init `(distributor_address, index)`.
+2. The distributor in the user's shard verifies the sending `double spend` address by checking the StateInit `(distributor_address, index)`.
 3. The distributor sends the fee to the fee wallet.
 4. The distributor checks the proof (with the user index included) and releases jettons via the jetton wallet in the same shard.
 
-**More naive art**
+ 
 
 Is there anything wrong with this approach? Let's take a closer look.  
 ...  
@@ -145,13 +143,12 @@ Yes, there is! There's only one fee wallet, and fees queue up to a single shard.
 1. It's the same as V3, but now there are 16 fee wallets, each in the same shard as its _distributor_.
 2. Make the _fee wallet_ address updatable.
 
-**A bit more art**
+ 
 
 How about now? LGTM.
 
 ## What's next?
 
-We can always push further. For example, consider a custom [jetton wallet](https://github.com/ton-community/mintless-jetton/blob/main/contracts/jetton-utils.fc#L142) with built-in shard optimization. This ensures the user's jetton wallet ends up in the same shard as the user with an 87% probability. However, this is relatively uncharted territory, so you'll need to explore it on your own. Good luck with your TGE!
+We can always push further. For example, consider a custom [jetton wallet](https://github.com/ton-community/mintless-jetton/blob/main/contracts/jetton-utils.fc#L142) with built-in shard optimization. This ensures the user's jetton wallet ends up in the same shard as the user with high probability. However, this is relatively uncharted territory, so you'll need to explore it on your own. Good luck with your TGE!
 
 <Feedback />
-

--- a/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx
+++ b/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx
@@ -43,6 +43,8 @@ The initial design that comes to mind is as follows:
 5. The distributor sends the claim fee to the fee wallet.
 6. The distributor releases jettons to the user.
 
+**NAIVE ART AHEAD!**
+
 What's wrong with that?
 Looks like a loop is redundant here.
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-smart-contracts-howto-airdrop-claim-best-practice.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx`

Related issues (from issues.normalized.md):
- [ ] **3757. Hyphenate “double-spend” consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx?plain=1

Standardize all occurrences to “double‑spend” (including headings and inline identifiers), replacing “double spend” and “double_spend” when referring to the contract.

---

- [ ] **3758. Fix fragment in “Double-spend” section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx?plain=1

Rewrite the fragment to a complete sentence: “Receives a message; if already used, it bounces; otherwise, it forwards the message.”

---

- [ ] **3759. Tighten jetton subsection phrasing and “out of scope”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx?plain=1

Replace “Jetton wallet, where the tokens will be sent from by the distributor.” with “Jetton wallet from which the distributor sends the tokens.” and change “out of the scope” to “out of scope for this article.”

---

- [ ] **3760. Add period to “Fee wallet” sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx?plain=1

Add a terminal period to the sentence “Any kind of wallet contract.”

---

- [ ] **3761. Replace informal “Ok” opening**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx?plain=1

Change “Ok, we got something going, but what about shard optimizations?” to “Okay, we have something going, but what about shard optimizations?”

---

- [ ] **3762. Clarify shard definition wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx?plain=1

Replace “A shard is a 4-bit address prefix” with “Shard selection (the shard index) is determined by the first 4 bits of the contract address hash (the shard prefix).”

---

- [ ] **3763. Capitalize “Merkle” terms**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx?plain=1

Capitalize “Merkle” in phrases like “Merkle proof” and “Merkle root,” including link text and narrative.

---

- [ ] **3764. Label TL‑B code blocks and fix field formatting**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx?plain=1

Add the language tag “tlb” to TL‑B schema code fences and normalize field formatting (e.g., “addr_hash:uint256” with no spaces around colons).

---

- [ ] **3765. Remove editorial artifact sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx?plain=1

Delete the sentence “Here’s the improved and more polished version of your text:”.

---

- [ ] **3766. Remove “?” to mark optionality in tuple**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx?plain=1

Replace “StateInit (distributor_address, user_address?)” with “StateInit (distributor_address, optional user_address)” and explain optionality in prose rather than via a question mark.

---

- [ ] **3767. Clarify V3 verification phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx?plain=1

Replace “verifies the sending `double spend` address” with “verifies the `double‑spend` contract address by checking the StateInit (distributor_address, index)”.

---

- [ ] **3768. Remove casual interjections**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx?plain=1

Remove “LGTM.” and the aside “(Has this ever happened in real life?)” to maintain a professional tone.

---

- [ ] **3769. Standardize lowercase “jetton” in running text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx?plain=1

Use lowercase “jetton” in sentences (e.g., “jetton wallet”), reserving capitalization for headings or proper names.

---

- [ ] **3770. Expand abbreviations in summary chains**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx?plain=1

Expand “double_spend -> dist -> dist_jetton” to “double‑spend -> distributor -> distributor jetton wallet” and similarly expand “dist_jetton -> user_jetton -> user_wallet” to full names without underscores.

---

- [x] **3771. Use mass noun “jettons” (no article)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx?plain=1

Prefer “releases jettons” (no definite article) in running text.

---

- [ ] **3772. Use TL‑B term “StateInit”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx?plain=1

Replace “state init” with the TL‑B term “StateInit” wherever it refers to the structure (e.g., in summaries and V2/V3 steps).

---

- [ ] **3773. Align “claim wallet” with “fee wallet”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx?plain=1

Change “at least one claim wallet” in the introduction to “at least one fee wallet” to match later usage and field names.

---

- [ ] **3774. Make address derivation wording precise**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx?plain=1

Replace “the contract address is defined by its state” with “a contract address is derived from the hash of its initial code and initial data (StateInit)”.

---

- [ ] **3775. Use canonical TL‑B casing “Hashmap”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx?plain=1

Replace “HashMap” with “Hashmap” (e.g., “Hashmap 64”, “Hashmap 256”) to match TL‑B type casing.

---

- [ ] **3776. Verify key width “Hashmap 267”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx?plain=1

Confirm whether “Hashmap 267” is intentional; if it is a placeholder, change to “Hashmap 256,” or otherwise add a brief note explaining the nonstandard width.

---

- [ ] **3777. Remove placeholder “naive art” lines**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx?plain=1

Delete placeholders like “NAIVE ART AHEAD!”, “More naive art”, and “A bit more art” or replace them with actual figures and captions.

---

- [ ] **3778. Avoid unsupported numeric claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx?plain=1

Replace the unsourced “87% probability” statement with a qualitative phrase (e.g., “with high probability”) or add a citation if a precise probability is documented.

---

- [ ] **3779. Clarify which loop is redundant**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/airdrop-claim-best-practice.mdx?plain=1

Replace “Looks like a loop is redundant here.” with a specific statement (e.g., “The round‑trip from the double‑spend contract back to the distributor is unnecessary; use a linear design.”).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.