### PR TITLE
Split: update docs/v3/guidelines/smart-contracts/howto/compile/instructions-low-memory.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/smart-contracts/howto/compile/instructions-low-memory.mdx
+++ b/docs/v3/guidelines/smart-contracts/howto/compile/instructions-low-memory.mdx
@@ -6,26 +6,26 @@ import Feedback from '@site/src/components/Feedback';
 This section provides low-level instructions for working with TON.
 :::
 
-To compile TON on systems with limited memory (< 1 GB), you need to create swap partitions.
+To compile TON on systems with limited memory (< 1 GiB), you need to create swap space (using a swap file).
 
-## Prerequisites
+## Symptoms
 
 When compiling C++ components on Linux, you may encounter memory-related failures:
 
-```
-C++: fatal error: Killed signal terminated program cc1plus
+```text
+fatal error: Killed signal terminated program cc1plus
 compilation terminated.
 ```
 
 ## Solution
 
-Follow these steps to create a 4GB swap partition:
+Follow these steps to create a 4 GiB swap file:
 
 ```bash
-# Create swap partition
+# Create swap directory
 sudo mkdir -p /var/cache/swap/
 
-# Allocate 4GB swap space (64MB blocks × 64)
+# Allocate 4 GiB swap space (64 MiB blocks × 64)
 sudo dd if=/dev/zero of=/var/cache/swap/swap0 bs=64M count=64
 
 # Set secure permissions
@@ -43,7 +43,7 @@ sudo swapon -s
 
 ### Swap management commands
 
-**Remove swap partition:**
+**Remove swap file:**
 
 ```bash
 sudo swapoff /var/cache/swap/swap0
@@ -54,8 +54,21 @@ sudo rm /var/cache/swap/swap0
 
 ```bash
 sudo swapoff -a
-# Check memory: free -m
+free -m
+```
+
+### Make swap persistent (optional)
+
+To enable the swap file on boot, add the following line to `/etc/fstab`:
+
+```text
+/var/cache/swap/swap0 none swap sw 0 0
+```
+
+After reboot, verify with:
+
+```bash
+sudo swapon --show
 ```
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-smart-contracts-howto-compile-instructions-low-memory.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/smart-contracts/howto/compile/instructions-low-memory.mdx`

Related issues (from issues.normalized.md):
- [ ] **3800. Replace “swap partition” with “swap file/space”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/instructions-low-memory.mdx?plain=1

Replace references to partitions with file-based swap to match the procedure: L9 “create swap partitions.” → “create swap space (using a swap file).”; L22 “create a 4GB swap partition:” → “create a 4 GiB swap file:”; L25 comment → “# Create swap directory” (if creating /var/cache/swap); L46 “Remove swap partition:” → “Remove swap file:”.

---

- [ ] **3801. Standardize size units and spacing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/instructions-low-memory.mdx?plain=1

Use consistent binary units with spaces and align with dd semantics: “< 1 GB” → “< 1 GiB” (L9), “4GB” → “4 GiB” (L22), “64MB” → “64 MiB” and “(64 MiB blocks × 64)” (L28 and its comment).

---

- [ ] **3802. Rename “Prerequisites” section to “Symptoms”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/instructions-low-memory.mdx?plain=1#L11-L18

The section shows an error symptom rather than requirements; change the heading “Prerequisites” to “Symptoms.”

---

- [ ] **3803. Fix error snippet prefix and add language tag**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/instructions-low-memory.mdx?plain=1#L15-L18

Remove the misleading “C++:” prefix from the error message (use a neutral line without a tool prefix) and mark the fenced block as text (```text```).

---

- [ ] **3804. Make “Free all swap space” commands runnable**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/instructions-low-memory.mdx?plain=1

Remove the leading “#” before “free -m” so the memory check runs when copied (e.g., “sudo swapoff -a” followed by “free -m” on the next line).

---

- [ ] **3805. Add optional swap persistence instructions**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/compile/instructions-low-memory.mdx?plain=1

Document making the swap file persistent by adding “/var/cache/swap/swap0 none swap sw 0 0” to /etc/fstab and noting verification after reboot with “sudo swapon --show.”

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.