### PR TITLE
Split: update docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx
+++ b/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx
@@ -28,25 +28,26 @@ git clone --recurse-submodules https://github.com/ton-blockchain/ton.git
    - `cmake` version 3.0.2 or later
    - `g++` or `clang` (or another C++14-compatible compiler as appropriate for your operating system).
    - OpenSSL (including C header files) version 1.1.1 or later
-   - `git`, `build-essential`, `zlib1g-dev`, `gperf`, `libreadline-dev`, `ccache`, `libmicrohttpd-dev`, `pkg-config`, `libsodium-dev`, `libsecp256k1-dev`, `liblz4-dev`
+   - `build-essential`, `zlib1g-dev`, `gperf`, `libreadline-dev`, `ccache`, `libmicrohttpd-dev`, `pkg-config`, `libsodium-dev`, `libsecp256k1-dev`, `liblz4-dev`
 
 ### On Ubuntu
 
 ```bash
 sudo apt update
-sudo apt install git build-essential cmake clang openssl libssl-dev zlib1g-dev gperf libreadline-dev ccache libmicrohttpd-dev pkg-config libsodium-dev libsecp256k1-dev liblz4-dev
+sudo apt install build-essential cmake clang openssl libssl-dev zlib1g-dev gperf libreadline-dev ccache libmicrohttpd-dev pkg-config libsodium-dev libsecp256k1-dev liblz4-dev
 ```
 
 3. Suppose that you have fetched the source tree to directory `~/ton`, where `~` is your home directory, and that you have created an empty directory `~/ton-build`:
 
 ```bash
-mkdir -p ~/ton-build && cd ~/ton-build
+mkdir ton-build
 ```
 
 Then run the following in a terminal on Linux or macOS:
 Then run the following in a terminal on Linux or macOS:
 
 ```bash
+cd ton-build
 export CC=clang
 export CXX=clang++
 cmake -DCMAKE_BUILD_TYPE=Release ../ton && cmake --build . -j$(nproc)
@@ -112,42 +113,29 @@ cmake -GNinja -DCMAKE_BUILD_TYPE=Release .. \
 -DLZ4_LIBRARIES=$lz4Path/lib/liblz4.a \
 -DLZ4_INCLUDE_DIRS=$lz4Path/lib
 ```
-
-Before invoking CMake, create and enter a build directory (for example, `mkdir -p ~/ton-build && cd ~/ton-build`) and point CMake to the TON sources with `../ton`.
-
-Note: On Intel Macs, Homebrew may be installed under `/usr/local` instead of `/opt/homebrew`. Adjust paths like `/opt/homebrew/opt/llvm@16/...` accordingly.
-
-Build the project:
-
-```zsh
-cmake --build . -j$(sysctl -n hw.ncpu)
-```
-
-
-
 :::tip
-If you are compiling on a computer with low memory (e.g., 1 GiB), don't forget to [create swap space](/v3/guidelines/smart-contracts/howto/compile/instructions-low-memory).
+If you are compiling on a computer with low memory (e.g., 1 GiB), don't forget to [create swap partitions](/v3/guidelines/smart-contracts/howto/compile/instructions-low-memory).
 :::
 
 ## Download global config
 
-For tools like the Lite Client, download the global network config.
+For tools like the lite client, download the global network config.
 
