### PR TITLE
Split: update docs/v3/guidelines/smart-contracts/security/random.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/smart-contracts/security/random.mdx
+++ b/docs/v3/guidelines/smart-contracts/security/random.mdx
@@ -8,7 +8,7 @@ This information is accurate at the time of writing. It may change during any ne
 
 Lottery contracts occasionally appear on TON. These contracts often use unsafe methods to handle randomness, making the generated values predictable and allowing the lottery to be exploited.  
 
-Exploiting weaknesses in random number generation typically involves using a proxy contract that forwards a message if the random value meets specific conditions. While proposals exist for wallet contracts that can execute arbitrary on-chain code (specified and signed by the user), most popular wallet versions do not support this functionality. So, if a lottery verifies that a gambler participates via a wallet contract, is it safe?  
+Exploiting weaknesses in random number generation typically involves using a proxy contract that forwards a message if the random value meets specific conditions. While proposals exist for wallet contracts that can execute arbitrary on-chain code (specified and signed by the user), most popular wallet versions do not support this functionality. So, if a lottery verifies that a gambler participates through a wallet contract, is it safe?  
 
 Alternatively, the question can be framed as: Can an external message be included in a block where the random value matches the sender's requirements?  
 
@@ -30,13 +30,13 @@ However, the most reliable and up-to-date source is the code itself. Let's exami
   }
 ```
 
-This code generates the random seed for a block. It resides in the collator code because the party generating blocks requires it, while lite clients (via liteservers) do not.
+This code generates the random seed for a block. It resides in the collator code because the party generating blocks requires it, while lite validators do not.
 
 A single validator or collator generates the seed when creating a block. This raises the following question:  
 
 ## Can the decision to include an external message be made after the seed is known?
 
-Yes, it can. Here’s why: if the system imports an external message, its execution must be deterministic and valid (succeed or fail with an exit code and possible bounce). Since execution can depend on random values, the block seed must be known beforehand.
+Yes, it can. Here’s why: if the system imports an external message, its execution must succeed. Since execution can depend on random values, the block seed must be known beforehand.
 
 Thus, there **is** a way to exploit "unsafe" (single-block) randomness if the sender collaborates with a validator. Even if the contract uses `randomize_lt()`, the validator can generate a suitable seed or include the proposed external message in a block that meets all conditions. A validator acting in this way would still be considered fair. This is the essence of decentralization.  
 
@@ -65,13 +65,13 @@ Pseudorandom numbers are then generated using the procedure described on the [TV
 > **x\{F810} RANDU256**  
 > Generates a new pseudorandom unsigned 256-bit Integer x. The algorithm is as follows: if r is the old value of the random seed, considered as a 32-byte array (by constructing the big-endian representation of an unsigned 256-bit integer), then its sha512(r) is computed; the first 32 bytes of this hash are stored as the new value r' of the random seed, and the remaining 32 bytes are returned as the next random value x.  
 
-This process is confirmed by examining the code for [preparing the contract's c7](https://github.com/ton-blockchain/ton/blob/f59c363ab942a5ddcacd670c97c6fbd023007799/crypto/block/transaction.cpp) (c7 is a tuple for temporary data, storing the contract address, starting balance, random seed, etc.) and [generating random values](https://github.com/ton-blockchain/ton/blob/f59c363ab942a5ddcacd670c97c6fbd023007799/crypto/vm/tonops.cpp).  
+This process is confirmed by examining the code for [preparing the contract's c7](https://github.com/ton-blockchain/ton/blob/master/crypto/block/transaction.cpp#L903) (c7 is a tuple for temporary data, storing the contract address, starting balance, random seed, etc.) and [generating random values](https://github.com/ton-blockchain/ton/blob/master/crypto/vm/tonops.cpp#L217-L268).
 
 ## Conclusion  
 
 No random number generation in TON is entirely safe in terms of unpredictability. This means **no perfect lottery can exist on TON**, nor can any lottery be fully trusted to be fair.  
 
-Typical usage of pseudorandom number generators (PRNGs) may include `randomize_lt()`, but such contracts can still be tricked by selecting the correct blocks to send messages. Proposed solutions, such as sending messages to another workchain and receiving a response to skip blocks, only delay the threat. In reality, any validator can choose the optimal time to send a request to a lottery contract so that the response arrives in a block they generate. They can then select any block seed they desire. If/when collators are introduced on mainnet, this risk could increase.  
+Typical usage of pseudorandom number generators (PRNGs) may include `randomize_lt()`, but such contracts can still be tricked by selecting the correct blocks to send messages. Proposed solutions, such as sending messages to another workchain and receiving a response to skip blocks, only delay the threat. In reality, any validator (representing 1/250 of the TON Blockchain) can choose the optimal time to send a request to a lottery contract so that the response arrives in a block they generate. They can then select any block seed they desire. This risk will increase once collators are introduced to the mainnet, as standard complaints cannot fine them since they do not stake anything in the Elector contract.
 
 {/* TODO: Find an example contract using random without any additions and demonstrate how to determine the result of RANDU256 knowing the block random seed (include a link to dton.io to show the generated value). */}
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-smart-contracts-security-random.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/smart-contracts/security/random.mdx`

