### PR TITLE
Split: update docs/v3/guidelines/ton-connect/cookbook/cells.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/ton-connect/cookbook/cells.mdx
+++ b/docs/v3/guidelines/ton-connect/cookbook/cells.mdx
@@ -37,7 +37,7 @@ To build a cell, you use the `beginCell()` function. While the cell is _open_, y
 When you're done, you close the cell with the `endCell()` function.
 
 ```ts
-import { Address, beginCell } from "@ton/ton";
+import { Address, beginCell } from "@ton/core";
 
 const cell = beginCell()
   .storeUint(99, 64) // Stores uint 99 in 64 bits
@@ -47,8 +47,8 @@ const cell = beginCell()
 ```
 
 :::info
-These examples use the `@ton/ton` library only. <br/>
-However, every [TON SDK](/v3/guidelines/dapps/apis-sdks/sdk) offers equivalent helper functions.
+These examples use the `@ton/core` library only. <br/>
+However, many [SDKs](/v3/guidelines/dapps/apis-sdks/sdk) provide similar helper functions.
 :::
 
 ### Parsing a cell
@@ -107,14 +107,15 @@ const cell = beginCell()
   .storeMaybeInt(1, 64)
   .storeMaybeRef(null) // Optionally stores a reference
   .storeMaybeRef(beginCell().storeCoins(123).endCell());
+  .endCell();
 ```
 
 You can parse optional values using the corresponding `loadMaybe...()` functions. Returned values are nullable, so do not forget to check them for null.
 
 ```ts
 const slice = cell.beginParse();
-const maybeInt = slice.loadMaybeUint(64);
-const maybeInt1 = slice.loadMaybeUint(64);
+const maybeInt = slice.loadMaybeInt(64);
+const maybeInt1 = slice.loadMaybeInt(64);
 const maybeRef = slice.loadMaybeRef();
 const maybeRef1 = slice.loadMaybeRef();
 if (maybeRef1) {
@@ -154,7 +155,7 @@ Using `@ton-community/assets-sdk` is more readable and less error-prone.
 
   </TabItem>
 
-  <TabItem value="@ton/ton" label="@ton/ton">
+  <TabItem value="@ton/core" label="@ton/core">
 
     ```ts
     import { Address, beginCell } from "@ton/core";

--- a/docs/v3/guidelines/ton-connect/cookbook/cells.mdx
+++ b/docs/v3/guidelines/ton-connect/cookbook/cells.mdx
@@ -18,7 +18,7 @@ import TabItem from '@theme/TabItem';
 
 # Message body
 
-When working with TON Connect you’ll need to craft a message body — a payload encoded in cells — for any on-chain action other than a simple TON transfer. This page explains the cell–building basics; concrete payload recipes are given on the following Cookbook pages.
+When working with TON Connect you’ll need to craft a message body — a payload encoded in cells — for any on-chain action other than a simple TON transfer. This page explains the cell-building basics; concrete payload recipes are given on the following Cookbook pages.
 
 ## Cells and message serialization
 
@@ -26,7 +26,7 @@ Before diving into building messages, let's introduce the concept of cells, whic
 
 ### What is a cell?
 
-A cell is a basic data structure in the TON Blockchain. It can store up to `1023` bits and hold up to `4` references to other cells, which allows you to store more complex data structures.
+A cell is a basic data structure in the TON blockchain. It can store up to `1023` bits and hold up to `4` references to other cells, which allows you to store more complex data structures.
 Libraries like `@ton/core` and `@ton-community/assets-sdk` provide efficient cell handling.
 
 You can read more about cells [here](/v3/documentation/data-formats/tlb/cell-boc).
@@ -41,7 +41,7 @@ import { Address, beginCell } from "@ton/ton";
 
 const cell = beginCell()
   .storeUint(99, 64) // Stores uint 99 in 64 bits
-  .storeAddress(Address.parse("[SOME_ADDR]")) // Stores an address
+  .storeAddress(Address.parse("EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c")) // Stores an address
   .storeCoins(123) // Stores 123 as coins
   .endCell(); // Closes the cell
 ```
@@ -109,7 +109,7 @@ const cell = beginCell()
   .storeMaybeRef(beginCell().storeCoins(123).endCell());
 ```
 
-You can parse optional values using the corresponding `loadMaybe...()` functions. Returned values are nullable so do not forget to check them for null!
+You can parse optional values using the corresponding `loadMaybe...()` functions. Returned values are nullable, so do not forget to check them for null.
 
 ```ts
 const slice = cell.beginParse();
@@ -122,18 +122,18 @@ if (maybeRef1) {
 }
 ```
 
-## Using assets SDK
+## Using the Assets SDK
 
 Manually handling cells can be tedious, so the `@ton-community/assets-sdk` provides convenient methods for serializing and deserializing messages.
 
 Using `@ton-community/assets-sdk` is more readable and less error-prone.
 
-<Tabs groupId="Serialization/Deserialization">
+<Tabs groupId="serialization-deserialization">
   <TabItem value="@ton-community/assets-sdk" label="@ton-community/assets-sdk">
 
     ```ts
-    import {Address, beginCell} from "@ton/core";
-    import {storeJettonTransferMessage, loadJettonTransferMessage} from "@ton-community/assets-sdk";
+    import { Address, beginCell } from "@ton/core";
+    import { storeJettonTransferMessage, loadJettonTransferMessage } from "@ton-community/assets-sdk";
 
     // serialization
     const cell = beginCell()
@@ -146,7 +146,7 @@ Using `@ton-community/assets-sdk` is more readable and less error-prone.
         forwardAmount: 1n,
         forwardPayload: null,
       }))
