### PR TITLE
Split: update docs/v3/guidelines/smart-contracts/security/overview.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/smart-contracts/security/overview.mdx
+++ b/docs/v3/guidelines/smart-contracts/security/overview.mdx
@@ -29,7 +29,7 @@ Learn from actual security incidents:
 - [TON Hack Challenge #1](https://github.com/ton-blockchain/hack-challenge-1)
 - [Drawing conclusions from TON Hack Challenge](/v3/guidelines/smart-contracts/security/ton-hack-challenge-1/)
 
-## TON Course: security
+## TON course: security
 
 :::tip
 Before diving into developer-level security topics, ensure you understand security at the user level. To achieve this, take the [Blockchain Basics with TON](https://stepik.org/course/201294/promo) course ([RU version](https://stepik.org/course/202221/), [CHN version](https://stepik.org/course/200976/)). Module 5 covers the basics of user-level security.


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-smart-contracts-security-overview.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/smart-contracts/security/overview.mdx`

Related issues (from issues.normalized.md):
- [x] **4556. Align link labels with destination H1 titles**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/overview.mdx?plain=1

In the “Essential reading” list, replace link labels to match their destination page H1s: /v3/guidelines/smart-contracts/security/common-vulnerabilities/ → “TON smart contract security best practices”; /v3/guidelines/smart-contracts/security/secure-programming/ → “Secure smart contract programming”; /v3/guidelines/smart-contracts/security/things-to-focus/ → “Things to focus on while working with TON Blockchain”.

---

- [ ] **4557. Remove or verify course module numbers in references**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/overview.mdx?plain=1

The page cites “Module 5” (user-level security) and “Module 8” (smart contract security) of “Blockchain Basics with TON” without a verifiable module outline; either remove module numbers or add a canonical citation to an official module list, or rephrase generically without module numbers.

---

- [ ] **4558. Title-case “TON Course: Security” heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/overview.mdx?plain=1

Change the section heading from “## TON course: security” to “## TON Course: Security” for consistent capitalization with related pages.

---

- [ ] **4559. Title-case primary button label**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/overview.mdx?plain=1

Change the primary button text from “Check TON Blockchain course” to “Check TON Blockchain Course” to align with chosen capitalization style.

---

- [x] **4560. Remove trailing spaces in tip admonition**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/overview.mdx?plain=1

In the tip block, delete the two trailing spaces after “:::tip” and the two trailing spaces at the end of the first sentence (unless a hard line break is intentionally needed).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.