### PR TITLE
Split: update docs/v3/guidelines/smart-contracts/testing/blueprint-config.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/smart-contracts/testing/blueprint-config.mdx
+++ b/docs/v3/guidelines/smart-contracts/testing/blueprint-config.mdx
@@ -1,6 +1,6 @@
 # Using blueprint.config.ts
 
-`blueprint.config.ts` is an **optional yet convenient** file that lives in the project root and pre-defines all network (and other) CLI parameters.
+`blueprint.config.ts` is an **optional yet convenient** file that lives in the project root and predefines all network (and other) CLI parameters.
 
 **Why bother?**
 
@@ -8,7 +8,7 @@
 - Keep a single source of truth every team member shares.
 - Still freely override any option with a CLI flag when you need to.
 
-### File skeleton
+## File skeleton
 
 ```ts
 import { Config } from '@ton/blueprint';
@@ -18,34 +18,37 @@ export const config: Config = {
 };
 ```
 
-After that you can simply call:
+Blueprint loads the named export `config` from `blueprint.config.ts`.
+
+After that, you can simply call:
 
 ```bash
 npx blueprint run          # or build / test / etc.
 ```
 
-CLI flags always have higher priority and can temporarily override the settings from the config.
+ 
 
-### Option reference
+## Option reference
 
 <div className="doc-table blueprint-options">
 | Path | Type / Values | Default | Description |
 |------|---------------|---------|-------------|
-| `plugins` | `Plugin[]` | `[]` | Connect external Blueprint extensions. A plugin must implement the `Plugin` interface and return a set of CLI runners. |
+| `plugins` | `Plugin[]` | `[]` | Connect external Blueprint extensions. A plugin must implement the `Plugin` interface. |
 | `network` | `'mainnet' \| 'testnet'` or `CustomNetwork` | `undefined` | Default network environment. If omitted, Blueprint will ask at runtime. |
