### PR TITLE
Split: update docs/v3/guidelines/smart-contracts/security/things-to-focus.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/smart-contracts/security/things-to-focus.mdx
+++ b/docs/v3/guidelines/smart-contracts/security/things-to-focus.mdx
@@ -8,15 +8,15 @@ In this article, we will review and discuss the elements to consider for those w
 
 ### 1. Name collisions
 
-FunC variable and function names may contain many valid characters; e.g., `var++`, `foo-bar+baz`. Only function names may start with `~` or `.`.
+FunC variables and functions may contain almost any legit character. i.e. `var++`, `~bits`, `foo-bar+baz` including commas are valid variables and functions names.
 
-When writing and reviewing FunC code, use a linter.
+When writing and inspecting a Func code, Linter should be used.
 
 - [IDE plugins](/v3/documentation/smart-contracts/getting-started/ide-plugins)
 
 ### 2. Check the throw values
 
-Each time the TVM execution stops normally, it stops with exit codes `0` or `1`. A contract can explicitly terminate with a successful exit by calling `throw(0)` or `throw(1)`.
+Each time the TVM execution stops normally, it stops with exit codes `0` or `1`. Although it is done automatically, TVM execution can be interrupted directly in an unexpected way if exit codes `0` and `1` are thrown directly by either `throw(0)` or `throw(1)` command.
 
 - [How to handle errors](/v3/documentation/smart-contracts/func/docs/builtins#throwing-exceptions)
 - [TVM exit codes](/v3/documentation/tvm/tvm-exit-codes)
@@ -25,11 +25,11 @@ Each time the TVM execution stops normally, it stops with exit codes `0` or `1`.
 
 It is crucial to keep track of what the code does and what it may return. Keep in mind that the compiler cares only about the code and only in its initial state. After certain operations stored values of some variables can change.
 
-Reading unexpected variable values and calling methods on data types that are not supposed to have such methods (or their return values are not stored properly) are errors and are not skipped as "warnings" or "notices" but lead to unreachable code. Keep in mind that storing an unexpected value may be okay, however, reading it may cause problems, e.g., error code 5 (integer out of expected range) may be thrown for an integer variable.
+Reading unexpected variables values and calling methods on data types that are not supposed to have such methods (or their return values are not stored properly) are errors and are not skipped as "warnings" or "notices" but lead to unreachable code. Keep in mind that storing an unexpected value may be okay, however, reading it may cause problems, e.g., error code 5 (integer out of expected range) may be thrown for an integer variable.
 
 ### 4. Messages have modes
 
-It is essential to check the message mode, in particular its interaction with previous messages sent and fees. A possible failure is not accounting for storage fees, in which case the contract may run out of Toncoin, leading to unexpected failures when sending outgoing messages. You can view the message modes [here](/v3/documentation/smart-contracts/message-management/sending-messages#message-modes).
+It is essential to check the message mode, in particular its interaction with previous messages sent and fees. A possible failure is not accounting for storage fees, in which case the contract may run out of TON, leading to unexpected failures when sending outgoing messages. You can view the message modes [here](/v3/documentation/smart-contracts/message-management/sending-messages#message-modes).
 
 ### 5. Replay protection \{#replay-protection}
 
@@ -42,7 +42,7 @@ For `seqno`, refer to [this section](/v3/documentation/smart-contracts/message-m
 
 ### 6. TON fully implements the actor model
 
-The code of a contract can be updated. It can be changed permanently using [`SETCODE`](/v3/documentation/smart-contracts/func/docs/stdlib#set_code) or updated at runtime using `set_c3` until the end of execution.
+It means the code of the contract can be changed. It can either be changed permanently, using [`SETCODE`](/v3/documentation/smart-contracts/func/docs/stdlib#set_code) TVM directive, or in runtime, setting the TVM code registry to a new cell value until the end of execution.
 
 ### 7. TON Blockchain has several transaction phases: compute phase, action phase, including a bounce phase
 
@@ -52,22 +52,22 @@ The compute phase executes the code of smart contracts and only then the actions
 
 ### 8. TON contracts are autonomous
 
-Contracts in the blockchain can reside in separate shards, processed by another set of validators, meaning that developers cannot pull data from other contracts on demand. Thus, any communication is asynchronous and done by sending messages.
+Contracts in the blockchain can reside in separate shards, processed by other set of validators, meaning that developer cannot pull data from other contracts on demand. Thus, any communication is asynchronous and done by sending messages.
 
 - [Sending messages from smart contract](/v3/documentation/smart-contracts/message-management/sending-messages)
 - [Sending messages from DApp](/v3/guidelines/ton-connect/cookbook/ton-transfer)
 
-### 9. TON does not include revert reason strings; outcomes are indicated by [exit codes](/v3/documentation/tvm/tvm-exit-codes)
+### 9. Unlike other blockchains, TON does not include revert messages; outcomes are indicated by exit codes
 
 It is helpful to think through the roadmap of exit codes for the code flow (and have it documented) before starting programming your TON smart contract.
 
-### 10. FunC method IDs
+### 10. FunC functions that have method_id identifiers have method IDs
 
 They can be either set explicitly `method_id(5)`, or implicitly by the FunC compiler. In this case, they can be found among method declarations in the Fift assembly (.fif) file. Two of them are predefined: `recv_internal` = 0 (receiving messages inside the blockchain) and `recv_external` = -1 (receiving messages from outside).
 
-### 11. TON address may not have any coins or code
+### 11. TON crypto address may not have any coins or code
 
-Smart contract addresses on the TON Blockchain are deterministic and can be precomputed. Accounts have states: non-existent, uninitialized, active, or frozen. Uninitialized addresses may still hold a balance.
+Smart contracts addresses in TON blockchain are deterministic and can be precomputed. Ton Accounts, associated with addresses may even contain no code which means they are uninitialized (if not deployed) or frozen while having no more storage or TON coins if the message with special flags was sent.
 
 ### 12. TON addresses have two standard representations
 
@@ -75,19 +75,19 @@ A full representation can either be "raw" (`workchain:address`) or "user-friendl
 
 - [Raw and user-friendly addresses](/v3/documentation/smart-contracts/addresses/address-formats)
 
-### 13. Understand method visibility
+### 13. Keep track of the flaws in code execution
 
-FunC has no visibility specifiers (unlike Solidity); implement access control in message handlers and contract logic.
+Unlike Solidity where it's up to you to set methods visibility, in the case of FunC, the visibility is restricted in a more intricate way either by showing errors or by `if` statements.
 
-### 14. Keep an eye on fees before sending bounced messages
+### 14. Keep an eye on gas fees before sending bounced messages
 
-When returning bounced value provided by a user, subtract the corresponding fees and be explicit about message mode/flags to control fee charging and bounce behavior.
+In case the smart contract sends the bounced messages with the value, provided by a user, make sure that the corresponding gas fees are subtracted from the returned amount not to be drained.
 
 ### 15. Monitor the callbacks and their failures
 
-TON blockchain is asynchronous. That means messages do not necessarily arrive in order; e.g., when a failure notification of an action arrives, it should be handled properly.
+TON blockchain is asynchronous. That means the messages do not have to arrive successively. e.g. when a fail notification of an action arrives, it should be handled properly.
 
-### 16. Check the bounced flag when receiving internal messages
+### 16. Check if the bounced flag was sent receiving internal messages
 
 You may receive bounced messages (error notifications), which should be handled.
 

--- a/docs/v3/guidelines/smart-contracts/security/things-to-focus.mdx
+++ b/docs/v3/guidelines/smart-contracts/security/things-to-focus.mdx
@@ -8,28 +8,28 @@ In this article, we will review and discuss the elements to consider for those w
 
 ### 1. Name collisions
 
-Func variables and functions may contain almost any legit character. I.e. `var++`, `~bits`, `foo-bar+baz` including commas are valid variables and functions names.
+FunC variable and function names may contain many valid characters; e.g., `var++`, `foo-bar+baz`. Only function names may start with `~` or `.`.
 
-When writing and inspecting a Func code, Linter should be used.
+When writing and reviewing FunC code, use a linter.
 
 - [IDE plugins](/v3/documentation/smart-contracts/getting-started/ide-plugins)
 
 ### 2. Check the throw values
 
-Each time the TVM execution stops normally, it stops with exit codes `0` or `1`. Although it is done automatically, TVM execution can be interrupted directly in an unexpected way if exit codes `0` and `1` are thrown directly by either `throw(0)` or `throw(1)` command.
+Each time the TVM execution stops normally, it stops with exit codes `0` or `1`. A contract can explicitly terminate with a successful exit by calling `throw(0)` or `throw(1)`.
 
 - [How to handle errors](/v3/documentation/smart-contracts/func/docs/builtins#throwing-exceptions)
 - [TVM exit codes](/v3/documentation/tvm/tvm-exit-codes)
 
-### 3. Func is a strictly typed language with data structures holding exactly what they are supposed to store
+### 3. FunC is a strictly typed language with data structures holding exactly what they are supposed to store
 
 It is crucial to keep track of what the code does and what it may return. Keep in mind that the compiler cares only about the code and only in its initial state. After certain operations stored values of some variables can change.
 
-Reading unexpected variables values and calling methods on data types that are not supposed to have such methods (or their return values are not stored properly) are errors and are not skipped as "warnings" or "notices" but lead to unreachable code. Keep in mind that storing an unexpected value may be okay, however, reading it may cause problems e.g. error code 5 (integer out of expected range) may be thrown for an integer variable.
+Reading unexpected variable values and calling methods on data types that are not supposed to have such methods (or their return values are not stored properly) are errors and are not skipped as "warnings" or "notices" but lead to unreachable code. Keep in mind that storing an unexpected value may be okay, however, reading it may cause problems, e.g., error code 5 (integer out of expected range) may be thrown for an integer variable.
 
 ### 4. Messages have modes
 
-It is essential to check the message mode, in particular its interaction with previous messages sent and fees. A possible failure is not accounting for storage fees, in which case contract may run out of TON leading to unexpected failures when sending outgoing messages. You can view the message modes [here](/v3/documentation/smart-contracts/message-management/sending-messages#message-modes).
+It is essential to check the message mode, in particular its interaction with previous messages sent and fees. A possible failure is not accounting for storage fees, in which case the contract may run out of Toncoin, leading to unexpected failures when sending outgoing messages. You can view the message modes [here](/v3/documentation/smart-contracts/message-management/sending-messages#message-modes).
 
 ### 5. Replay protection \{#replay-protection}
 
@@ -42,53 +42,52 @@ For `seqno`, refer to [this section](/v3/documentation/smart-contracts/message-m
 
 ### 6. TON fully implements the actor model
 
-It means the code of the contract can be changed. It can either be changed permanently, using [`SETCODE`](/v3/documentation/smart-contracts/func/docs/stdlib#set_code) TVM directive, or in runtime, setting the TVM code registry to a new cell value until the end of execution.
+The code of a contract can be updated. It can be changed permanently using [`SETCODE`](/v3/documentation/smart-contracts/func/docs/stdlib#set_code) or updated at runtime using `set_c3` until the end of execution.
 
-### 7. TON Blockchain has several transaction phases: computational phase, actions phase, and a bounce phase among them
+### 7. TON Blockchain has several transaction phases: compute phase, action phase, including a bounce phase
 
-The computational phase executes the code of smart contracts and only then the actions are performed (sending messages, code modification, changing libraries, and others). So, unlike on Ethereum-based blockchains, you won't see the computational phase exit code if you expected the sent message to fail, as it was performed not in the computational phase, but later, during the action phase.
+The compute phase executes the code of smart contracts and only then the actions are performed (sending messages, code modification, changing libraries, and others). Unlike on Ethereum-based blockchains, a sent message may fail during the action phase while the compute phase still exits successfully; such a failure is reflected in the action phase result, not in the compute phase exit code.
 
 - [Transactions and phases](/v3/documentation/tvm/tvm-overview#transactions-and-phases)
 
 ### 8. TON contracts are autonomous
 
-Contracts in the blockchain can reside in separate shards, processed by other set of validators, meaning that developer cannot pull data from other contracts on demand. Thus, any communication is asynchronous and done by sending messages.
+Contracts in the blockchain can reside in separate shards, processed by another set of validators, meaning that developers cannot pull data from other contracts on demand. Thus, any communication is asynchronous and done by sending messages.
 
-- [Sending messages from smart-contract](/v3/documentation/smart-contracts/message-management/sending-messages)
+- [Sending messages from smart contract](/v3/documentation/smart-contracts/message-management/sending-messages)
 - [Sending messages from DApp](/v3/guidelines/ton-connect/cookbook/ton-transfer)
 
-### 9. Unlike other blockchains, TON does not contain revert messages, only exit codes
+### 9. TON does not include revert reason strings; outcomes are indicated by [exit codes](/v3/documentation/tvm/tvm-exit-codes)
 
 It is helpful to think through the roadmap of exit codes for the code flow (and have it documented) before starting programming your TON smart contract.
 
-### 10. Func functions that have method_id identifiers have method IDs
+### 10. FunC method IDs
 
-They can be either set explicitly `"method_id(5)"`, or implicitly by a func compiler. In this case, they can be found among methods declarations in the .fift assembly file. Two of them are predefined: one for receiving messages inside of blockchain `(0)`, commonly named `recv_internal`, and one for receiving messages from outside `(-1)`, `recv_external`.
+They can be either set explicitly `method_id(5)`, or implicitly by the FunC compiler. In this case, they can be found among method declarations in the Fift assembly (.fif) file. Two of them are predefined: `recv_internal` = 0 (receiving messages inside the blockchain) and `recv_external` = -1 (receiving messages from outside).
 
-### 11. TON crypto address may not have any coins or code
+### 11. TON address may not have any coins or code
 
-Smart contracts addresses in TON blockchain are deterministic and can be precomputed. Ton Accounts, associated with addresses may even contain no code which means they are uninitialized (if not deployed) or frozen while having no more storage or TON coins if the message with special flags was sent.
+Smart contract addresses on the TON Blockchain are deterministic and can be precomputed. Accounts have states: non-existent, uninitialized, active, or frozen. Uninitialized addresses may still hold a balance.
 
-### 12. TON addresses may have three representations
+### 12. TON addresses have two standard representations
 
-TON addresses may have three representations.
-A full representation can either be "raw" (`workchain:address`) or "user-friendly". The last one is the one users encounter most often. It contains a tag byte, indicating whether the address is `bounceable` or `not bounceable`, and a workchain id byte. This information should be noted.
+A full representation can either be "raw" (`workchain:address`) or "user-friendly". The latter is the one users encounter most often. It contains a tag byte (e.g., bounceable, testnet, checksum) and a workchain ID byte. For full definitions of user-friendly flags, refer to the Address formats page below.
 
 - [Raw and user-friendly addresses](/v3/documentation/smart-contracts/addresses/address-formats)
 
-### 13. Keep track of the flaws in code execution
+### 13. Understand method visibility
 
-Unlike Solidity where it's up to you to set methods visibility, in the case of Func, the visibility is restricted in a more intricate way either by showing errors or by `if` statements.
+FunC has no visibility specifiers (unlike Solidity); implement access control in message handlers and contract logic.
 
-### 14. Keep an eye on gas before sending bounced messages
+### 14. Keep an eye on fees before sending bounced messages
 
-In case the smart contract sends the bounced messages with the value, provided by a user, make sure that the corresponding gas fees are subtracted from the returned amount not to be drained.
+When returning bounced value provided by a user, subtract the corresponding fees and be explicit about message mode/flags to control fee charging and bounce behavior.
 
 ### 15. Monitor the callbacks and their failures
 
-TON blockchain is asynchronous. That means the messages do not have to arrive successively. e.g. when a fail notification of an action arrives, it should be handled properly.
+TON blockchain is asynchronous. That means messages do not necessarily arrive in order; e.g., when a failure notification of an action arrives, it should be handled properly.
 
-### 16. Check if the bounced flag was sent receiving internal messages
+### 16. Check the bounced flag when receiving internal messages
 
 You may receive bounced messages (error notifications), which should be handled.
 
@@ -99,4 +98,3 @@ You may receive bounced messages (error notifications), which should be handled.
 - [Original article](https://0xguard.com/things_to_focus_on_while_working_with_ton_blockchain) - _0xguard_
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-smart-contracts-security-things-to-focus.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/smart-contracts/security/things-to-focus.mdx`

Related issues (from issues.normalized.md):
- [ ] **4010. Correct identifier rules and examples**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/things-to-focus.mdx?plain=1#L11-L12

Identifiers must not include ; , ( ) [ ] spaces/tabs, ~, or . (only function names may start with ~ or .), so remove the “including commas” claim, fix examples (e.g., drop `~bits` as a variable and show it only as a function name example), and improve wording to “valid”, “e.g.,” and “variable and function names”.

---

- [x] **4011. Use “FunC”, not “Func”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/things-to-focus.mdx?plain=1#L11-L13,L24,L64

Replace all instances of “Func” with “FunC” in headings and body text.

---

- [x] **4012. Fix linter sentence grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/things-to-focus.mdx?plain=1#L13

Change “When writing and inspecting a Func code, Linter should be used.” to “When writing and reviewing FunC code, use a linter.”

---

- [x] **4013. Fix “variables values” typo**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/things-to-focus.mdx?plain=1#L28

Change “variables values” to “variable values.”

---

- [ ] **4014. Use “Toncoin” and add article**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/things-to-focus.mdx?plain=1#L32

Use the currency name “Toncoin” (not “TON”) and add the article: “the contract may run out of Toncoin…”.

---

- [x] **4015. Use canonical phase names and improve heading phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/things-to-focus.mdx?plain=1#L47

Replace “computational phase”/“actions phase” with “compute phase”/“action phase” and rephrase “and a bounce phase among them” to “including a bounce phase.”

---

- [x] **4016. Clarify action-phase failures vs compute exit codes**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/things-to-focus.mdx?plain=1#L47

Explain that if a sent message fails during the action phase, the compute phase may still exit successfully and the failure is reflected in the action phase result, not the compute phase exit code.

---

- [x] **4017. Fix sharding paragraph grammar and link hyphenation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/things-to-focus.mdx?plain=1#L55-L58

Change “processed by other set of validators” to “processed by another set of validators”, “developer” to “developers”, and update the link text to “Sending messages from smart contract” (remove the hyphen).

---

- [x] **4018. Clean up FunC method IDs section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/things-to-focus.mdx?plain=1#L64-L66

Rename the heading to “FunC method IDs”, format `method_id(5)` without quotes, change “a func compiler” to “the FunC compiler” and “methods declarations” to “method declarations”, refer to “Fift assembly (.fif)”, and ensure predefined IDs are correct (e.g., `recv_internal` = 0, `recv_external` = -1).

---

- [ ] **4019. Fix address terminology, capitalization, and states**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/things-to-focus.mdx?plain=1#L68-L71

Use “TON address” and “Smart contract addresses”, capitalize “the TON Blockchain”, and align wording with documented account states (non-existent, uninitialized, active, frozen) noting that uninitialized addresses may hold a balance.

---

- [x] **4020. Correct address representations and flag wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/things-to-focus.mdx?plain=1#L72-L76

Change “three representations” to “two standard representations: raw and user-friendly”, remove the duplicate sentence, prefer “workchain ID byte”, and refer readers to the Address formats page for full user‑friendly flag definitions (bounceable/testnet/checksum).

---

- [ ] **4021. Clarify visibility heading and content**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/things-to-focus.mdx?plain=1#L79-L81

Retitle to “Understand method visibility” and state that FunC has no visibility specifiers (unlike Solidity); access control is implemented in message handlers and contract logic.

---

- [ ] **4022. Make bounced-fee guidance actionable**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/things-to-focus.mdx?plain=1#L85

Clarify that when returning bounced value provided by a user, subtract the corresponding fees and be explicit about message mode/flags to control fee charging and bounce behavior.

---

- [ ] **4023. Improve asynchronous delivery phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/things-to-focus.mdx?plain=1#L89

Use “do not necessarily arrive in order”, fix “fail notification” to “failure notification”, and place a comma after “e.g.,”.

---

- [ ] **4024. Fix bounced flag header grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/things-to-focus.mdx?plain=1#L91

Change the header to “Check the bounced flag when receiving internal messages.”

---

- [ ] **4025. Remove undefined “code registry” claim and clarify code updates**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/things-to-focus.mdx?plain=1

Avoid asserting that the actor model implies mutability or mentioning an undefined “code registry”; state that contract code can be updated via `set_code` (and `set_c3` for runtime updates) instead.

---

- [x] **4026. Clarify “no revert messages” phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/things-to-focus.mdx?plain=1

Replace with “TON does not include revert reason strings; outcomes are indicated by exit codes,” and link “exit codes” to the canonical page.

---

- [ ] **4027. Rephrase throw(0)/throw(1) behavior**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/security/things-to-focus.mdx?plain=1

State that the contract can explicitly terminate with a successful exit by calling `throw(0)` or `throw(1)`.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.