### PR TITLE
Split: update docs/v3/guidelines/smart-contracts/testing/overview.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/smart-contracts/testing/overview.mdx
+++ b/docs/v3/guidelines/smart-contracts/testing/overview.mdx
@@ -22,7 +22,7 @@ npx blueprint test
 As a result, you’ll see the corresponding output in the terminal window:
 
 ```bash
-% npx blueprint test
+npx blueprint test
 
 > MyProject@0.0.1 test
 > jest
@@ -40,18 +40,18 @@ Ran all test suites.
 
 ## Basic usage
 
-Testing smart contracts allows you to cover security, optimize gas spending, and examine edge cases.  
+Testing smart contracts allows you to cover security, optimize gas spending, and examine edge cases.
 Writing tests in Blueprint (based on [Sandbox](https://github.com/ton-org/sandbox)) involves defining arbitrary actions with the contract and comparing the test results with the expected outcome. For example:
 
 ```typescript
-it("should execute with success", async () => {
+it("should execute successfully", async () => {
   // Description of the test case
   const res = await main.sendMessage(sender.getSender(), toNano("0.05")); // Perform an action with the contract and save the result in res
 
   expect(res.transactions).toHaveTransaction({
     // Configure the expected result with the expect() function
-    from: main.address, // Set the expected sender for the transaction
-    success: true, // Set the desirable result using the matcher property success
+    on: main.address, // Set the expected target for the transaction
+    success: true, // Set the desired result using the matcher property success
  });
 
   printTransactionFees(res.transactions); // Print a table with details on spent fees
@@ -71,21 +71,19 @@ The `toHaveTransaction` matcher expects an object with any combination of fields
 | Name    | Type     | Description                                                                                                                                                |
 | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | from    | Address? | Contract address of the message sender                                                                                                                     |
-| on      | Address  | Contract address of the message destination (alternative name for the property `to`).                                                                      |
+| on      | Address? | Contract address of the message destination (alternative name for the property `to`).                                                                      |
 | value   | bigint?  | Amount of TON coins in the message, in nanotons                                                                                                            |
-| body    | Cell     | Message body defined as a Cell                                                                                                                             |
-| op      | number?  | Op code is usually the operation identifier number (crc32 from TL-B). Expected in the first 32 bits of a message body.                                     |
-| success | boolean? | Custom Sandbox flag that defines the resulting status of a certain transaction. True if both the compute and the action phases succeeded. Otherwise, False. |
+| body    | Cell?    | Message body defined as a Cell                                                                                                                             |
+| op      | number?  | Opcode is usually the operation identifier number (CRC32 from TL-B). Expected in the first 32 bits of a message body.                                      |
+| success | boolean? | Custom Sandbox flag that defines the resulting status of a certain transaction. true if both the compute and the action phases succeeded; otherwise, false. |
 
 You can omit fields you’re not interested in and pass functions that accept the types and return booleans (`true` meaning good) to check, for example, number ranges, message opcodes, etc. Note that if a field is optional (like `from?: Address`), the function must also accept the optional type.
 
-:::tip  
-The complete list of matcher fields is in the [Sandbox documentation](https://github.com/ton-org/sandbox#test-a-transaction-with-matcher).  
+:::tip
+The complete list of matcher fields is in the [Sandbox documentation](https://github.com/ton-org/sandbox#test-a-transaction-with-matcher).
 :::
 
-### Specific test suite
-
-#### Extract send mode
+### Extracting send mode
 
 To extract the send mode of a sent message, use the following code:
 
@@ -100,7 +98,7 @@ const re = await blockchain.executor.runTransaction({
  .endCell()
  .toBoc()
  .toString("base64"),
-  now: Math.floor(Date.now()) / 1000,
+  now: Math.floor(Date.now() / 1000),
   lt: BigInt(Date.now()),
   randomSeed: null,
   ignoreChksig: false,
@@ -145,4 +143,3 @@ Check test suites used for TON Ecosystem contracts and learn by examples:
 - [Blueprint](/v3/documentation/smart-contracts/getting-started/javascript)
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-smart-contracts-testing-overview.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/smart-contracts/testing/overview.mdx`

Related issues (from issues.normalized.md):
- [ ] **4071. Fix UNIX timestamp flooring**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/overview.mdx?plain=1#extract-send-mode

In the “Extract send mode” snippet, change now: Math.floor(Date.now()) / 1000 to now: Math.floor(Date.now() / 1000) to ensure an integer UNIX timestamp in seconds.

---

- [ ] **4072. Use lowercase boolean literals**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/overview.mdx?plain=1#writing-tests-for-complex-assertions

Replace “True/False” with “true/false,” e.g., “true if both the compute and action phases succeeded; otherwise, false.”

---

- [ ] **4073. Standardize “opcode” and “CRC32” casing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/overview.mdx?plain=1

Use “opcode” (one word) and uppercase “CRC32”; e.g., “Opcode is usually the operation identifier (CRC32 from TL‑B), expected in the first 32 bits of the message body.”

---

- [ ] **4074. Remove shell prompt from output example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/overview.mdx?plain=1

Make shell output consistent by removing the leading “% ” so the block starts with npx blueprint test.

---

- [ ] **4075. Improve test name and comment wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/overview.mdx?plain=1#basic-usage

Change it("should execute with success", ...) to it("should execute successfully", ...) and “Set the desirable result” to “Set the desired result.”

---

- [ ] **4076. Correct Blueprint description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/overview.mdx?plain=1#overview

Replace “The TypeScript SDK, named Blueprint …” with a correct phrasing such as “Blueprint is the TON development environment for TypeScript and includes a test toolkit.”

---

- [ ] **4077. State Sandbox usage unambiguously**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/overview.mdx?plain=1#overview

Replace “(usually Sandbox)” with “uses Sandbox for testing” or “is based on Sandbox for testing.”

---

- [ ] **4078. Mark matcher fields optional consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/overview.mdx?plain=1#writing-tests-for-complex-assertions

Align the table with “any combination of fields” by marking fields like on and body as optional (e.g., on: Address?, body: Cell?).

---

- [ ] **4079. Rename “Specific test suite” section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/overview.mdx?plain=1

Rename the section to better reflect the content, e.g., “Extracting send mode” (or “Advanced example”).

---

- [ ] **4080. Remove trailing spaces and fix admonition spacing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/overview.mdx?plain=1

Delete trailing double spaces and use :::tip without extra spaces to avoid unintended breaks and spacing.

---

- [ ] **4081. Disambiguate duplicate “Governance_tests” links**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/overview.mdx?plain=1#examples

Use distinct labels (e.g., “Governance_tests (config)” and “Governance_tests (elector)”) and ensure links point to relevant test suites.

---

- [ ] **4082. Fix indentation in basic example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/overview.mdx?plain=1#basic-usage

Align the closing brace in the toHaveTransaction call so it matches the opening level for improved readability.

---

- [ ] **4083. Correct matcher field for target contract**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/overview.mdx?plain=1#basic-usage

In the basic example, replace from: main.address with on: main.address to assert the transaction targets the contract.

---

- [ ] **4084. Define address in shardAccount example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/overview.mdx?plain=1#extract-send-mode

Introduce address before use (e.g., const address = /* contract Address */;) to make the snippet self-contained.

---

- [ ] **4085. Add imports for Cell and loadOutList**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/overview.mdx?plain=1#extract-send-mode

Add a brief note or import hints indicating that Cell and loadOutList must be imported from the appropriate packages before use.

---

- [ ] **4086. Document imports for toNano and printTransactionFees**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/overview.mdx?plain=1#basic-usage

Add a short note showing that toNano and printTransactionFees must be imported prior to use to make the example reproducible.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.