-      .endCell()
+      .endCell();
 
     // deserialization
     const transferMessage = loadJettonTransferMessage(cell.beginParse());
@@ -157,7 +157,7 @@ Using `@ton-community/assets-sdk` is more readable and less error-prone.
   <TabItem value="@ton/ton" label="@ton/ton">
 
     ```ts
-    import {Address, beginCell} from "@ton/core";
+    import { Address, beginCell } from "@ton/core";
 
     // serialization
     const cell = beginCell()


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-ton-connect-cookbook-cells.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/ton-connect/cookbook/cells.mdx`

Related issues (from issues.normalized.md):
- [x] **4122. Use 'TON blockchain' capitalization**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/cells.mdx?plain=1#L19-L32

Replace “TON Blockchain” with “TON blockchain” to match site-wide style.

---

- [x] **4123. Standardize imports and tab labels to @ton/core**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/cells.mdx?plain=1#L25-L32, #L40-L49, #L157-L166

Replace imports from "@ton/ton" with "@ton/core" and rename the second TabItem label/value from "@ton/ton" to "@ton/core" so the opening library list and examples are consistent and use a single library.

---

- [x] **4124. Soften SDK parity claim and note @ton/core usage**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/cells.mdx?plain=1#L56-L60

Change the info note to: “These examples use the @ton/core library only; many SDKs provide similar helper functions—see the SDKs list,” avoiding the universal “every TON SDK” claim.

---

- [x] **4125. Append .endCell() in optional values example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/cells.mdx?plain=1#L102-L110

Finish the outer builder chain with .endCell() and assign it (e.g., const cell = beginCell()... .endCell();) to produce a Cell like other examples.

---

- [x] **4126. Use matching optional int/uint helpers**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/cells.mdx?plain=1#L102-L121

Do not mix signed/unsigned helpers; use storeMaybeUint(value, 64) with loadMaybeUint(64) (or storeMaybeInt with loadMaybeInt), or remove the numeric optional example if such helpers aren’t documented.

---

- [x] **4127. Use hyphen instead of en dash in “cell-building”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/cells.mdx?plain=1

Replace the en dash in “cell–building basics” with a hyphen: “cell-building basics.”

---

- [x] **4128. Add comma after 'nullable'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/cells.mdx?plain=1

Change “Returned values are nullable so do not forget to check them for null!” to “Returned values are nullable, so do not forget to check them for null.”

---

- [x] **4129. Make code style consistent (semicolon, import spacing)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/cells.mdx?plain=1

Add a semicolon after .endCell() in the @ton-community/assets-sdk snippet, and format imports with spaced braces (e.g., import { Address, beginCell } from "@ton/core";).

---

- [x] **4130. Replace invalid placeholder addresses or mark as placeholders**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/cells.mdx?plain=1

Do not pass strings like "[SOME_ADDR]" to Address.parse; either use a syntactically valid placeholder (e.g., EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c) or add a note that these are non-executable placeholders.

---

- [x] **4131. Fix heading to 'Using the Assets SDK'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/cells.mdx?plain=1

Change the section title “Using assets SDK” to “Using the Assets SDK.”

---

- [x] **4132. Use simple Tabs groupId without slash**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/cells.mdx?plain=1

Change <Tabs groupId="Serialization/Deserialization"> to a simple identifier without special characters, e.g., groupId="serialization-deserialization".

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.