### PR TITLE
Split: update docs/v3/guidelines/smart-contracts/howto/multisig.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/smart-contracts/howto/multisig.mdx
+++ b/docs/v3/guidelines/smart-contracts/howto/multisig.mdx
@@ -1,13 +1,12 @@
----
-description: At the end of the tutorial, you will have deployed multisig contract in TON Blockchain.
+description: At the end of the tutorial, you will have deployed a multisig contract on the TON blockchain.
 ---
 
 import Feedback from '@site/src/components/Feedback';
 
-# Make a simple multisig contract with fift
+# Make a Simple Multisig Contract with Fift
 
 :::caution advanced level
-This information is **very low-level**. It could be hard for newcomers and designed for advanced people who want to understand [fift](/v3/documentation/smart-contracts/fift/overview). The use of fift is not required in everyday tasks.
+This information is **very low-level**. It could be hard for newcomers and designed for advanced people who want to understand [Fift](/v3/documentation/smart-contracts/fift/overview). The use of Fift is not required in everyday tasks.
 :::
 
 ## 💡 Overview
@@ -18,7 +17,7 @@ Recall that an (n, k)-multisig contract is a multisignature wallet with n privat
 Based on the original multisig contract code and updates by akifoq:
 
 - [Original TON Blockchain multisig-code.fc](https://github.com/ton-blockchain/ton/blob/master/crypto/smartcont/multisig-code.fc)
-- [akifoq/multisig](https://github.com/akifoq/multisig) with fift libraries to work with multisig.
+- [akifoq/multisig](https://github.com/akifoq/multisig) with Fift libraries to work with multisig.
 
 :::tip starter tip
 For anyone new to multisig: [What is Multisig Technology? (video)](https://www.youtube.com/watch?v=yeLqe_gg2u0)
@@ -27,24 +26,24 @@ For anyone new to multisig: [What is Multisig Technology? (video)](https://www.y
 ## 📖 What you'll learn
 
 - How to create and customize a simple multisig wallet.
-- How to deploy a multisig wallet using lite-client.
+- How to deploy a multisig wallet using Lite Client.
 - How to sign a request and send it in a message to the blockchain.
 
-## ⚙ Set your environment
+## ⚙ Set up your environment
 
 Before we begin our journey, check and prepare your environment.
 
-- Install `func`, `fift`, `lite-client` binaries, and `fiftlib` from the [Installation](/v3/documentation/archive/precompiled-binaries) section.
+- Install `func`, `fift`, `lite-client` binaries, and `fiftlib` from the [Precompiled binaries](/v3/documentation/archive/precompiled-binaries) section.
 - Clone the [repository](https://github.com/akifoq/multisig) and open its directory in CLI.
 
 ```bash
 git clone https://github.com/akifoq/multisig.git
-cd ~/multisig
+cd ./multisig
 ```
 
 ## 🚀 Let's get started!
 
-1. Compile the code to fift.
+1. Compile the code to Fift.
 2. Prepare multisig owners' keys.
 3. Deploy your contract.
 4. Interact with the deployed multisig wallet in the blockchain.
@@ -53,7 +52,7 @@ cd ~/multisig
 
 Compile the contract to Fift with:
 
-```cpp
+```bash
 func -o multisig-code.fif -SPA stdlib.fc multisig-code.fc
 ```
 
@@ -63,7 +62,7 @@ func -o multisig-code.fif -SPA stdlib.fc multisig-code.fc
 
 To create a key, you need to run:
 
-```cpp
+```bash
 fift -s new-key.fif $KEY_NAME$
 ```
 
@@ -71,7 +70,7 @@ fift -s new-key.fif $KEY_NAME$
 
 For example:
 
-```cpp
+```bash
 fift -s new-key.fif multisig_key
 ```
 
@@ -85,13 +84,13 @@ Also, the script will issue a public key in the format:
 Public key = Pub5XqPLwPgP8rtryoUDg2sadfuGjkT4DLRaVeIr08lb8CB5HW
 ```
 
-Anything after `"Public key = "` needs to be saved somewhere!
+Anything after `Public key = ` needs to be saved somewhere!
 
 Let's store it in a file called `keys.txt`. It's important to have one public key per line.
 
 ### Deploy your contract
 
-#### Deploy via lite-client
+#### Deploy via `lite-client`
 
 After creating all the keys, you need to collect the public keys into a text file, `keys.txt`.
 
@@ -104,15 +103,15 @@ PubH821csswh8R1uO9rLYyP1laCpYWxhNkx+epOkqwdWXgzY4
 
 After that, you need to run:
 
-```cpp
+```bash
 fift -s new-multisig.fif 0 $WALLET_ID$ wallet $KEYS_COUNT$ ./keys.txt
 ```
 
-- `$WALLET_ID$` - the wallet number assigned for the current key. It is recommended that each new wallet with the same key use a unique `$WALLET_ID$`.
-- `$KEYS_COUNT$` - the number of keys needed for confirmation, usually equal to the number of public keys.
+ - `$WALLET_ID$`: the wallet number assigned to the current key. It is recommended that each new wallet with the same key use a unique `$WALLET_ID$`.
+ - `$KEYS_COUNT$`: the number of keys needed for confirmation, usually equal to the number of public keys.
 
-:::info wallet_id explained
-It is possible to create many wallets with the same keys (Alice key, Bob key). What should we do if Alice and Bob already have a treasure? That's why `$WALLET_ID$` is crucial here.
+:::info Wallet ID explained
+It is possible to create many wallets with the same keys (Alice key, Bob key). What should we do if Alice and Bob already share a wallet? That's why `$WALLET_ID$` is crucial here.
 :::
 
 The script will output something like:
@@ -130,18 +129,18 @@ Bounceable address (for later access): kQBLuyZgCX21xy3V6QhhFQEPD4yFAeC4_vH-MY2d5
 ```
 
 :::info
-If you have a "public key must be 48 characters long" error, please make sure your `keys.txt` has a Unix-type word wrap - LF. For example, word wrap can be changed via the Sublime text editor.
+If you have a "public key must be 48 characters long" error, please make sure your `keys.txt` uses Unix-style line endings (LF). For example, line endings can be changed via Sublime Text.
 :::
 
 :::tip
-A bounceable address is better to keep - this is the wallet's address.
+Keep the bounceable address — this is the wallet address.
 :::
 
 #### Activate your contract
 
-You need to send some TON to our newly generated _treasure_. For example, 0.5 TON. You can send testnet coins via [@testgiver_ton_bot](https://t.me/testgiver_ton_bot).
+You need to send some TON to the newly generated wallet. For example, 0.5 TON. You can send testnet coins via [@testgiver_ton_bot](https://t.me/testgiver_ton_bot).
 
-After that, you need to run lite-client:
+After that, run `lite-client`:
 
 ```bash
 lite-client -C global.config.json
@@ -151,17 +150,17 @@ lite-client -C global.config.json
 You can get a fresh config file `global.config.json` for [mainnet](https://ton.org/global-config.json) or [testnet](https://ton.org/testnet-global.config.json).
 :::
 
-After starting lite-client, it's best to run the `time` command in the lite-client console to make sure the connection was successful:
+After starting Lite Client, it's best to run the `time` command in the `lite-client` console to make sure the connection was successful:
 
 ```bash
 time
 ```
 
-Okay, lite-client works!
+Okay, Lite Client works!
 
 After that, you need to deploy the wallet. Run the command:
 
-```
+```bash
 sendfile ./wallet-create.boc
 ```
 
@@ -173,17 +172,17 @@ After that, the wallet will be ready to work within a minute.
 
 First, you need to create a message request:
 
-```cpp
+```bash
 fift -s create-msg.fif $ADDRESS$ $AMOUNT$ $MESSAGE$
 ```
 
 - `$ADDRESS$` - address where to send coins.
-- `$AMOUNT$` - number of coins.
+- `$AMOUNT$` - number of coins (in TON).
 - `$MESSAGE$` - the file name for the compiled message.
 
 For example:
 
-```cpp
+```bash
 fift -s create-msg.fif EQApAj3rEnJJSxEjEHVKrH3QZgto_MQMOmk8l72azaXlY1zB 0.1 message
 ```
 
@@ -195,27 +194,27 @@ Use the `-C comment` attribute to add a comment for your transaction. To get mor
 
 Next, you need to choose a wallet to send coins from:
 
-```
+```bash
 fift -s create-order.fif $WALLET_ID$ $MESSAGE$ -t $AWAIT_TIME$
 ```
 
 Where
 
-- `$WALLET_ID$` — is an ID of the wallet backed by this multisig contract.
-- `$AWAIT_TIME$` — Time in seconds that the smart contract will await signs from multisig wallet's owners for the request.
-- `$MESSAGE$` — here is the name of the message boc-file created in the previous step.
+- `$WALLET_ID$` — ID of the wallet backed by this multisig contract.
+- `$AWAIT_TIME$` — time in seconds the smart contract will await signatures from the multisig wallet owners for the request.
+- `$MESSAGE$` — name of the message BoC file created in the previous step.
 
 :::info
-The request expires if the time equals `$AWAIT_TIME$` passed before the request signs. As usual, `$AWAIT_TIME$` equals a couple of hours (7200 seconds).
+The request expires if `$AWAIT_TIME$` elapses before the request is signed. As usual, `$AWAIT_TIME$` equals a couple of hours (7200 seconds).
 :::
 
 For example:
 
-```
+```bash
 fift -s create-order.fif 0 message -t 7200
 ```
 
-The ready file will be saved in `order.boc`.
+The resulting file is saved as `order.boc`.
 
 :::info
 `order.boc` must be shared with key holders; they must sign it.
@@ -223,7 +222,7 @@ The ready file will be saved in `order.boc`.
 
 #### Sign your part
 
-To sign, you need to do:
+To sign, run:
 
 ```bash
 fift -s add-signature.fif $KEY$ $KEY_INDEX$
@@ -234,7 +233,7 @@ fift -s add-signature.fif $KEY$ $KEY_INDEX$
 
 For example, for our `multisig_key.pk` file:
 
-```
+```bash
 fift -s add-signature.fif multisig_key 0
 ```
 
@@ -242,21 +241,21 @@ fift -s add-signature.fif multisig_key 0
 
 After everyone has signed the order, it needs to be turned into a message for the wallet and signed again with the following command:
 
-```
+```bash
 fift -s create-external-message.fif wallet $KEY$ $KEY_INDEX$
 ```
 
-In this case, only one sign of the wallet's owner will be enough. The idea is that you can't attack a contract with invalid signatures.
+In this case, only one signature from a wallet owner is enough. The idea is that you can't attack a contract with invalid signatures.
 
 For example:
 
-```
+```bash
 fift -s create-external-message.fif wallet multisig_key 0
 ```
 
-#### Send sign to TON blockchain
+#### Send the signed message to the TON blockchain
 
-After that, you need to start the light client again:
+After that, start `lite-client` again:
 
 ```bash
 lite-client -C global.config.json
@@ -270,11 +269,11 @@ sendfile wallet-query.boc
 
 If everyone else signed the request, it will be completed!
 
-You did it, ha-ha! 🚀🚀🚀
+You did it!
 
 ## See also
 
-- [Read more about multisig wallets in TON](https://github.com/akifoq/multisig) — _[@akifoq](https://t.me/aqifoq)_
+- [Read more about multisig wallets in TON](https://github.com/akifoq/multisig) — _[@akifoq](https://t.me/akifoq)_
 - [Multisig wallet v2](https://github.com/ton-blockchain/multisig-contract-v2)
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-smart-contracts-howto-multisig.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/smart-contracts/howto/multisig.mdx`

Related issues (from issues.normalized.md):
- [ ] **3815. Fix frontmatter description grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig.mdx?plain=1#L2

Change to: "At the end of the tutorial, you will have deployed a multisig contract on the TON blockchain."

---

- [ ] **3816. Capitalize page title (Fift)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig.mdx?plain=1#L7

Change the title to "Make a Simple Multisig Contract with Fift" (at minimum, capitalize "Fift").

---

- [ ] **3817. Capitalize “Fift” consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig.mdx?plain=1#L10,L47,L54

Use “Fift” (proper case) in all occurrences, e.g., "The use of Fift..." and "Compile the code to Fift."

---

- [ ] **3818. Change section heading to “Set up your environment”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig.mdx?plain=1#L33

Rename "Set your environment" to "Set up your environment."

---

- [ ] **3819. Fix clone directory path**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig.mdx?plain=1#L41-L43

After cloning, use "cd multisig" (or "cd ./multisig") instead of "cd ~/multisig".

---

- [ ] **3820. Use bash fences for shell and Lite Client commands**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig.mdx?plain=1#L56,L66,L74,L107,L176,L186

Change command fences from cpp to bash at L56, L66, L74, L107, L176, and L186, and add bash fences to Lite Client console snippets (e.g., sendfile commands) for consistent highlighting.

---

- [ ] **3821. Remove escaped quotes in public key note**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig.mdx?plain=1#L88

Change "Anything after `\"Public key = \"` needs to be saved..." to "Anything after `Public key = ` needs to be saved..."

---

- [ ] **3822. Standardize parameter descriptions and grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig.mdx?plain=1#L111-L112,L202-L206

Replace dashes with colons and fix grammar for $WALLET_ID$, $KEYS_COUNT$, $AWAIT_TIME$, and $MESSAGE$; use "message BoC file" in prose while keeping the .boc extension lowercase.

---

- [ ] **3823. Capitalize admonition title**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig.mdx?plain=1#L114

Change "wallet_id explained" to "Wallet ID explained".

---

- [ ] **3824. Replace “treasure” with “wallet”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig.mdx?plain=1#L115,L142

Use “wallet” instead of “treasure” (e.g., "...already share a wallet?" and "send some TON to the newly generated wallet").

---

- [ ] **3825. Fix line endings phrasing and product name**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig.mdx?plain=1#L132-L134

Use "Unix-style line endings (LF)" and "Sublime Text".

---

- [ ] **3826. Clarify bounceable address sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig.mdx?plain=1#L136-L138

Change to "Keep the bounceable address — this is the wallet address."

---

- [ ] **3827. Clarify request expiration wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig.mdx?plain=1#L208-L210

Change to "The request expires if $AWAIT_TIME$ elapses before the request is signed."

---

- [ ] **3828. Rephrase resulting file sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig.mdx?plain=1#L218

Change to "The resulting file is saved as `order.boc`."

---

- [ ] **3829. Rephrase signing instruction**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig.mdx?plain=1#L226

Change "To sign, you need to do:" to "To sign, run:".

---

- [ ] **3830. Use “signature” instead of “sign”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig.mdx?plain=1#L249

Change to "only one signature from a wallet owner is enough."

---

- [ ] **3831. Update section wording to “Send the signed message...”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig.mdx?plain=1#L257

Change "Send sign to TON blockchain" to "Send the signed message to the TON blockchain."

---

- [ ] **3832. Clarify Lite Client vs `lite-client` naming**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig.mdx?plain=1#L259

Refer to the tool as "Lite Client" and the command as `lite-client` (e.g., "start `lite-client` again") and update any heading to "Deploy via `lite-client`".

---

- [ ] **3833. Fix Telegram handle mismatch**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig.mdx?plain=1#L277

Make the Telegram handle/link consistent with the GitHub user "akifoq" (correct the "@akifoq" link currently pointing to https://t.me/aqifoq).

---

- [ ] **3834. Use glossary-consistent “BoC” capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig.mdx?plain=1

Refer to the format as "BoC — Bag of Cells" in prose (e.g., "message BoC file") while keeping file extensions like `.boc` lowercase.

---

- [ ] **3835. Specify $AMOUNT$ units**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig.mdx?plain=1

Explicitly state whether $AMOUNT$ values are in TON or nanotons to avoid ambiguity (the example uses 0.1).

---

- [ ] **3836. Tone down celebratory phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig.mdx?plain=1

Replace "You did it, ha-ha! 🚀🚀🚀" with a neutral "You did it!" (optional single emoji if desired).

---

- [ ] **3837. Match link text to destination title**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/multisig.mdx?plain=1

Change the "Installation" link text to "Precompiled binaries" to match /v3/documentation/archive/precompiled-binaries.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.