Related issues (from issues.normalized.md):
- [ ] **3971. Use stable external link and add internal reference**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/random-number-generation.mdx?plain=1#L41

Replace the UI-parameterized link with https://github.com/puppycats/ton-random#ton-random and also reference docs/v3/guidelines/smart-contracts/security/random.mdx#conclusion as the canonical guidance.

---

- [x] **3981. Improve awkward sentence phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/random.mdx?plain=1#L11

Rephrase to: “So, if a lottery verifies that a gambler participates via a wallet contract, is it safe?”

---

- [ ] **3982. Replace “lite validators” with correct term**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/random.mdx?plain=1#L33

Use “lite clients (via liteservers)” instead of “lite validators” to match TON terminology.

---

- [ ] **3983. Clarify external message outcome phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/random.mdx?plain=1#L39

Replace “its execution must succeed” with “its execution must be deterministic and valid (succeed or fail with an exit code and possible bounce).”

---

- [ ] **3984. Pin GitHub source links to a commit**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/random.mdx?plain=1#L68

Change GitHub links that point to the master branch (e.g., transaction.cpp, tonops.cpp) to a specific commit hash and update or remove line anchors accordingly (matching the earlier pinned collator.cpp link).

---

- [x] **3985. Remove unsupported “1/250 of the TON Blockchain” claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/random.mdx?plain=1#L74

Delete the “1/250” fraction or replace with a sourced statement; use “any validator can choose the optimal time...” without a specific ratio.

---

- [ ] **3986. Qualify speculative collator statement**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/random.mdx?plain=1#L74

Revise to conditional wording (“If/when collators are introduced on mainnet…”) and avoid unsourced claims about fines via Elector, or add an authoritative citation.

---

- [ ] **3987. Remove TODO comments from published page**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/random.mdx?plain=1#L76-L78

Delete the MDX TODO comments or track them as GitHub issues so they don’t appear in published docs.

---

- [ ] **3988. Reconcile rand_seed derivation with c7 docs**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/random.mdx?plain=1

Align this page’s description of contract rand_seed with docs/v3/documentation/tvm/tvm-initialization.mdx#control-register-c7 (block seed, address, message hash if any, and trans_lt) or add a clear note explaining the implementation difference; ensure both pages are consistent.

---

- [ ] **3989. Fix TVM instructions link and apply trailing slash style**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/random.mdx?plain=1

Update the [TVM instructions] link to a valid, canonical target present in this repo (or an approved external URL) and use the trailing slash style: “/v3/documentation/tvm/instructions/#F810”.

---

- [ ] **3990. Standardize capitalization of “WorkChain”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/random.mdx?plain=1

Replace lowercase “workchain” with “WorkChain” for consistency with terminology elsewhere in the docs.

---

- [ ] **3991. Neutralize normative “fairness” phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/random.mdx?plain=1

Replace “A validator acting in this way would still be considered fair. This is the essence of decentralization.” with “This behavior does not violate consensus rules.”

---

- [ ] **3992. Scope the absolute conclusion and reference alternatives**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/random.mdx?plain=1

Revise the conclusion to specify that single-block randomness is unsafe under validator influence and acknowledge multi-phase schemes (e.g., commit–reveal) as stronger alternatives; link to docs/v3/guidelines/smart-contracts/security/random-number-generation.mdx#commit-reveal.

---

- [ ] **3993. Add citation or soften claim about seed timing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/random.mdx?plain=1

In “Can the decision to include an external message be made after the seed is known?”, either cite a spec confirming block seed availability during block assembly or rephrase to avoid asserting strict ordering (e.g., “Block producers know the seed during construction and may decide message inclusion accordingly.”).

---

- [ ] **3994. Correct c7 field name to “remaining balance”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/random.mdx?plain=1

Replace “starting balance” with “remaining balance” to match the c7 field name balance_remaining in docs/v3/documentation/tvm/tvm-initialization.mdx#control-register-c7.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.