### PR TITLE
Split: update docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx
+++ b/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx
@@ -8,34 +8,39 @@ Before reading this tutorial, you should familiarize yourself with [nominator po
 
 ## Running the validator in nominator pool mode \{#validator-pool-mode}
 
-1. Set up the hardware for the validator - you will need 8 vCPUs, 128GB memory, 1TB SSD, a fixed IP address, and 1Gb/s internet speed.
+1. Set up the hardware for the validator — you will need 16 cores CPU, 128 GB RAM, 1 TB NVMe SSD (or ≥64k IOPS), 1 Gbit/s network connectivity, Public IP.
 
-   To maintain network stability, distribute validator nodes across different geographical locations worldwide rather than concentrating them in a single data center. Use [this site](https://status.toncenter.com/) to assess the load of various locations. The map indicates high data center utilization in Europe, especially in Finland, Germany, and Paris. Therefore, avoid using providers such as Hetzner and OVH.
+   To maintain network stability, distribute validator nodes across different geographical locations worldwide rather than concentrating them in a single data center. See [recommended providers](/v3/guidelines/nodes/running-nodes/full-node#recommended-providers).
 
-   > Ensure your hardware meets or exceeds the specifications above. Running the validator on insufficient hardware negatively impacts the network and could result in penalties.
+   :::caution
+   Ensure your hardware meets or exceeds the specifications above. Running the validator on insufficient hardware negatively impacts the network and could result in penalties.
+   :::
+   :::caution
+   Ensure your hardware meets or exceeds the specifications above. Running the validator on insufficient hardware negatively impacts the network and could result in penalties.
+   :::
 
-   > Note that as of May 2021, Hetzner has prohibited mining on its servers. This ban includes both PoW and PoS algorithms. Even installing a regular node may violate their terms of service.
+2. Install and synchronize **MyTonCtrl** as described in the guide [here](/v3/guidelines/nodes/running-nodes/full-node#install-mytonctrl).
 
-   > **Recommended providers include:** [Amazon](https://aws.amazon.com/), [DigitalOcean](https://www.digitalocean.com/), [Linode](https://www.linode.com/), [Alibaba Cloud](https://alibabacloud.com/), [Latitude](https://www.latitude.sh/).
+   For additional help, refer to this video tutorial.
 
-2. Install and synchronize **mytonctrl** as described in the guide [here](/v3/guidelines/nodes/running-nodes/full-node#install-the-mytonctrl).
-
-   For additional help, refer to this [video instruction](/v3/guidelines/nodes/running-nodes/full-node#run-a-node-video).
-
-3. Transfer 1 TON to the validator wallet address in the `wl` list.
+3. Transfer 1 TON to the validator wallet address listed by the `wl` command.
 
 4. Use the `aw` command to activate your validator wallet.
 
 5. Activate pool mode:
 
-   ```bash
+   Run in the MyTonCtrl console.
+
+   ```text
    enable_mode nominator-pool
    set stake null
    ```
 
 6. Create two pools (for even and odd validation rounds):
 
-   ```bash
+   Run in the MyTonCtrl console.
+
+   ```text
    new_pool p1 0 1 1000 300000
    new_pool p2 0 1 1001 300000
    ```
@@ -43,27 +48,39 @@ Before reading this tutorial, you should familiarize yourself with [nominator po
    Where:
 
    - `p1` is the pool name;
-   - `0` % is the validator's reward share (e.g., use 40 for 40%);
+   - `0%` is the validator's reward share (e.g., use 40 for 40%);
    - `1` is the maximum number of nominators in the pool (should be \<= 40);
    - `1000` TON is the minimum validator stake (should be >= 1K TON);
    - `300000` TON is the minimum nominator stake (should be >= 10K TON);
 
-   > (!) Pool configurations do not have to be identical. You can add 1 to the minimum stake of one pool to make them different.
+   :::note
+   Pool configurations do not have to be identical. You can add 1 to the minimum stake of one pool to make them different.
+   :::
 
-   > (!) Use https://tonmon.xyz/ to determine the current minimum validator stake.
+   :::tip
+   Use https://tonmon.xyz/ to determine the current minimum validator stake.
+   :::
 
 7. Type `pools_list` to display pool addresses:
 
-   ```bash
+   Run in the MyTonCtrl console.
+
+   ```text
    pools_list
    Name  Status  Balance  Address
    p1    empty   0        0f98YhXA9wnr0d5XRXT-I2yH54nyQzn0tuAYC4FunT780qIT
    p2    empty   0        0f9qtmnzs2-PumMisKDmv6KNjNfOMDQG70mQdp-BcAhnV5jL
    ```
 
+   :::info
+   Addresses may appear in raw form (starting with `0f…`) or user-friendly form (starting with `kf…`). Both represent the same address in different formats.
+   :::
+
 8. Send 1 TON to each pool and activate the pools:
 
-   ```bash
+   Run in the MyTonCtrl console.
+
+   ```text
    mg validator_wallet_001 0f98YhXA9wnr0d5XRXT-I2yH54nyQzn0tuAYC4FunT780qIT 1
    mg validator_wallet_001 0f9qtmnzs2-PumMisKDmv6KNjNfOMDQG70mQdp-BcAhnV5jL 1
    activate_pool p1
@@ -72,64 +89,76 @@ Before reading this tutorial, you should familiarize yourself with [nominator po
 
 9. Type `pools_list` to display pools:
 
-   ```bash
+   Run in the MyTonCtrl console.
+
+   ```text
    pools_list
    Name  Status  Balance      Address
    p1    active  0.731199733  kf98YhXA9wnr0d5XRXT-I2yH54nyQzn0tuAYC4FunT780v_W
    p2    active  0.731199806  kf9qtmnzs2-PumMisKDmv6KNjNfOMDQG70mQdp-BcAhnV8UO
    ```
 
-10. Open each pool via the link `https://tonscan.org/nominator/{address_of_pool}` and verify pool configurations.
+10. Open each pool via the link `https://tonscan.org/nominator/{address_of_pool}` and verify each pool’s configuration.
 
 11. Proceed with the validator deposit to each pool:
 
-    ```bash
+    Run in the MyTonCtrl console.
+
+    ```text
     deposit_to_pool validator_wallet_001 <address_of_pool_1> 1005
     deposit_to_pool validator_wallet_001 <address_of_pool_2> 1005
     ```
 
-In these commands, `1005` TON is the deposit amount. The pool will deduct 1 TON to process the deposit.
+In these commands, `1005` TON is the deposit amount. Ensure you attach sufficient fees as required; see the [nominator pool specification](/v3/documentation/smart-contracts/contracts-specs/nominator-pool) for details.
 
-12. Proceed with the nominator deposit to each pool:
+12. Make a nominator deposit to each pool.
 
-    Visit the pool link (from **Step 9**) and click **ADD STAKE**.
-    You can also make a deposit using **mytonctrl**, using the following commands:
+    Visit the pool link (from **Step 10**) and click **ADD STAKE**.
+    You can also make a deposit using **MyTonCtrl** with the following commands:
 
-    ```bash
+    Run in the MyTonCtrl console.
+
+    ```text
     mg nominator_wallet_001 <address_of_pool_1> 300001 -C d
     mg nominator_wallet_001 <address_of_pool_2> 300001 -C d
     ```
 
-> (!) The nominator wallet must be initialized in the basechain (workchain 0).
+:::info
+The nominator wallet must be initialized in the basechain (workchain 0).
+:::
 
-> (!) Remember that the validator and nominator wallets must be stored separately! Store the validator wallet on the server with the validator node to ensure the processing of all system transactions. Meanwhile, store the nominator wallet in your cold cryptocurrency wallet.
+:::caution
+Remember that the validator and nominator wallets must be stored separately! Store the validator wallet on the server with the validator node to ensure the processing of all system transactions. Meanwhile, store the nominator wallet in your cold cryptocurrency wallet.
+:::
 
-> To withdraw a nominator deposit, send a transaction with the comment `w` to the pool address (attach 1 TON to process the transaction). You can also perform this action using **mytonctrl**.
+:::note
+To withdraw a nominator deposit, send a transaction with the comment `w` to the pool address (attach 1 TON to process the transaction). You can also perform this action using **mytonctrl**.
+:::
 
-13. Invite nominators to deposit into your pools. The participation in validation will commence automatically.
+13. Invite nominators to deposit into your pools. Participation in validation will commence automatically.
 
+:::note
+Ensure you have at least 200 TON/month in your validator wallet for operation fees.
 
-> (!) Ensure you have at least 200 TON/month in your validator wallet for operation fees.
+In the TON blockchain, the validator cycle is approximately 18 hours, and there are roughly 40.5 validation rounds per month (assuming a 30-day month).
 
-  > In the TON blockchain, the validator cycle is approximately 18 hours, and there are roughly 40.5 validation rounds per month (assuming a 30-day month).
-  
-  > Here's the breakdown of costs based on participation:
-    >
-    > - **Participating in only odd or even cycles (half of the rounds):**
-    >
-    >   - Rounds per month: ~20.25
-    >   - Cost per round: ~5 Toncoins
-    >   - `total cost = 20.25 * 5 -> ~101.25 Toncoins`
-    >
-    > - **Participating in both odd and even cycles (all rounds):**
-    >   - Rounds per month: ~40.5
-    >   - Cost per round : ~ 5 Toncoins
-    >   - `total cost = 40.5 * 5 -> ~202.50 Toncoins`
+Here's the breakdown of costs based on participation:
+
+- **Participating in only odd or even cycles (half of the rounds):**
+  - Rounds per month: ~20.25
+  - Cost per round: ~5 Toncoins
+  - `total cost = 20.25 * 5 -> ~101.25 Toncoins`
+
+- **Participating in both odd and even cycles (all rounds):**
+  - Rounds per month: ~40.5
+  - Cost per round : ~ 5 Toncoins
+  - `total cost = 40.5 * 5 -> ~202.50 Toncoins`
+:::
 
 
 ## Pool configuration
 
-If you intend to lend to yourself, use `new_pool p1 0 1 1000 300000` (maximum of 1 nominator, 0% validator share).
+If you intend to self-nominate, use `new_pool p1 0 1 1000 300000` (maximum of 1 nominator, 0% validator share).
 
 If you're creating a pool for numerous nominators, you might use something like this: `new_pool p1 40 40 10000 10000` (maximum of 40 nominators, 40% validator share, minimum participant stakes of 10K TON).
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-smart-contracts-howto-nominator-pool.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx`

Related issues (from issues.normalized.md):
- [ ] **3498. Rephrase Hetzner/OVH guidance to recommendation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/running-nodes/liteserver-node.mdx?plain=1

Change “Hetzner and OVH are not allowed to run a validator” to “Hetzner and OVH are not recommended for validators” and add a citation to docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx#validator-pool-mode (or provide a canonical policy source).

---

- [ ] **3838. Align hardware requirements with validator docs**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx?plain=1#L11-L19

Replace the sentence with “16 cores CPU, 128 GB RAM, 1 TB NVMe SSD (or ≥64k IOPS), 1 Gbit/s network connectivity, Public IP” and standardize units/spaces, matching the canonical validator requirements.

---

- [ ] **3839. Use AWS naming consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx?plain=1#L19

Replace “Amazon” with “AWS” to match provider naming used elsewhere.

---

- [ ] **3840. Fix MyTonCtrl install link anchor**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx?plain=1#L21

Change the link fragment to /v3/guidelines/nodes/running-nodes/full-node#install-mytonctrl.

---

- [ ] **3841. Capitalize MyTonCtrl properly**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx?plain=1#L21,L96,L107

Use “MyTonCtrl” when referring to the software; keep command names (e.g., mytonctrl) lowercase and do not change “mytoncore.”

---

- [ ] **3842. Improve “video instruction” phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx?plain=1#L23

Change to “For additional help, refer to this video tutorial.”

---

- [ ] **3843. Clarify wl reference**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx?plain=1#L25

Change to “to the validator wallet address listed by the `wl` command.”

---

- [ ] **3844. Relabel MyTonCtrl console commands**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx?plain=1#L31-L34,L38-L41,L57-L62,L66-L71,L75-L80,L86-L89,L98-L101

Change fenced code blocks from bash to text (or omit a language) and preface with “Run in the MyTonCtrl console.”

---

- [ ] **3845. Correct validator reward units and examples**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx?plain=1#L46-L49,L134

State the validator’s reward share in basis points (per 10,000), e.g., “4000 = 40%”; fix “0 %” to “0%”; update the example to: new_pool p1 4000 40 10000 10000.

---

- [ ] **3846. Replace external stake link and remove hard-coded minimum**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx?plain=1#L53

Replace the tonmon.xyz reference with an internal link to /v3/guidelines/nodes/running-nodes/validator-node#activate-the-wallets for current stake info and remove the fixed “≥ 1K TON” claim.

---

- [ ] **3847. Fix singular/plural in verification step**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx?plain=1#L82

Change to “verify each pool’s configuration.”

---

- [ ] **3848. Simplify nominator deposit step text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx?plain=1#L93

Change to “Make a nominator deposit to each pool.”

---

- [ ] **3849. Correct step cross-reference**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx?plain=1#L95

Change “from Step 9” to “from Step 10.”

---

- [ ] **3850. Remove duplicate “using”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx?plain=1#L96

Rephrase to “You can also make a deposit using MyTonCtrl with the following commands:”.

---

- [ ] **3851. Remove article before “Participation”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx?plain=1#L109

Change to “Participation in validation will commence automatically.”

---

- [ ] **3852. Normalize colon spacing in cost line**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx?plain=1#L126

Change to “Cost per round: ~5 Toncoins”.

---

- [ ] **3853. Replace “lend to yourself” with “self-nominate”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx?plain=1#L132

Change to “If you intend to self-nominate, use `new_pool p1 0 1 1000 300000` …”.

---

- [ ] **3854. Replace undocumented “set stake null” with “set stake 0”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx?plain=1

Change the example to use `set stake 0`, which matches documented usage and later guidance.

---

- [ ] **3855. Correct deposit_to_pool command syntax**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx?plain=1

Use `deposit_to_pool <pool-addr> <amount>` (no wallet name) and instruct users to select the wallet beforehand with `aw`.

---

- [ ] **3856. Replace mg -C d with deposit_to_pool**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx?plain=1

Use the documented `deposit_to_pool <pool-addr> <amount>` instead of `mg … -C d`, which is not documented.

---

- [ ] **3857. Remove unsupported “1 TON fee” claim for validator deposit**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx?plain=1

Delete the fixed “pool will deduct 1 TON” statement for validator deposits and replace with a generic note to attach sufficient fees, citing the nominator pool spec.

---

- [ ] **3858. Make address format consistent in examples**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx?plain=1

Use one address representation consistently (e.g., user-friendly addresses starting with kf…) and add a brief note explaining formats if necessary.

---

- [ ] **3859. Replace ad-hoc callouts with standard admonitions**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx?plain=1

Convert “> (!)” blockquote callouts to site admonitions (e.g., :::info, :::tip, :::caution) for consistency.

---

- [ ] **3860. Remove provider prohibitions and external map link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/nominator-pool.mdx?plain=1

Remove advice to avoid specific providers and the external status/load map, and link to /v3/guidelines/nodes/running-nodes/full-node#recommended-providers instead.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.