### PR TITLE
Split: update docs/v3/guidelines/smart-contracts/testing/writing-test-examples.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/smart-contracts/testing/writing-test-examples.mdx
+++ b/docs/v3/guidelines/smart-contracts/testing/writing-test-examples.mdx
@@ -8,7 +8,7 @@ import ThemedImage from "@theme/ThemedImage";
 This page demonstrates how to write tests for FunC contracts using the [Blueprint](https://github.com/ton-org/blueprint) ([Sandbox](https://github.com/ton-org/sandbox)).
 The test suites focus on the demo contract [Fireworks](https://github.com/ton-community/fireworks-func), a smart contract that starts running with the `set_first` message.
 
-When you create a new FunC project using `npm create ton@latest`, the SDK automatically generates a test file `tests/contract.spec.ts` in the project directory for testing the contract:
+When you create a new FunC project using `npm create ton@latest`, the SDK automatically generates a test file `tests/Main.spec.ts` in the project directory for testing the contract:
 
 ```typescript
 import ...
@@ -51,7 +51,7 @@ The Fireworks contract demonstrates different ways of sending messages in the TO
 
 <br></br>
 <ThemedImage
-  alt=""
+  alt="Direct unit tests flow diagram"
   sources={{
     light: "/img/docs/writing-test-examples/test-examples-schemes.svg?raw=true",
     dark: "/img/docs/writing-test-examples/test-examples-schemes-dark.svg?raw=true",
@@ -100,7 +100,7 @@ To filter a specific transaction from the `launchResult.transactions` array, you
 
 <br></br>
 <ThemedImage
-  alt=""
+  alt="Transaction ID 1 flow diagram"
   sources={{
     light:
       "/img/docs/writing-test-examples/test-examples-schemes_id1.svg?raw=true",
@@ -135,7 +135,7 @@ it("first transaction[ID:1] should set fireworks successfully", async () => {
 
 <br></br>
 <ThemedImage
-  alt=""
+  alt="Transaction ID 2 flow diagram"
   sources={{
     light:
       "/img/docs/writing-test-examples/test-examples-schemes_id2.svg?raw=true",
@@ -184,7 +184,7 @@ The complete list of account status-related fields includes:
 
 <br></br>
 <ThemedImage
-  alt=""
+  alt="Transaction ID 3 flow diagram"
   sources={{
     light:
       "/img/docs/writing-test-examples/test-examples-schemes_id3.svg?raw=true",
@@ -222,7 +222,7 @@ it("should exist a transaction[ID:3] which launches second fireworks successfull
 
 <br></br>
 <ThemedImage
-  alt=""
+  alt="Transaction ID 4 flow diagram"
   sources={{
     light:
       "/img/docs/writing-test-examples/test-examples-schemes_id4.svg?raw=true",
@@ -259,7 +259,7 @@ it("should exist a transaction[ID:4] with a comment send mode = 0", async () => 
 
 <br></br>
 <ThemedImage
-  alt=""
+  alt="Transaction ID 5 flow diagram"
   sources={{
     light:
       "/img/docs/writing-test-examples/test-examples-schemes_id5.svg?raw=true",
@@ -296,7 +296,7 @@ it("should exist a transaction[ID:5] with a comment send mode = 1", async () => 
 
 <br></br>
 <ThemedImage
-  alt=""
+  alt="Transaction ID 6 flow diagram"
   sources={{
     light:
       "/img/docs/writing-test-examples/test-examples-schemes_id6.svg?raw=true",
@@ -333,7 +333,7 @@ it("should exist a transaction[ID:6] with a comment send mode = 2", async () => 
 
 <br></br>
 <ThemedImage
-  alt=""
+  alt="Transaction ID 7 flow diagram"
   sources={{
     light:
       "/img/docs/writing-test-examples/test-examples-schemes_id7.svg?raw=true",
@@ -370,7 +370,7 @@ it("should exist a transaction[ID:7] with a comment send mode = 32 + 128", async
 
 <br></br>
 <ThemedImage
-  alt=""
+  alt="Transaction ID 8 flow diagram"
   sources={{
     light:
       "/img/docs/writing-test-examples/test-examples-schemes_id8.svg?raw=true",
@@ -431,7 +431,7 @@ For instance, in the case of `launchResult`, the following table will be printed
 | 7       | '0x0'        | '0.783142 TON' | '0 TON'        | '0.000309 TON' | 0          |
 | 8       | '0x0'        | '1.088638 TON' | '0 TON'        | '0.000309 TON' | 0          |
 
-![](/img/docs/writing-test-examples/fireworks_trace_tonviewer.png?=RAW)
+![Fireworks transaction fee trace](/img/docs/writing-test-examples/fireworks_trace_tonviewer.png?=RAW)
 
 **Index** refers to the ID of a transaction in the `launchResult` array.
 
@@ -637,4 +637,3 @@ Since the order of lines may change when updating the code, some links may becom
 :::
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-smart-contracts-testing-writing-test-examples.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/smart-contracts/testing/writing-test-examples.mdx`

Related issues (from issues.normalized.md):
- [ ] **4087. Update default test filename**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/writing-test-examples.mdx?plain=1#L11

Change the referenced generated test file from “tests/contract.spec.ts” to “tests/Main.spec.ts” to match the quick start and overview.

---

- [ ] **4088. Add descriptive alt text to images**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/writing-test-examples.mdx?plain=1#L54-L60

Replace empty alt attributes with brief descriptions (e.g., “Direct unit tests flow diagram”; apply similarly at L103–110, 139–145, 186–193, 223–230, 260–267, 297–304, 334–341, 371–378, and the fee trace image).

---

- [ ] **4089. Replace “usable combinations” with “common”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/writing-test-examples.mdx?plain=1#L62-L64

Use a more idiomatic phrasing: “…executes with primary and common combinations of send modes.”

---

- [ ] **4090. Clarify StateInit wording and casing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/writing-test-examples.mdx?plain=1#L67

Rephrase to: “For clarity, define Fireworks instances with different StateInit by ID as follows:”.

---

- [ ] **4091. Fix outbound IDs for “fireworks” messages**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/writing-test-examples.mdx?plain=1#L90

Change “IDs 3 and 4” to “IDs 2 and 3” to match the breakdown (Launcher‑1 emits four outbounds in ID:2; Launcher‑2 emits one outbound in ID:3).

---

- [ ] **4092. Add space in “transaction [ID:x]”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/writing-test-examples.mdx?plain=1#L112-L114

Use “transaction [ID:1]” (with a space) instead of “transaction[ID:1]”; apply consistently for IDs 1–8.

---

- [ ] **4093. Correct Transaction ID:3 narrative**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/writing-test-examples.mdx?plain=1#L196-L199

Update to: “Transaction [ID:3] occurs in Fireworks Launcher‑2, is invoked with op::launch_second, and executes one outbound message to the launcher.”

---

- [ ] **4094. Fix null-check in fees test**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/writing-test-examples.mdx?plain=1#L259-L261

Replace `if (computeFee == null || undefined || actionFee == null || undefined)` with `if (computeFee == null || actionFee == null)` (also fix the later duplicate at ~L479–L481).

---

- [ ] **4095. Correct 256‑bit integer range wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/writing-test-examples.mdx?plain=1#L296-L300

Change “-2^256 < x < 2^256” to “from -2^256 to 2^256 - 1 inclusive” for the valid signed 256‑bit range.

---

- [ ] **4096. Standardize “send mode = 128 + 32”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/writing-test-examples.mdx?plain=1#L345-L363

Use the same ordering in narrative and literals; set both to “send mode = 128 + 32”.

---

- [ ] **4097. Standardize “send mode = 64” wording for ID:8**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/writing-test-examples.mdx?plain=1#L369-L410

Align narrative and example body to use “send mode = 64” (replace any “send_mode = 64” occurrences).

---

- [ ] **4098. Fix outdated “This test” GitHub anchors**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/writing-test-examples.mdx?plain=1

Update “This test” links to stable permalinks with correct line ranges (IDs 4–8 are off), and fix the duplicate target for ID:7 and ID:8; or remove line anchors and link to the test file/sections to avoid drift.

---

- [ ] **4099. Normalize image query parameter**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/writing-test-examples.mdx?plain=1#L434

Change `fireworks_trace_tonviewer.png?=RAW` to `fireworks_trace_tonviewer.png?raw=true` for consistent rendering.

---

- [ ] **4100. Fix message count for ID:1 in fees section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/writing-test-examples.mdx?plain=1#L438-L446

Update the bullet for index 1 to say “two messages to the launcher,” matching the earlier explanation and table (outActions: 2).

---

- [ ] **4101. Align exit code 1 guidance with reference**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/writing-test-examples.mdx?plain=1#L498-L503

Revise to reflect that TVM exit code 1 is reserved and does not occur (or add a clarifying note consistent with the exit‑codes reference).

---

- [ ] **4102. Clarify function API naming consistency**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/smart-contracts/testing/writing-test-examples.mdx?plain=1#L520-L523

Use the correct API name consistently: prefer TypeScript `storeUint(...)` if referring to TS builders, or use FunC `store_uint(...)` if referring to FunC; do not mix styles in the same context.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.