### PR TITLE
Split: update docs/v3/guidelines/smart-contracts/testing/collect-contract-gas-metric.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/smart-contracts/testing/collect-contract-gas-metric.mdx
+++ b/docs/v3/guidelines/smart-contracts/testing/collect-contract-gas-metric.mdx
@@ -1,6 +1,6 @@
 import Feedback from '@site/src/components/Feedback';
 
-# Collecting contract gas metrics
+# Collect contract gas metric
 
 ## Gas consumption
 
@@ -16,14 +16,14 @@ For a deeper breakdown of how fees work in TON, refer to:
 - [Transaction fees](/v3/documentation/smart-contracts/transaction-fees/fees)
 - [Storage fees](/v3/documentation/smart-contracts/transaction-fees/fees-low-level#storage-fee)
 - [Forward fees](/v3/documentation/smart-contracts/transaction-fees/forward-fees)
-  :::
+:::
 
 ## Gas metrics reporting
 
 To simplify tracking changes in gas usage and data size,
 we’ve introduced a reporting system that lets you collect and compare metrics across different versions of a contract.
 
-To enable this, write test scenarios that cover the contract’s primary usage patterns and verify that its behavior is as expected. This approach is sufficient to gather relevant metrics, which you can later use to compare performance changes after updating the implementation.
+To enable this, write test scenarios that cover the contract’s primary usage patterns and verify expected behavior. This approach is sufficient to gather relevant metrics, which you can later use to compare performance changes after updating the implementation.
 
 Before running the tests, a store is created to collect metrics from all transactions generated during the tests. After test execution, the collected metrics are supplemented with [ABI information from the snapshot](https://github.com/ton-org/sandbox/blob/main/docs/collect-metric-api.md#abi-auto-mapping), and a report is generated based on this data.
 
@@ -117,7 +117,7 @@ npx blueprint test --gas-report
 
 This runs your tests with gas tracking enabled and outputs a `gas-report.json` with transaction metrics.
 
-```cpp
+```text
 ...
 PASS  Comparison metric mode: gas depth: 1
 Gas report write in 'gas-report.json'
@@ -141,7 +141,7 @@ Gas report write in 'gas-report.json'
 You can use the `cells` and `bits` values from the report to estimate the **storage fee** for your contract.
 Here’s the formula:
 
-```cpp
+```text
 storage_fee = ceil(
                   (account.bits * bit_price
                   + account.cells * cell_price)
@@ -184,7 +184,7 @@ npx blueprint test --gas-report
 
 Now the method name appears in the report as `increase`, making it easier to read:
 
-```cpp
+```text
 ...
 │           ├──────────────┼──────────┼────────┼───────┤
 │           │   increase   │   2681   │   11   │  900  │
@@ -201,7 +201,7 @@ npx blueprint snapshot --label "v1"
 
 This creates a snapshot file in `.snapshot/`:
 
-```cpp
+```text
 ...
 PASS  Collect metric mode: "gas"
 Report write in '.snapshot/1749821319408.json'
@@ -239,7 +239,7 @@ npx blueprint test --gas-report
 
 You see a side-by-side comparison of gas usage before and after the change:
 
-```cpp
+```text
 ...
 PASS  Comparison metric mode: gas depth: 2
 Gas report write in 'gas-report.json'
@@ -267,24 +267,19 @@ You can do this in one of two ways:
 
 Add the necessary environment and reporter settings:
 
-```ts title="jest.config.ts"
+```diff title="jest.config.ts"
 import type { Config } from 'jest';
 
 const config: Config = {
     preset: 'ts-jest',
-+    testEnvironment: '@ton/sandbox/jest-environment',
     testPathIgnorePatterns: ['/node_modules/', '/dist/'],
-+    reporters: [
-+        'default',
-+        ['@ton/sandbox/jest-reporter', {}],
-+    ]
 };
 
 export default config;
 ```
 
 :::tip
-See the full list of options in the [Sandbox jest config docs](https://github.com/ton-org/sandbox?tab=readme-ov-file#setup-in-jestconfigts).
+See the full list of options in the [Sandbox Jest config docs](https://github.com/ton-org/sandbox/blob/main/README.md#setup-in-jestconfigts).
 :::
 
 #### Option 2: create a separate config `gas-report.config.ts`
@@ -315,7 +310,7 @@ npx blueprint snapshot --label 'v2' -- --config gas-report.config.ts
 
 You can collect metrics manually using the low-level API from `@ton/sandbox`.
 
-```typescript title=""
+```typescript title="collect-metrics.ts"
 import {
     Blockchain,
     createMetricStore,
@@ -343,6 +338,6 @@ main().catch((error) => {
 });
 ```
 
-For more details, see the [Collect Metric API documentation](https://github.com/ton-org/sandbox/blob/develop/docs/collect-metric-api.md#example).
+For more details, see the [Collect Metric API documentation](https://github.com/ton-org/sandbox/blob/main/docs/collect-metric-api.md#example).
 
 <Feedback />

--- a/docs/v3/guidelines/smart-contracts/testing/collect-contract-gas-metric.mdx
+++ b/docs/v3/guidelines/smart-contracts/testing/collect-contract-gas-metric.mdx
@@ -27,7 +27,7 @@ To enable this, write test scenarios that cover the contract’s primary usage p
 
 Before running the tests, a store is created to collect metrics from all transactions generated during the tests. After test execution, the collected metrics are supplemented with [ABI information from the snapshot](https://github.com/ton-org/sandbox/blob/main/docs/collect-metric-api.md#abi-auto-mapping), and a report is generated based on this data.
 
-While more [metrics are collected](https://github.com/ton-org/sandbox/blob/main/docs/collect-metric-api.md#snapshot-structure), the current report format includes only `compute.phase`, `state.code`, and `state.data`.
+While more [metrics are collected](https://github.com/ton-org/sandbox/blob/main/docs/collect-metric-api.md#snapshot-structure), the current report format includes `gasUsed`, `cells`, and `bits`, which correspond to the internal metrics `compute.phase`, `state.code`, and `state.data`.
 
 ## Metrics comparison example
 
@@ -38,6 +38,17 @@ Start by creating a new project using `npm create ton@latest`:
 ```bash
 npm create ton@latest -y -- sample --type func-counter --contractName Sample
 cd sample
+```
+
+**Note:**
+- The `-y` flag skips prompts and accepts defaults.
+- `--type` specifies the template (e.g., `func-counter`).
+- `--contractName` sets the contract name.
+
+Alternatively, you can run:
+
+```bash
+npm create ton@latest sample
 ```
 
 This command scaffolds a project with a basic counter contract at `contracts/sample.fc`.
@@ -145,7 +156,7 @@ Here’s the formula:
 storage_fee = ceil(
                   (account.bits * bit_price
                   + account.cells * cell_price)
-               * time_delta / 2 ^ 16)
+               * time_delta / 2 ** 16)
 ```
 
 To try this in practice, use the [calculator example](/v3/documentation/smart-contracts/transaction-fees/fees-low-level#calculator-example).
@@ -272,14 +283,19 @@ import type { Config } from 'jest';
 
 const config: Config = {
     preset: 'ts-jest',
++    testEnvironment: '@ton/sandbox/jest-environment',
     testPathIgnorePatterns: ['/node_modules/', '/dist/'],
++    reporters: [
++        'default',
++        ['@ton/sandbox/jest-reporter', {}],
++    ]
 };
 
 export default config;
 ```
 
 :::tip
-See the full list of options in the [Sandbox Jest config docs](https://github.com/ton-org/sandbox/blob/main/README.md#setup-in-jestconfigts).
+See the full list of options in the [Sandbox jest config docs](https://github.com/ton-org/sandbox/blob/main/README.md#setup-in-jestconfigts).
 :::
 
 #### Option 2: create a separate config `gas-report.config.ts`
@@ -303,7 +319,7 @@ When using this separate config, pass it using the `--config` option:
 
 ```bash
 npx blueprint test --gas-report -- --config gas-report.config.ts
-npx blueprint snapshot --label 'v2' -- --config gas-report.config.ts
+npx blueprint snapshot --label "v2" -- --config gas-report.config.ts
 ```
 
 ## Collect metrics manually


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-smart-contracts-testing-collect-contract-gas-metric.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/smart-contracts/testing/collect-contract-gas-metric.mdx`

Related issues (from issues.normalized.md):
- [x] **4055. Fix tip block closing fence indentation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/collect-contract-gas-metric.mdx?plain=1#L13-L18

The closing ::: of the first tip block is indented by two spaces; unindent it so the fence is exactly ::: aligned with the opening :::tip.

---

- [x] **4056. Simplify phrasing for expected behavior**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/collect-contract-gas-metric.mdx?plain=1#L26-L35

Replace “and verify that its behavior is as expected.” with “and verify expected behavior.”

---

- [x] **4057. Use text fences for console output tables**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/collect-contract-gas-metric.mdx?plain=1#L84-L110

Console/table outputs are fenced as cpp (here and similarly at L177-L183 and L208-L217); change these code fences to text or omit the language for plain output.

---

- [ ] **4058. Clarify storage fee formula and fence language**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/collect-contract-gas-metric.mdx?plain=1#L118-L127

Change the formula to avoid XOR ambiguity and use a text fence, e.g., replace “2 ^ 16” with “2**16” (or “2^16” without spaces) and fence the block as text.

---

- [ ] **4059. Clarify opcode vs method name mapping**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/collect-contract-gas-metric.mdx?plain=1#L129-L138

Clarify that op::increase is a constant and the report initially shows the operation code (e.g., 0x7e8764ef) until mapped via the ABI, not the method name.

---

- [ ] **4060. Add caution about inlining increasing code size**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/collect-contract-gas-metric.mdx?plain=1#L233-L251

Augment the note to mention that inlining can increase code size, which may affect storage costs.

---

- [x] **4061. Update Sandbox Jest tip link to stable README blob**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/collect-contract-gas-metric.mdx?plain=1#L298-L301

Replace the UI-specific URL with a stable link: use https://github.com/ton-org/sandbox/blob/main/README.md#setup-in-jestconfigts.

---

- [x] **4062. Capitalize “Jest” in link text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/collect-contract-gas-metric.mdx?plain=1#L300-L301

Correct the link text to use “Jest” with a capital J for proper noun consistency.

---

- [x] **4063. Provide meaningful code block title for TypeScript example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/collect-contract-gas-metric.mdx?plain=1#L323-L360

Replace the empty title attribute (title="") with a meaningful filename, e.g., title="collect-metrics.ts", or remove the title attribute entirely.

---

- [x] **4064. Point Collect Metric API link to main branch**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/collect-contract-gas-metric.mdx?plain=1#L362-L366

Change https://github.com/ton-org/sandbox/blob/develop/docs/collect-metric-api.md#example to https://github.com/ton-org/sandbox/blob/main/docs/collect-metric-api.md#example.

---

- [ ] **4065. Fix diff markers in jest.config.ts example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/collect-contract-gas-metric.mdx?plain=1

In the “Option 1” jest.config.ts snippet, remove leading “+” characters (or alternatively change the fence to diff); prefer keeping ```ts and removing the pluses to present valid TypeScript.

---

- [ ] **4066. Align text with visible report columns**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/collect-contract-gas-metric.mdx?plain=1

Revise the description to match the examples by stating that the report shows gasUsed, cells, and bits (omit internal metric names or add a brief parenthetical mapping if needed).

---

- [ ] **4067. Standardize quotes in snapshot labels**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/collect-contract-gas-metric.mdx?plain=1

Use a consistent quoting style for snapshot labels (e.g., use double quotes in all examples).

---

- [ ] **4068. Explain npm create flags or add interactive alternative**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/collect-contract-gas-metric.mdx?plain=1

Add a brief note explaining -y, --type, and --contractName, and include an interactive alternative command (e.g., npm create ton@latest sample) for users to select options via prompts.

---

- [ ] **4069. Align page title with index entry**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/collect-contract-gas-metric.mdx?plain=1

Make the H1 match the index wording; for consistency, change the page title to “Collect contract gas metric” (or update the index accordingly).

---

- [ ] **4070. Include default reporter in Jest reporters example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/collect-contract-gas-metric.mdx?plain=1

In “Option 2,” preserve Jest’s default reporter by setting config.reporters = ["default", ["@ton/sandbox/jest-reporter", {}]].

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.