### PR TITLE
Split: update docs/v3/guidelines/smart-contracts/howto/multisig-js.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/smart-contracts/howto/multisig-js.mdx
+++ b/docs/v3/guidelines/smart-contracts/howto/multisig-js.mdx
@@ -243,7 +243,7 @@ You can access public properties from `MultisigWallet`, `MultisigOrderBuilder`, 
 
 - **MultisigWallet**:
 
-  - `owners`: `Dictionary<number, Buffer>` of owner public keys (`ownerId => publicKey`).
+  - `owners`: `Dictionary<number, Buffer>` of signatures (`ownerId => signature`).
   - `workchain`: Workchain where the wallet is deployed.
   - `walletId`: Wallet ID.
   - `k`: Number of signatures required to confirm a transaction.

--- a/docs/v3/guidelines/smart-contracts/howto/multisig-js.mdx
+++ b/docs/v3/guidelines/smart-contracts/howto/multisig-js.mdx
@@ -243,7 +243,7 @@ You can access public properties from `MultisigWallet`, `MultisigOrderBuilder`, 
 
 - **MultisigWallet**:
 
-  - `owners`: `Dictionary<number, Buffer>` of signatures (`ownerId => signature`).
+  - `owners`: `Dictionary<number, Buffer>` of owner public keys (`ownerId => publicKey`).
   - `workchain`: Workchain where the wallet is deployed.
   - `walletId`: Wallet ID.
   - `k`: Number of signatures required to confirm a transaction.
@@ -264,8 +264,7 @@ You can access public properties from `MultisigWallet`, `MultisigOrderBuilder`, 
 ## References
 
 - [Low-level multisig guide](/v3/guidelines/smart-contracts/howto/multisig)
-- [ton.js Documentation](https://ton-community.github.io/ton/)
-- [Multisig contract sources](https://github.com/ton-blockchain/multisig-contract)
+ - [ton.js Documentation](https://ton-community.github.io/ton/)
+ - [Multisig contract sources](https://github.com/ton-blockchain/multisig-contract-v2)
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-smart-contracts-howto-multisig-js.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/smart-contracts/howto/multisig-js.mdx`

Related issues (from issues.normalized.md):
- [ ] **3806. Fix frontmatter description grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig-js.mdx?plain=1#L2

Change to: "At the end of this guide, you will deploy a multisig wallet and send transactions using the TON TypeScript libraries."

---

- [ ] **3807. Reword outdated warning banner**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig-js.mdx?plain=1#L8-L12

Replace maintainer-focused, tool-specific text with a reader-facing, tool-agnostic note, e.g., "This page is outdated; prefer multisig-contract-v2. Use npm or Yarn. The examples below may not reflect current APIs."; apply the same change to the second banner at lines 25–28.

---

- [ ] **3808. Tag TypeScript code blocks correctly**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig-js.mdx?plain=1#L43

Code fences containing TypeScript (e.g., at L43, L72, L94, L101, L118, L143, L151, L178, L187) are tagged as js; change their language tag to ts for correct highlighting and signaling.

---

- [ ] **3809. Avoid top-level await or configure ESM**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig-js.mdx?plain=1#L63-L66

Top-level await will fail under CommonJS; either wrap the example in an async main() with main().catch(console.error) or switch to ESM (e.g., "module": "esnext" in tsconfig and "type": "module" in package.json) on a Node version that supports it.

---

- [ ] **3810. Update packages and imports to @ton/* scope**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig-js.mdx?plain=1

Update install commands and imports to the canonical packages: yarn add @ton/ton @ton/core @ton/crypto @types/node buffer @orbs-network/ton-access; and use imports such as import { TonClient, WalletContractV4, Address } from "@ton/ton"; import { beginCell, toNano } from "@ton/core"; import { KeyPair, mnemonicToPrivateKey } from "@ton/crypto".

---

- [ ] **3811. Use provider pattern for internal deploy**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig-js.mdx?plain=1

Replace direct provider usage with the current pattern: const provider = client.open(wallet); await mw.deployInternal(provider.sender(keyPairs[4].secretKey), toNano("0.05")).

---

- [ ] **3812. Explain send mode magic number**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig-js.mdx?plain=1

Annotate order1.addMessage(msg, 3) to clarify that 3 is the send mode (1 + 2) and link to docs/v3/documentation/smart-contracts/message-management/sending-messages.mdx#mode3; adjust if a different mode is intended.

---

- [ ] **3813. Fix MultisigWallet.owners description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig-js.mdx?plain=1#L246-L251

Change from signatures to public keys: "owners: Dictionary<number, Buffer> of owner public keys (ownerId => publicKey)."

---

- [x] **3814. Update References to multisig-contract-v2**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig-js.mdx?plain=1#L268

Replace the old link to https://github.com/ton-blockchain/multisig-contract with https://github.com/ton-blockchain/multisig-contract-v2 to match the banner and current recommendations.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.