### PR TITLE
Split: update docs/v3/guidelines/smart-contracts/security/secure-programming.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/smart-contracts/security/secure-programming.mdx
+++ b/docs/v3/guidelines/smart-contracts/security/secure-programming.mdx
@@ -267,7 +267,6 @@ builder store_body_header(builder b, int op, int query_id) inline {
 
 ## References
 
-- [Original article](https://blog.ton.org/secure-smart-contract-programming-in-func) - _CertiK_
+- [Secure smart contract programming in FunC — CertiK](https://blog.ton.org/secure-smart-contract-programming-in-func)
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-smart-contracts-security-secure-programming.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/smart-contracts/security/secure-programming.mdx`

Related issues (from issues.normalized.md):
- [ ] **3995. Remove unused ThemedImage import**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/secure-programming.mdx?plain=1#L3

ThemedImage is imported but never used; delete the import to avoid dead code.

---

- [ ] **3996. Use sentence case for AMM phrase**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/secure-programming.mdx?plain=1#L11

Replace “Liquidity Pairs in an Automated Market Maker” with “liquidity pairs in an automated market maker (AMM)” to follow sentence case within prose.

---

- [ ] **3997. Replace generic image alt text with descriptive text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/secure-programming.mdx?plain=1#L22,L97

Change filename-style alt texts (“smart1.png”, “smart2.png”) to meaningful descriptions (e.g., “Jetton transfer message flow”, “DEX message flow diagram”) to improve accessibility.

---

- [ ] **3998. Standardize op:: operation reference style**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/secure-programming.mdx?plain=1#L26-L33

Choose a single style for op:: operation mentions and apply it consistently here (e.g., op::internal_transfer() with parentheses) per project conventions.

---

- [ ] **3999. Remove backticks around concept term “Jetton”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/secure-programming.mdx?plain=1#L33

In prose, remove code formatting from the concept name—change the `Jetton` to “the Jetton” per typography guidelines.

---

- [ ] **4000. Use official token name “Toncoin”/“Toncoins”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/secure-programming.mdx?plain=1#L47

Replace “TON coins” with “Toncoins” to match the official token name used across the docs.

---

- [ ] **4001. Standardize on “carry-value pattern”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/secure-programming.mdx?plain=1#L47,L135

Change “carry-value principle” to “carry-value pattern” for consistency with the section title and related docs (see /v3/guidelines/smart-contracts/security/common-vulnerabilities/#carry-value-pattern-violations).

---

- [ ] **4002. Replace typographic ellipses and fix code placeholders**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/secure-programming.mdx?plain=1#L205,L56-L57

Replace the Unicode ellipsis (…) with three dots (...) in prose and use a valid placeholder in code blocks (e.g., “;; ...”) to keep FunC syntax correct.

---

- [ ] **4003. Correct misquote of FunC type-checking phrase**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/secure-programming.mdx?plain=1#L89

Replace “compile-time insurance” with the accurate wording, e.g., “a compile-time check ensuring that x has type int,” to match the source.

---

- [ ] **4004. Remove or substantiate claim about “chain bounces”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/secure-programming.mdx?plain=1#L129

Delete the sentence “TON doesn’t support chain bounces, so a bounced message cannot be re-bounced,” or add a vetted internal reference explicitly stating this behavior.

---

- [ ] **4005. Clarify “non-linear handlers” wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/secure-programming.mdx?plain=1#L170

Replace “non-linear handlers” with a clearer phrase such as “other message handlers,” or briefly define the term in context.

---

- [ ] **4006. Add cross-reference for end_parse()**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/secure-programming.mdx?plain=1#L213-L215

Link end_parse() to its stdlib entry at /v3/documentation/smart-contracts/func/docs/stdlib/#end_parse to aid discoverability.

---

- [ ] **4007. Use consistent wallet address function name**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/secure-programming.mdx?plain=1#L254

Replace calculate_address_by_state_init(state_init) with calculate_jetton_wallet_address(state_init) for consistency with usage elsewhere.

---

- [ ] **4008. Define or replace undefined store_msg_flags(BOUNCEABLE)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/secure-programming.mdx?plain=1#L257

Replace .store_msg_flags(BOUNCEABLE) with an explicit header encoding (e.g., .store_uint(0x18, 6)) or define store_msg_flags and a BOUNCEABLE constant before use.

---

- [x] **4009. Use article title in References link text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/secure-programming.mdx?plain=1#L270

Change “Original article” to “Secure smart contract programming in FunC — CertiK” and link it to https://blog.ton.org/secure-smart-contract-programming-in-func.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.