-| `network.endpoint` | `string` | — | RPC node URL. Required for `custom`; for the rest the built-in TON Center endpoint is used. |
-| `network.version` | `'v2' \| 'v4' \| 'tonapi' \| 'liteclient'` | `'v2'` | API version of the target node. |
+| _Note (CustomNetwork):_ |  |  | When using the object form (`CustomNetwork`), the following fields apply. Defaults mentioned below apply only within `CustomNetwork`. |
+| `network.endpoint` | `string` | — | RPC node URL. Required for `custom`; for other types, the built-in [TON Center](/v3/guidelines/dapps/apis-sdks/ton-http-apis#rpc-nodes) endpoint is used. |
+| `network.version` | `'v2' \| 'v4' \| 'tonapi' \| 'liteclient'` | `'v2'` | API backend/mode — `v2`/`v4`: TON Center; `tonapi`: TonAPI; `liteclient`: lite-client. See [TON HTTP APIs](/v3/guidelines/dapps/apis-sdks/ton-http-apis). |
 | `network.key` | `string` | — | API key if required (e.g., TON Center v2 / TonAPI). |
 | `network.type` | `'mainnet' \| 'testnet' \| 'custom'` | `'custom'` | Logical network type that will be reflected in explorer links, etc. |
 | `separateCompilables` | `boolean` | `false` | When `true`, `*.compile.ts` files are placed into `compilables` folder (otherwise into `wrappers`). |
 | `requestTimeout` | `number` (ms) | `undefined` | Overrides the global HTTP timeout for API requests. |
-| `recursiveWrappers` | `boolean` | `false` | Recursively walk through sub-folders of `wrappers` / `compilables` when searching for contracts. |
+| `recursiveWrappers` | `boolean` | `false` | Recursively walk through subfolders of `wrappers/compilables` when searching for contracts. |
 | `manifestUrl` | `string` | `'https://raw.githubusercontent.com/ton-org/blueprint/main/tonconnect/manifest.json'` | URL of the `manifest.json` file that a TON Connect wallet shows to the user. |
 </div>
 
-> **Priority:** CLI flags (e.g. `--custom …`) always override values from the config.
+> **Priority:** CLI flags (e.g. `--testnet ...`) always override values from the config.
 
-### Full example
+## Full example
 
 ```ts
 import { Config } from '@ton/blueprint';
@@ -68,7 +71,9 @@ export const config: Config = {
 };
 ```
 
-### When to use
+Note: `blueprint-scaffold` is shown only as an example plugin; replace it with your own plugin as needed.
+
+## When to use
 
 1. **CI & automation** – run `blueprint build`, `blueprint test`, etc. without any interactive questions.  
 2. **Team projects** – share the same network parameters and timeouts across all developers.  

--- a/docs/v3/guidelines/smart-contracts/testing/blueprint-config.mdx
+++ b/docs/v3/guidelines/smart-contracts/testing/blueprint-config.mdx
@@ -10,6 +10,8 @@
 
 ## File skeleton
 
+If a config is needed, create a blueprint.config.ts file in the root of your project with something like this:
+
 ```ts
 import { Config } from '@ton/blueprint';
 
@@ -36,9 +38,9 @@ npx blueprint run          # or build / test / etc.
 | `plugins` | `Plugin[]` | `[]` | Connect external Blueprint extensions. A plugin must implement the `Plugin` interface. |
 | `network` | `'mainnet' \| 'testnet'` or `CustomNetwork` | `undefined` | Default network environment. If omitted, Blueprint will ask at runtime. |
 | _Note (CustomNetwork):_ |  |  | When using the object form (`CustomNetwork`), the following fields apply. Defaults mentioned below apply only within `CustomNetwork`. |
-| `network.endpoint` | `string` | — | RPC node URL. Required for `custom`; for other types, the built-in [TON Center](/v3/guidelines/dapps/apis-sdks/ton-http-apis#rpc-nodes) endpoint is used. |
-| `network.version` | `'v2' \| 'v4' \| 'tonapi' \| 'liteclient'` | `'v2'` | API backend/mode — `v2`/`v4`: TON Center; `tonapi`: TonAPI; `liteclient`: lite-client. See [TON HTTP APIs](/v3/guidelines/dapps/apis-sdks/ton-http-apis). |
-| `network.key` | `string` | — | API key if required (e.g., TON Center v2 / TonAPI). |
+| `network.endpoint` | `string` | — | API URL. Required for `custom`; for other types, the built-in [TON Center](https://docs.ton.org/v3/guidelines/dapps/apis-sdks/api-types) endpoint is used. |
+| `network.version` | `'v2' \| 'v4' \| 'tonapi' \| 'liteclient'` | `'v2'` | API backend/mode — `v2`: TON Center; `tonapi`: TON API; `liteclient`: lite-client. See [APIs](https://docs.ton.org/v3/guidelines/dapps/apis-sdks/api-types). |
+| `network.key` | `string` | — | API key if required (e.g., TON Center or TonAPI). |
 | `network.type` | `'mainnet' \| 'testnet' \| 'custom'` | `'custom'` | Logical network type that will be reflected in explorer links, etc. |
 | `separateCompilables` | `boolean` | `false` | When `true`, `*.compile.ts` files are placed into `compilables` folder (otherwise into `wrappers`). |
 | `requestTimeout` | `number` (ms) | `undefined` | Overrides the global HTTP timeout for API requests. |


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-smart-contracts-testing-blueprint-config.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/smart-contracts/testing/blueprint-config.mdx`

Related issues (from issues.normalized.md):
- [x] **4044. Use “predefines” not “pre‑defines”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/blueprint-config.mdx?plain=1#L3

Replace “pre-defines” with the closed form “predefines” for style consistency.

---

- [x] **4045. Add comma after introductory phrase**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/blueprint-config.mdx?plain=1#L21

Insert a comma: “After that, you can simply call:”.

---

- [x] **4046. Clarify default endpoint phrasing and link provider**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/blueprint-config.mdx?plain=1#L36

Change to “Required for ‘custom’; for other types, the built-in TON Center endpoint is used,” and link “TON Center” to docs/v3/guidelines/dapps/apis-sdks/ton-http-apis.mdx#rpc-nodes.

---

- [x] **4047. Rename “API version” and explain options**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/blueprint-config.mdx?plain=1#L37

Rename the label to “API backend/mode” and add one‑line meanings for 'v2', 'v4', 'tonapi', and 'liteclient', linking to docs/v3/guidelines/dapps/apis-sdks/ton-http-apis.mdx for context.

---

- [x] **4048. Prefer “subfolders” and tighten path slashes**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/blueprint-config.mdx?plain=1#L42

Use “subfolders” (not “sub-folders”) and remove spaces around slashes in paths (e.g., “wrappers/compilables”).

---

- [ ] **4049. Fix CLI override example and remove duplicate note**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/blueprint-config.mdx?plain=1#L46

Change the example to use a real flag (e.g., “--testnet”), replace the Unicode ellipsis with ASCII “…”, and remove the redundant earlier sentence at L27 so the point is stated once.

---

- [x] **4050. Clarify network union shape and defaults scope**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/blueprint-config.mdx?plain=1

Add a note before sub‑field rows: “When using the object form (CustomNetwork), the following fields apply,” and state that defaults (e.g., network.type: 'custom') apply only within CustomNetwork.

---

- [x] **4051. Specify required export from blueprint.config.ts**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/blueprint-config.mdx?plain=1

Explicitly state the export shape (e.g., “Blueprint loads the named export ‘config’”); if a default export is also supported, say so.

---

- [x] **4052. Replace or document example plugin reference**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/blueprint-config.mdx?plain=1

Replace the undocumented 'blueprint-scaffold' example with a neutral placeholder (e.g., “// plugins: [new YourPlugin()]”) or link to official plugin documentation if applicable.

---

- [x] **4053. Promote section headings to level 2**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/blueprint-config.mdx?plain=1

Change section headings from “###” to “##” under the top-level title for proper hierarchy and navigation.

---

- [x] **4054. Define or trim “CLI runners” in plugin description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/blueprint-config.mdx?plain=1

Either link to a reference defining the Plugin interface and “CLI runners” or remove the unverifiable “returns a set of CLI runners” claim.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.