-Download the newest configuration file from [https://ton.org/global-config.json](https://ton.org/global-config.json) for mainnet:
+Download the newest configuration file from [https://ton.org/global-config.json](https://ton-blockchain.github.io/global.config.json) for mainnet:
 
 ```bash
 wget https://ton-blockchain.github.io/global.config.json
 ```
 
-or from [https://ton.org/testnet-global.config.json](https://ton.org/testnet-global.config.json) for testnet:
+or from [https://ton.org/testnet-global.config.json](https://ton-blockchain.github.io/testnet-global.config.json) for testnet:
 
 ```bash
 wget https://ton-blockchain.github.io/testnet-global.config.json
 ```
 
-## Lite Client
+## Lite client
 
-To build the Lite Client, do [common part](/v3/guidelines/smart-contracts/howto/compile/compilation-instructions#common), [download the config](/v3/guidelines/smart-contracts/howto/compile/compilation-instructions#download-global-config), and then do:
+To build the lite client, do [common part](/v3/guidelines/smart-contracts/howto/compile/compilation-instructions#common), [download the config](/v3/guidelines/smart-contracts/howto/compile/compilation-instructions#download-global-config), and then do:
 
 ```bash
 cmake --build . --target lite-client

--- a/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx
+++ b/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx
@@ -9,16 +9,17 @@ If you still want to compile sources yourself, follow the instructions below.
 :::caution
 This is a simplified quick build guide.
 
-If you are building for production and not for home use, it's better to use [autobuild scripts](https://github.com/ton-blockchain/ton/tree/master/.github/workflows).
+If you are building for production and not for home use, it's better to use [GitHub Actions workflows for automatic builds](https://github.com/ton-blockchain/ton/tree/master/.github/workflows).
 :::
 
 ## Common
 
 The software is likely to compile and work properly on most Linux systems. It should work on macOS and even Windows.
 
-1. Download the newest version of TON Blockchain sources available at the GitHub repository https://github.com/ton-blockchain/ton/:
+1. Download the newest version of TON Blockchain sources available at the [GitHub repository](https://github.com/ton-blockchain/ton/):
 
 ```bash
+cd ~
 git clone --recurse-submodules https://github.com/ton-blockchain/ton.git
 ```
 
@@ -27,69 +28,71 @@ git clone --recurse-submodules https://github.com/ton-blockchain/ton.git
    - `cmake` version 3.0.2 or later
    - `g++` or `clang` (or another C++14-compatible compiler as appropriate for your operating system).
    - OpenSSL (including C header files) version 1.1.1 or later
-   - `build-essential`, `zlib1g-dev`, `gperf`, `libreadline-dev`, `ccache`, `libmicrohttpd-dev`, `pkg-config`, `libsodium-dev`, `libsecp256k1-dev`, `liblz4-dev`
+   - `git`, `build-essential`, `zlib1g-dev`, `gperf`, `libreadline-dev`, `ccache`, `libmicrohttpd-dev`, `pkg-config`, `libsodium-dev`, `libsecp256k1-dev`, `liblz4-dev`
 
 ### On Ubuntu
 
 ```bash
-apt update
-sudo apt install build-essential cmake clang openssl libssl-dev zlib1g-dev gperf libreadline-dev ccache libmicrohttpd-dev pkg-config libsodium-dev libsecp256k1-dev liblz4-dev
+sudo apt update
+sudo apt install git build-essential cmake clang openssl libssl-dev zlib1g-dev gperf libreadline-dev ccache libmicrohttpd-dev pkg-config libsodium-dev libsecp256k1-dev liblz4-dev
 ```
 
 3. Suppose that you have fetched the source tree to directory `~/ton`, where `~` is your home directory, and that you have created an empty directory `~/ton-build`:
 
 ```bash
-mkdir ton-build
+mkdir -p ~/ton-build && cd ~/ton-build
 ```
 
-Then run the following in a terminal of Linux or MacOS:
+Then run the following in a terminal on Linux or macOS:
+Then run the following in a terminal on Linux or macOS:
 
 ```bash
-cd ton-build
 export CC=clang
 export CXX=clang++
 cmake -DCMAKE_BUILD_TYPE=Release ../ton && cmake --build . -j$(nproc)
 ```
 
-### On MacOS
+Note: `-j$(nproc)` is Linux-specific. On macOS, use a fixed `-jN` or `-j$(sysctl -n hw.ncpu)`.
+Note: `-j$(nproc)` is Linux-specific. On macOS, use a fixed `-jN` or `-j$(sysctl -n hw.ncpu)`.
+### On macOS
 
-Prepare the system by installing required system packages
+Prepare the system by installing required system packages:
 
 ```zsh
 brew install ninja libsodium libmicrohttpd pkg-config automake libtool autoconf gnutls
 brew install llvm@16
 ```
 
-Use newly installed clang.
+Use the newly installed clang:
 
 ```zsh
-  export CC=/opt/homebrew/opt/llvm@16/bin/clang
-  export CXX=/opt/homebrew/opt/llvm@16/bin/clang++
+export CC=/opt/homebrew/opt/llvm@16/bin/clang
+export CXX=/opt/homebrew/opt/llvm@16/bin/clang++
 ```
 
-Compile secp256k1
+Compile secp256k1:
 
 ```zsh
-  git clone https://github.com/bitcoin-core/secp256k1.git
-  cd secp256k1
-  secp256k1Path=`pwd`
-  git checkout v0.3.2
-  ./autogen.sh
-  ./configure --enable-module-recovery --enable-static --disable-tests --disable-benchmark
-  make -j12
+git clone https://github.com/bitcoin-core/secp256k1.git
+cd secp256k1
+secp256k1Path=`pwd`
+git checkout v0.3.2
+./autogen.sh
+./configure --enable-module-recovery --enable-static --disable-tests --disable-benchmark
+make -j12
 ```
 
 and lz4:
 
 ```zsh
-  git clone https://github.com/lz4/lz4
-  cd lz4
-  lz4Path=`pwd`
-  git checkout v1.9.4
-  make -j12
+git clone https://github.com/lz4/lz4
+cd lz4
+lz4Path=`pwd`
+git checkout v1.9.4
+make -j12
 ```
 
-and relink OpenSSL 3.0
+Relink OpenSSL 3.0:
 
 ```zsh
 brew unlink openssl@1.1
@@ -97,7 +100,7 @@ brew install openssl@3
 brew unlink openssl@3 &&  brew link --overwrite openssl@3
 ```
 
-Now you can compile TON
+Now you can compile TON:
 
 ```zsh
 cmake -GNinja -DCMAKE_BUILD_TYPE=Release .. \
@@ -110,31 +113,41 @@ cmake -GNinja -DCMAKE_BUILD_TYPE=Release .. \
 -DLZ4_INCLUDE_DIRS=$lz4Path/lib
 ```
 
+Before invoking CMake, create and enter a build directory (for example, `mkdir -p ~/ton-build && cd ~/ton-build`) and point CMake to the TON sources with `../ton`.
+
+Note: On Intel Macs, Homebrew may be installed under `/usr/local` instead of `/opt/homebrew`. Adjust paths like `/opt/homebrew/opt/llvm@16/...` accordingly.
+
+Build the project:
+
+```zsh
+cmake --build . -j$(sysctl -n hw.ncpu)
+```
+
 
 
 :::tip
-If you are compiling on a computer with low memory (e.g., 1 Gb), don't forget to [create a swap partitions](/v3/guidelines/smart-contracts/howto/compile/instructions-low-memory).
+If you are compiling on a computer with low memory (e.g., 1 GiB), don't forget to [create swap space](/v3/guidelines/smart-contracts/howto/compile/instructions-low-memory).
 :::
 
 ## Download global config
 
-For tools like lite client you need to download the global network config.
+For tools like the Lite Client, download the global network config.
 
-Download the newest configuration file from https://ton-blockchain.github.io/global.config.json for mainnet:
+Download the newest configuration file from [https://ton.org/global-config.json](https://ton.org/global-config.json) for mainnet:
 
 ```bash
 wget https://ton-blockchain.github.io/global.config.json
 ```
 
-or from https://ton-blockchain.github.io/testnet-global.config.json for testnet:
+or from [https://ton.org/testnet-global.config.json](https://ton.org/testnet-global.config.json) for testnet:
 
 ```bash
 wget https://ton-blockchain.github.io/testnet-global.config.json
 ```
 
-## Lite client
+## Lite Client
 
-To build a lite client, do [common part](/v3/guidelines/smart-contracts/howto/compile/compilation-instructions#common), [download the config](/v3/guidelines/smart-contracts/howto/compile/compilation-instructions#download-global-config), and then do:
+To build the Lite Client, do [common part](/v3/guidelines/smart-contracts/howto/compile/compilation-instructions#common), [download the config](/v3/guidelines/smart-contracts/howto/compile/compilation-instructions#download-global-config), and then do:
 
 ```bash
 cmake --build . --target lite-client
@@ -147,7 +160,7 @@ Run the Lite Client with config:
 ```
 
 If everything was installed successfully, the Lite Client will connect to a special server (a full node for the TON Blockchain Network) and will send some queries to the server.
-If you indicate a writeable "database" directory as an extra argument to the client, it will download and save the block and the state corresponding to the newest masterchain block:
+If you indicate a writable "database" directory as an extra argument to the client, it will download and save the block and the state corresponding to the newest masterchain block:
 
 ```bash
 ./lite-client/lite-client -C global.config.json -D ~/ton-db-dir
@@ -180,10 +193,10 @@ cmake --build . --target fift
 To run Fift script:
 
 ```bash
-./crypto/fift -s script.fif script_param0 script_param1 ..
+./crypto/fift -s script.fif script_param0 script_param1 ...
 ```
 
-## Tonlib-cli
+## tonlib-cli
 
 To build tonlib-cli, do [common part](/v3/guidelines/smart-contracts/howto/compile/compilation-instructions#common), [download the config](/v3/guidelines/smart-contracts/howto/compile/compilation-instructions#download-global-config) and then do:
 
@@ -243,7 +256,7 @@ The binary will be located at:
 
 # Compile old TON versions
 
-TON releases: https://github.com/ton-blockchain/ton/tags
+TON releases: [https://github.com/ton-blockchain/ton/tags](https://github.com/ton-blockchain/ton/tags)
 
 ```bash
 git clone https://github.com/ton-blockchain/ton.git
@@ -272,7 +285,6 @@ To compile older TON revisions on Apple M1:
    git checkout fcf3d75f3f022a6a55ff1222d6b06f8518d38c7c
    ```
 
-2. Replace root `CMakeLists.txt` by https://github.com/ton-blockchain/ton/blob/c00302ced4bc4bf1ee0efd672e7c91e457652430/CMakeLists.txt
+2. Replace root `CMakeLists.txt` by [https://github.com/ton-blockchain/ton/blob/c00302ced4bc4bf1ee0efd672e7c91e457652430/CMakeLists.txt](https://github.com/ton-blockchain/ton/blob/c00302ced4bc4bf1ee0efd672e7c91e457652430/CMakeLists.txt)
 
 <Feedback />
-

--- a/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx
+++ b/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx
@@ -114,7 +114,7 @@ cmake -GNinja -DCMAKE_BUILD_TYPE=Release .. \
 -DLZ4_INCLUDE_DIRS=$lz4Path/lib
 ```
 :::tip
-If you are compiling on a computer with low memory (e.g., 1 GiB), don't forget to [create swap partitions](/v3/guidelines/smart-contracts/howto/compile/instructions-low-memory).
+If you are compiling on a computer with low memory (e.g., 1 Gb), don't forget to [create swap partitions](/v3/guidelines/smart-contracts/howto/compile/instructions-low-memory).
 :::
 
 ## Download global config


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-smart-contracts-howto-compile-compilation-instructions.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx`

Related issues (from issues.normalized.md):
- [ ] **3780. Standardize "macOS" capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx?plain=1

Replace all instances of "MacOS" with "macOS" in headings and prose.

---

- [ ] **3781. Fix wording: "terminal of" → "terminal on"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx?plain=1#common

Change “Then run the following in a terminal of Linux or MacOS:” to “Then run the following in a terminal on Linux or macOS:”.

---

- [x] **3782. Prepend sudo to Ubuntu apt update**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx?plain=1#on-ubuntu

In the Ubuntu section, change `apt update` to `sudo apt update` to match typical non-root usage.

---

- [ ] **3783. Make ton/ton-build paths consistent**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx?plain=1#common

Ensure the documented layout matches the commands by adding `cd ~` before `git clone`, using `mkdir -p ~/ton-build && cd ~/ton-build`, and running `cmake ... ../ton`.

---

- [x] **3784. Add macOS build step after CMake**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx?plain=1#on-macos

After the CMake configure command, add a build invocation, e.g., `cmake --build . -j$(sysctl -n hw.ncpu)` (or `ninja -j$(sysctl -n hw.ncpu)` if using Ninja).

---

- [x] **3785. Add colons before code blocks**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx?plain=1

End sentences that introduce code blocks with colons, e.g., “Use the newly installed clang:”, “Relink OpenSSL 3.0:”, “Now you can compile TON:”.

---

- [ ] **3786. Remove leading spaces in macOS code blocks**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx?plain=1#on-macos

Delete the unnecessary two-space indent before commands in macOS code blocks to avoid copy-paste issues.

---

- [ ] **3787. Fix low-memory note grammar and units**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx?plain=1#common

Change “1 Gb” to “1 GB” and “a swap partitions” to “a swap partition”.

---

- [ ] **3788. Use "writable" instead of "writeable"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx?plain=1#lite-client

Replace “writeable” with the standard spelling “writable”.

---

- [ ] **3789. Use "Lite Client" consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx?plain=1

Use “Lite Client” for the tool name in headings and prose (keep lowercase only for the binary path if shown).

---

- [x] **3790. Lowercase heading: "tonlib-cli"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx?plain=1

Change the section heading “Tonlib-cli” to “tonlib-cli” to match the tool name.

---

- [ ] **3791. Use three-dot ellipsis in Fift example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx?plain=1

Change “..” to “...” in the Fift example to indicate omitted parameters.

---

- [x] **3792. Format bare URLs as Markdown links**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx?plain=1

Convert bare URLs to Markdown links, e.g., “available at the [GitHub repository](https://github.com/ton-blockchain/ton/)”; do similarly in the config download section.

---

- [ ] **3793. Clarify global config download sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx?plain=1#download-global-config

Rephrase to “For tools like the Lite Client, download the global network config.” for clarity and consistent capitalization.

---

- [ ] **3794. Include git in prerequisites and Ubuntu install**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx?plain=1

Add `git` to the prerequisites list and include it in the Ubuntu install command (`sudo apt install ... git`).

---

- [ ] **3795. Replace nproc in cross-platform example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx?plain=1#common

In the mixed Linux/macOS step, avoid Linux-only `nproc`; either scope the parallel build flag to Linux or provide a macOS alternative (e.g., `-j$(sysctl -n hw.ncpu)` or a fixed `-jN`).

---

- [ ] **3796. Create and enter build dir in macOS section before CMake**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx?plain=1#on-macos

Before invoking CMake, add `mkdir -p ~/ton-build && cd ~/ton-build` and configure with `cmake ... ../ton` to avoid running from the `lz4` directory.

---

- [ ] **3797. Note Homebrew prefix may differ on Intel Macs**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx?plain=1#on-macos

Add a note that Homebrew may be under `/usr/local` on Intel Macs; adjust paths like `/opt/homebrew/opt/llvm@16/...` accordingly.

---

- [x] **3798. Use canonical ton.org URLs for global configs**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx?plain=1#download-global-config

Replace `https://ton-blockchain.github.io/global.config.json` and its testnet variant with `https://ton.org/global-config.json` and `https://ton.org/testnet-global.config.json` to align with other pages.

---

- [x] **3799. Clarify “autobuild scripts” link label**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/compilation-instructions.mdx?plain=1

Change the link text “autobuild scripts” to “GitHub Actions workflows for automatic builds” (keep the same target) to better describe the link.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.