### PR TITLE
Split: update docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx
+++ b/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 Before proceeding with this tutorial, we recommend familiarizing yourself with the [single nominator pool specification](/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool).
 :::
 
-## Set up single-nominator mode
+## Set up single nominator mode
 
 :::caution
 Before starting, ensure you have topped up and [activated](/v3/guidelines/nodes/running-nodes/validator-node#activate-the-wallets) the validator's wallet.
@@ -23,27 +23,27 @@ MyTonCtrl> enable_mode single-nominator
 
 2. Verify if single nominator mode is enabled:
 
-```text
+```bash
 MyTonCtrl> status_modes
 Name              Status   Description
-single-nominator  enabled  Single nominator pools.
+single-nominator  enabled  Orbs's single nominator pools.
 ```
 
 3. Create a pool:
 
-```text
+```bash
 MyTonCtrl> new_single_pool <pool-name> <owner-address>
 ```
 
 If you have already created a pool, you can import it:
 
-```text
+```bash
 MyTonCtrl> import_pool <pool-name> <pool-addr>
 ```
 
 4. Display pool addresses using `pools_list`:
 
-```text
+```bash
 MyTonCtrl> pools_list
 Name       Status  Balance  Version   Address
 test-pool  empty   0.0      spool_r2  kf_JcC5pn3etTAdwOnc16_tyMmKE8-ftNUnf0OnUjAIdDJpX
@@ -51,13 +51,13 @@ test-pool  empty   0.0      spool_r2  kf_JcC5pn3etTAdwOnc16_tyMmKE8-ftNUnf0OnUjA
 
 5. Activate the pool:
 
-```text
+```bash
 MyTonCtrl> activate_single_pool <pool-name>
 ```
 
 After successfully activating the pool:
 
-```text
+```bash
 MyTonCtrl> pools_list
 Name       Status  Balance  Version   Address
 test-pool  active  0.99389  spool_r2  kf_JcC5pn3etTAdwOnc16_tyMmKE8-ftNUnf0OnUjAIdDJpX
@@ -185,31 +185,37 @@ $ fift -s ./scripts/fift/withdraw.fif <withdraw_amount>
 $ tons wallet transfer <my-wallet> <single_nominator_address> <amount=1> --body withdraw.boc
 ```
 
-3. Generate a deeplink:
+3. Link TypeScript:
+
+```bash
+npm link typescript
+```
+
+4. Generate a deeplink:
 
 ```bash
 npx ts-node scripts/ts/withdraw-deeplink.ts <single-nominator-addr> <withdraw-amount>
 ```
 
-4. Open the deeplink on the owner's phone.
+5. Open the deeplink on the owner's phone.
 
 ## Deposit to pool
 
 You can deposit using **MyTonCtrl** with the following commands:
 
-```text
+```bash
 MyTonCtrl> mg <from-wallet-name> <pool-addr> <amount>
 ```
 
 or
 
-```text
+```bash
 MyTonCtrl> deposit_to_pool <pool-addr> <amount>
 ```
 
 Alternatively, follow these steps:
 
-1. Navigate to the pool’s page: [tonscan nominator page](https://tonscan.org/nominator/{pool_address}).
+1. Navigate to the pool’s page: `https://tonscan.org/nominator/{pool_address}`.
 2. Ensure the pool information is displayed correctly. If the pool has an incorrect smart contract, no information will appear.
 3. Click the `ADD STAKE` button or scan the QR code using Tonkeeper or another TON wallet.
 4. Enter the TON amount and send the transaction. The TON coins will then be added to staking.
@@ -220,7 +226,7 @@ If the wallet does not open automatically, manually send the transaction by copy
 
 You can withdraw funds using the following command:
 
-```text
+```bash
 MyTonCtrl> withdraw_from_pool <pool-addr> <amount>
 ```
 
@@ -301,7 +307,7 @@ Configure the single nominator pool contract using the [following instructions](
 
 **MyTonCtrl** will automatically join the elections. You can set the stake amount that MyTonCtrl sends to the [elector contract](/v3/documentation/smart-contracts/contracts-specs/governance#elector) approximately every 18 hours on Mainnet and 2 hours on Testnet.
 
-```text
+```bash
 MyTonCtrl> set stake 90000
 ```
 
@@ -313,13 +319,13 @@ Set `stake` to `null` to have it calculated from `stakePercent` (see `status_set
 
 Verify if the election has started:
 
-```text
+```bash
 MyTonCtrl> status
 ```
 
 For Testnet:
 
-```text
+```bash
 MyTonCtrl> status fast
 ```
 
@@ -331,7 +337,7 @@ If the election has started and the single nominator pool is activated, the vali
 
 Check the validator wallet:
 
-```text
+```bash
 MyTonCtrl> wl
 Name                  Status  Balance           Ver  Wch  Address
 validator_wallet_001  active  995.828585374     v1   -1   kf_dctjwS4tqWdeG4GcCLJ53rkgxZOGGrdDzHJ_mxPkm_Xct
@@ -339,7 +345,7 @@ validator_wallet_001  active  995.828585374     v1   -1   kf_dctjwS4tqWdeG4GcCLJ
 
 Check the transaction history:
 
-```text
+```bash
 MyTonCtrl> vas kf_dctjwS4tqWdeG4GcCLJ53rkgxZOGGrdDzHJ_mxPkm_Xct
 Address                                           Status  Balance        Version
 kf_dctjwS4tqWdeG4GcCLJ53rkgxZOGGrdDzHJ_mxPkm_Xct  active  995.828585374  v1r3
@@ -384,7 +390,7 @@ If you no longer wish to participate in validation:
 
 1. Disable validator mode:
 
-```text
+```bash
 MyTonCtrl> disable_mode validator
 ```
 
@@ -423,25 +429,25 @@ Ensure you have backed up the vesting `owner_wallet` recovery phrase. If you los
 3. Send 200 TON (for monthly expenses) to the `validator_wallet`.
 4. Create a `single_nominator_pool`:
 
-```text
+```bash
 MyTonCtrl> new_single_pool <pool-name> <vesting>
 ```
 
 Example:
 
-```text
+```bash
 MyTonCtrl> new_single_pool my_s_pool EQD...lme-D
 ```
 
 5. Activate the `single_nominator_pool`:
 
-```text
+```bash
 MyTonCtrl> activate_single_pool <pool-name>
 ```
 
 Example:
 
-```text
+```bash
 MyTonCtrl> activate_single_pool my_s_pool
 ```
 

--- a/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx
+++ b/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 Before proceeding with this tutorial, we recommend familiarizing yourself with the [single nominator pool specification](/v3/documentation/smart-contracts/contracts-specs/single-nominator-pool).
 :::
 
-### Set up single nominator mode
+## Set up single-nominator mode
 
 :::caution
 Before starting, ensure you have topped up and [activated](/v3/guidelines/nodes/running-nodes/validator-node#activate-the-wallets) the validator's wallet.
@@ -17,33 +17,33 @@ Before starting, ensure you have topped up and [activated](/v3/guidelines/nodes/
 
 1. Enable single nominator mode:
 
-```bash
+```text
 MyTonCtrl> enable_mode single-nominator
 ```
 
 2. Verify if single nominator mode is enabled:
 
-```bash
+```text
 MyTonCtrl> status_modes
 Name              Status   Description
-single-nominator  enabled  Orbs's single nominator pools.
+single-nominator  enabled  Single nominator pools.
 ```
 
 3. Create a pool:
 
-```bash
-MyTonCtrl> new_single_pool <pool-name> <owner_address>
+```text
+MyTonCtrl> new_single_pool <pool-name> <owner-address>
 ```
 
 If you have already created a pool, you can import it:
 
-```bash
+```text
 MyTonCtrl> import_pool <pool-name> <pool-addr>
 ```
 
 4. Display pool addresses using `pools_list`:
 
-```bash
+```text
 MyTonCtrl> pools_list
 Name       Status  Balance  Version   Address
 test-pool  empty   0.0      spool_r2  kf_JcC5pn3etTAdwOnc16_tyMmKE8-ftNUnf0OnUjAIdDJpX
@@ -51,19 +51,19 @@ test-pool  empty   0.0      spool_r2  kf_JcC5pn3etTAdwOnc16_tyMmKE8-ftNUnf0OnUjA
 
 5. Activate the pool:
 
-```bash
+```text
 MyTonCtrl> activate_single_pool <pool-name>
 ```
 
 After successfully activating the pool:
 
-```bash
+```text
 MyTonCtrl> pools_list
 Name       Status  Balance  Version   Address
 test-pool  active  0.99389  spool_r2  kf_JcC5pn3etTAdwOnc16_tyMmKE8-ftNUnf0OnUjAIdDJpX
 ```
 
-You can manage this pool via MyTonCtrl like a standard nominator pool.
+You can manage this pool in MyTonCtrl as a standard nominator pool.
 
 :::info
 If the pool's balance is sufficient to participate in both rounds (`balance > min_stake_amount * 2`), MyTonCtrl will automatically participate in both rounds using `stake = balance / 2`, unless you manually set the stake using the `set stake` command. This behavior differs from using a nominator pool but resembles staking with a validator wallet.
@@ -145,7 +145,7 @@ $ fift -s ./scripts/fift/str-to-addr.fif Ef-kC0..._WLqgs
 
 7. Back up the deployer private key (`./build/deploy.config.json`) and `single-nominator.addr` files.
 8. Copy `single-nominator.addr` to `mytoncore/pools/single-nominator-1.addr`.
-9. Send a stake from the owner's address to the single nominator's address.
+9. Send a stake from the owner address to the single-nominator address.
 
 ### Withdrawals from the single nominator
 
@@ -185,37 +185,31 @@ $ fift -s ./scripts/fift/withdraw.fif <withdraw_amount>
 $ tons wallet transfer <my-wallet> <single_nominator_address> <amount=1> --body withdraw.boc
 ```
 
-3. Link TypeScript:
-
-```bash
-npm link typescript
-```
-
-4. Generate a deeplink:
+3. Generate a deeplink:
 
 ```bash
 npx ts-node scripts/ts/withdraw-deeplink.ts <single-nominator-addr> <withdraw-amount>
 ```
 
-5. Open the deeplink on the owner's phone.
+4. Open the deeplink on the owner's phone.
 
 ## Deposit to pool
 
 You can deposit using **MyTonCtrl** with the following commands:
 
-```sh
-MyTonCtrl> mg <from-wallet-name> <pool-account-addr> <amount>
+```text
+MyTonCtrl> mg <from-wallet-name> <pool-addr> <amount>
 ```
 
 or
 
-```sh
+```text
 MyTonCtrl> deposit_to_pool <pool-addr> <amount>
 ```
 
 Alternatively, follow these steps:
 
-1. Navigate to the pool’s page: `https://tonscan.org/nominator/{pool_address}`.
+1. Navigate to the pool’s page: [tonscan nominator page](https://tonscan.org/nominator/{pool_address}).
 2. Ensure the pool information is displayed correctly. If the pool has an incorrect smart contract, no information will appear.
 3. Click the `ADD STAKE` button or scan the QR code using Tonkeeper or another TON wallet.
 4. Enter the TON amount and send the transaction. The TON coins will then be added to staking.
@@ -226,7 +220,7 @@ If the wallet does not open automatically, manually send the transaction by copy
 
 You can withdraw funds using the following command:
 
-```sh
+```text
 MyTonCtrl> withdraw_from_pool <pool-addr> <amount>
 ```
 
@@ -299,33 +293,33 @@ func WithdrawSingleNominatorMessage(single_nominator_address string, query_id, a
 
 ### Set up a single nominator pool
 
-Configure the single nominator pool contract using the [following instructions](/v3/guidelines/smart-contracts/howto/single-nominator-pool#set-up-a-single-nominator-pool).
+Configure the single nominator pool contract using the [following instructions](/v3/guidelines/smart-contracts/howto/single-nominator-pool#create-a-single-nominator-pool).
 
 ### Join the elections
 
-[Deposit](/v3/guidelines/smart-contracts/howto/single-nominator-pool#set-up-a-single-nominator-pool) the minimum stake amount into the single nominator pool.
+[Deposit](/v3/guidelines/smart-contracts/howto/single-nominator-pool#deposit-to-pool) the minimum stake amount into the single nominator pool.
 
 **MyTonCtrl** will automatically join the elections. You can set the stake amount that MyTonCtrl sends to the [elector contract](/v3/documentation/smart-contracts/contracts-specs/governance#elector) approximately every 18 hours on Mainnet and 2 hours on Testnet.
 
-```sh
+```text
 MyTonCtrl> set stake 90000
 ```
 
 Find the **minimum stake** amount using the `status` command.
 
-![](/img/docs/single-nominator/tetsnet-conf.png)
+![](/img/docs/single-nominator/testnet-status.png)
 
-You can set `stake` to `null`, which will calculate based on the `stakePercent` value (check with `status_settings`).
+Set `stake` to `null` to have it calculated from `stakePercent` (see `status_settings`).
 
 Verify if the election has started:
 
-```bash
+```text
 MyTonCtrl> status
 ```
 
 For Testnet:
 
-```bash
+```text
 MyTonCtrl> status fast
 ```
 
@@ -337,7 +331,7 @@ If the election has started and the single nominator pool is activated, the vali
 
 Check the validator wallet:
 
-```sh
+```text
 MyTonCtrl> wl
 Name                  Status  Balance           Ver  Wch  Address
 validator_wallet_001  active  995.828585374     v1   -1   kf_dctjwS4tqWdeG4GcCLJ53rkgxZOGGrdDzHJ_mxPkm_Xct
@@ -345,7 +339,7 @@ validator_wallet_001  active  995.828585374     v1   -1   kf_dctjwS4tqWdeG4GcCLJ
 
 Check the transaction history:
 
-```sh
+```text
 MyTonCtrl> vas kf_dctjwS4tqWdeG4GcCLJ53rkgxZOGGrdDzHJ_mxPkm_Xct
 Address                                           Status  Balance        Version
 kf_dctjwS4tqWdeG4GcCLJ53rkgxZOGGrdDzHJ_mxPkm_Xct  active  995.828585374  v1r3
@@ -390,7 +384,7 @@ If you no longer wish to participate in validation:
 
 1. Disable validator mode:
 
-```bash
+```text
 MyTonCtrl> disable_mode validator
 ```
 
@@ -400,7 +394,7 @@ MyTonCtrl> disable_mode validator
 
 1. Disable the `validator` mode to stop participating in elections.
 2. Wait for both stakes to return from the elector.
-3. Follow the [steps](/v3/guidelines/smart-contracts/howto/single-nominator-pool#set-up-a-single-nominator-pool) to set up a single nominator pool.
+3. Follow the [steps](/v3/guidelines/smart-contracts/howto/single-nominator-pool#set-up-single-nominator-mode) to set up a single nominator pool.
 
 ## Single nominator pool client
 
@@ -429,25 +423,25 @@ Ensure you have backed up the vesting `owner_wallet` recovery phrase. If you los
 3. Send 200 TON (for monthly expenses) to the `validator_wallet`.
 4. Create a `single_nominator_pool`:
 
-```bash
+```text
 MyTonCtrl> new_single_pool <pool-name> <vesting>
 ```
 
 Example:
 
-```bash
+```text
 MyTonCtrl> new_single_pool my_s_pool EQD...lme-D
 ```
 
 5. Activate the `single_nominator_pool`:
 
-```bash
+```text
 MyTonCtrl> activate_single_pool <pool-name>
 ```
 
 Example:
 
-```bash
+```text
 MyTonCtrl> activate_single_pool my_s_pool
 ```
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-smart-contracts-howto-single-nominator-pool.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx`

Related issues (from issues.normalized.md):
- [ ] **3881. Fix heading level for setup section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#L12

Change "### Set up single nominator mode" to "## Set up single nominator mode" to align with peer second-level sections.

---

- [ ] **3882. Hyphenate “single-nominator” in heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#L12

Update the heading to "Set up single-nominator mode" for consistent hyphenation.

---

- [ ] **3883. Use `text` for MyTonCtrl prompts/outputs**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#L20-L30,L46-L50,L54-L56,L60-L64,L229-L231

Change code fences from bash/sh to text for interactive prompts and plain outputs, and apply consistently across the page.

---

- [ ] **3884. Improve “via … like” phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#L66

Replace with "You can manage this pool in MyTonCtrl as a standard nominator pool." (or "… via MyTonCtrl as you would a standard nominator pool.").

---

- [ ] **3885. Correct ts-node installation method**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#L89-L95

Replace `sudo apt install ts-node` with an npm-based install, e.g., `npm i -g ts-node typescript arg`.

---

- [ ] **3886. Add repository clone and install steps before npm scripts**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#L104-L146

Before running `npm run …` commands, add: `git clone https://github.com/ton-blockchain/single-nominator && cd single-nominator && npm install`.

---

- [ ] **3887. Fix address phrasing and hyphenation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#L148-L149

Change to "Send a stake from the owner address to the single-nominator address." to avoid double possessives and keep hyphenation consistent.

---

- [ ] **3888. Document or replace undefined `tons` CLI**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#L182-L186

Either document what `tons` is and how to install it, or replace the command with a documented method (e.g., MyTonCtrl mg/lite-client).

---

- [ ] **3889. Remove `npm link typescript` from Tonkeeper steps**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#L188-L199

Delete the `npm link typescript` instruction; if a generator requires TS, run it from the cloned repo after `npm install`.

---

- [ ] **3890. Split Tonkeeper withdrawal into clear alternatives**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#withdrawals-from-the-single-nominator

Separate the CLI-with-BOC method (steps 1–2) and the deeplink method (steps 3–5) into two clearly labeled alternative approaches.

---

- [ ] **3891. Make pool URL clickable**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#L218

Replace inline code with a link, e.g., `[tonscan nominator page](https://tonscan.org/nominator/{pool_address})`.

---

- [ ] **3892. Remove unused import in JS example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#L238-L245

Drop `storeMessageRelaxed` from the import: `import { Address, beginCell, internal, toNano } from "@ton/core";`.

---

- [ ] **3893. Fix broken self-links to setup/deposit sections**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#L300-L307,L302,L306,#election-process,L401-L403,#transitioning-a-regular-validator-to-nominator-pool-mode

Replace links to `#set-up-a-single-nominator-pool` with existing anchors (e.g., `#set-up-single-nominator-mode` and/or `#create-a-single-nominator-pool`), and point the deposit reference to `#deposit-to-pool`.

---

- [ ] **3894. Fix typo in image filename**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#L316

Rename `tetsnet-conf.png` to `testnet-conf.png` and update the reference (or replace with the existing `testnet-status.png`).

---

- [ ] **3895. Clarify auto-calculated stake sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#L318-L321

Reword to "Set `stake` to `null` to have it calculated from `stakePercent` (see `status_settings`)."

---

- [ ] **3896. Standardize address placeholders to hyphenated form**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1

Use hyphenated placeholders consistently: change `new_single_pool <pool-name> <owner_address>` to `<owner-address>`, prefer `<pool-addr>` over `<pool-account-addr>`, and replace underscore variants like `<single_nominator_address>` with `<single-nominator-addr>`.

---

- [ ] **3897. Reference canonical fift/func setup instead of hard-coded paths**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#prepare-single-nominator

Link to the precompiled binaries/setup guide and instruct ensuring `fift`/`func` are on PATH; avoid assuming `/usr/bin/ton/crypto/*` locations.

---

- [ ] **3898. Prefer `import_pool` over manual `.addr` copy**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#create-a-single-nominator-pool

Remove the manual file copy step and use `MyTonCtrl> import_pool <pool-name> <pool-addr>` as the canonical way to register the pool.

---

- [ ] **3899. Add explicit steps to stop validation and withdraw**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#start-without-mytonctrl

Link to `disable_mode validator` and relevant withdrawal steps so users can stop validation and withdraw funds with concrete commands.

---

- [ ] **3900. Update outdated branding in status example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#set-up-single-nominator-mode

Change "Orbs's single nominator pools" to a neutral "Single nominator pools" in the `status_modes` example text.

---

- [ ] **3901. Instruct enabling validator mode before elections**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#election-process

Add a step to run `enable_mode validator` (with a link to its reference) before the election flow.

---

- [ ] **3902. Clarify deposit commission applicability**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#deposit-to-pool

Confirm the commission for single-nominator deposits or soften to "A commission (about 1 TON) may be deducted for processing the deposit."

---

- [ ] **3903. Clarify withdrawal fee in vesting flow**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#run-a-single-nominator-pool-with-a-vesting-contract

Explicitly state whether any TON must be attached (and how much) when sending the vesting "w" message to cover fees, or explain the exception if 0 is correct.

---

- [ ] **3904. Use the standard validator wallet name**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#run-a-single-nominator-pool-with-a-vesting-contract

Replace `wallet_v1` with `validator_wallet_001` to match MyTonCtrl naming in other docs.

---

- [ ] **3905. Soften or cite the 2.1 TON top-up requirement**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#create-a-single-nominator-pool

Either cite the source for "2.1 TON" or change to "at least 2 TON (verify current fees)" with guidance to check the repository/fees.

---

- [ ] **3906. Update or mark legacy Orbs script link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/howto/single-nominator-pool.mdx?plain=1#prepare-single-nominator

Point to the official `ton-blockchain/single-nominator` scripts (if available) or clearly label the Orbs script link as legacy and verify support.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.