### PR TITLE
Split: update docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx
+++ b/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx
@@ -18,16 +18,16 @@ import TabItem from '@theme/TabItem';
 
 # Jetton transfer
 
-The `body` for jetton transfers is based on the ([TEP-74](https://github.com/ton-blockchain/TEPs/blob/master/text/0074-jettons-standard.md#1-transfer)) standard. Please note that the number of decimals can vary between different tokens: for example, USDT uses 6 decimals (1 USDT = 1 × 10<sup>6</sup>), while typically jettons and Toncoin uses 9 decimals (1 TON = 1 × 10<sup>9</sup>).
+The `body` for jetton transfers is based on the [TEP-74](https://github.com/ton-blockchain/TEPs/blob/master/text/0074-jettons-standard.md#1-transfer) standard. Please note that the number of decimals can vary between different tokens: for example, USDT uses 6 decimals (1 USDT = 1 × 10<sup>6</sup>), while typically jettons and Toncoin use 9 decimals (1 TON = 1 × 10<sup>9</sup>).
   
 :::info
 The `assets-sdk` library works out of the box with `ton-connect`.
 :::
 
-<Tabs groupId="Jetton transfer">
+<Tabs groupId="jetton-transfer">
   <TabItem value="@ton/ton" label="@ton/ton">
   
-    ```js
+    ```ts
     import { beginCell, toNano, Address } from '@ton/ton'
     // transfer#0f8a7ea5 query_id:uint64 amount:(VarUInteger 16) destination:MsgAddress
     // response_destination:MsgAddress custom_payload:(Maybe ^Cell)
@@ -37,21 +37,24 @@ The `assets-sdk` library works out of the box with `ton-connect`.
     const body = beginCell()
         .storeUint(0xf8a7ea5, 32)                 // jetton transfer op code
         .storeUint(0, 64)                         // query_id:uint64
-        .storeCoins(toNano("0.001"))              // amount:(VarUInteger 16) -  Jetton amount for transfer (decimals = 6 - USDT, 9 - default). Function toNano use decimals = 9 (remember it)
+        .storeCoins(toNano("0.001"))              // amount:(VarUInteger 16) -  Jetton amount for transfer (decimals = 6 - USDT, 9 - default). Function `toNano` uses 9 decimals (remember it)
         .storeAddress(Address.parse(Wallet_DST))  // destination:MsgAddress
         .storeAddress(Address.parse(Wallet_SRC))  // response_destination:MsgAddress
         .storeUint(0, 1)                          // custom_payload:(Maybe ^Cell)
         .storeCoins(toNano("0.05"))               // forward_ton_amount:(VarUInteger 16) - if >0, will send notification message
-        .storeUint(0,1)                           // forward_payload:(Either Cell ^Cell)
+        .storeBit(1)                              // forward_payload:(Either Cell ^Cell) - as a reference
+        .storeRef(beginCell().endCell())          // empty payload reference
         .endCell();
     ```
 
-    Next, sending the transaction with this body to sender's `jettonWalletContract` executed:
+    Note: `toNano` assumes 9 decimals. For jettons with a different number of decimals (for example, 6), compute the amount using the token’s `decimals` value, such as `BigInt(value) * 10n ** BigInt(jettonDecimals)`.
 
-    <Tabs groupId="JettonTransferUI">
+    Next, send the transaction with this body to the sender's `jettonWalletContract`:
+
+    <Tabs groupId="jetton-transfer-ui">
       <TabItem value="tonconnect-react-ui" label="@tonconnect/react-ui">
 
-        ```js
+        ```ts
         import { useTonConnectUI } from '@tonconnect/ui-react';
         import { toNano } from '@ton/ton'
 
@@ -83,7 +86,7 @@ The `assets-sdk` library works out of the box with `ton-connect`.
 
       <TabItem value="tonconnect-ui" label="@tonconnect/ui">
 
-        ```js
+        ```ts
         import TonConnectUI from '@tonconnect/ui'
         import { toNano } from '@ton/ton'
 
@@ -104,21 +107,21 @@ The `assets-sdk` library works out of the box with `ton-connect`.
       </TabItem>
     </Tabs>
 
-    - `validUntil` - UNIX-time until message valid
-    - `jettonWalletAddress` - Address, JettonWallet address, that defined based on JettonMaser and Wallet contracts
-    - `balance` - Integer, the amount of Toncoin used for gas payments in nanotons.
-    - `body` - payload for the `jettonContract`
+    - `validUntil` - UNIX timestamp until the message is valid
+    - `jettonWalletAddress` - Address, Jetton wallet address that is defined based on JettonMaster and wallet contracts
+    - `amount` - Integer, the amount of Toncoin used for gas payments in nanotons.
+    - `body` - payload for the jetton wallet contract
 
     <details>
       <summary>Jetton wallet state init and address preparation example</summary>
 
-      ```js
+      ```ts
       import { Address, TonClient, beginCell, StateInit, storeStateInit } from '@ton/ton'
 
       async function main() {
           const client = new TonClient({
               endpoint: 'https://toncenter.com/api/v2/jsonRPC',
-              apiKey: 'put your api key'
+              apiKey: 'enter your API key'
           })
 
           const jettonWalletAddress = Address.parse('Sender_Jetton_Wallet');
@@ -158,7 +161,8 @@ The `assets-sdk` library works out of the box with `ton-connect`.
 
     For more examples, check [documentation](https://github.com/ton-community/assets-sdk)
 
-    ```js
+    ```ts
+    ```ts
     const NETWORK = "testnet";
     const api = await createApi(NETWORK);
     const provider = new TonConnectUI(); // OR you can use tonConnectUI as a provider from @tonconnect/ui-react
@@ -178,7 +182,7 @@ The `assets-sdk` library works out of the box with `ton-connect`.
     });
 
     const jetton = sdk.openJettonWallet(Address.parse("JETTON_ADDRESS"));
-    const RECEIVER_ADDRESS = Address.parse("RECIEVER_ADDRESS");
+    const RECEIVER_ADDRESS = Address.parse("RECEIVER_ADDRESS");
 
     jetton.send(sender, RECEIVER_ADDRESS, toNano(10));
     ```
@@ -197,7 +201,7 @@ The `assets-sdk` library works out of the box with `ton-connect`.
 
     const jettonMaster = client.open(
       JettonMinter.createFromAddress(
-        Address.parse("[JETTON_WALLET]"),
+        Address.parse("[JETTON_MASTER]"),
         new DefaultContentResolver()
       )
     );
@@ -212,7 +216,7 @@ The `assets-sdk` library works out of the box with `ton-connect`.
 
     await jetton.send(
       sender,
-      Address.parse("[SENDER_WALLET]"),
+      Address.parse("[RECEIVER_WALLET]"),
       BigInt(1 * 10 ** jettonDecimals)
     );
 
@@ -225,7 +229,7 @@ The `assets-sdk` library works out of the box with `ton-connect`.
 
 <Tabs groupId="JettonTransferComment">
   <TabItem value="@ton/ton" label="@ton/ton">
-    The `messageBody` for jetton transfer([TEP-74](https://github.com/ton-blockchain/TEPs/blob/master/text/0074-jettons-standard.md#1-transfer)) with comment we should additionally to the regular transfer `body` serialize comment and pack this in the `forwardPayload`.  Please note that the number of decimals can vary between different tokens:
+    The `messageBody` for a jetton transfer with a comment ([TEP-74](https://github.com/ton-blockchain/TEPs/blob/master/text/0074-jettons-standard.md#1-transfer)): in addition to the regular transfer `body`, serialize the comment and place it into the `forwardPayload`. Please note that the number of decimals can vary between different tokens:
 
     - 9 decimals: 1 TON = 1 × 10<sup>9</sup> typically for various jettons and always for Toncoin
     - 6 decimals: 1 USDT = 1 × 10<sup>6</sup> specific jettons, like USDT
@@ -247,7 +251,7 @@ The `assets-sdk` library works out of the box with `ton-connect`.
     const body = beginCell()
         .storeUint(0xf8a7ea5, 32)           // opcode for jetton transfer
         .storeUint(0, 64)                   // query id
-        .storeCoins(toNano("5"))            // Jetton amount for transfer (decimals = 6 - USDT, 9 - default). Function toNano use decimals = 9 (remember it)
+        .storeCoins(toNano("5"))            // Jetton amount for transfer (decimals = 6 - USDT, 9 - default). Function `toNano` uses 9 decimals (remember it)
         .storeAddress(destinationAddress)   // TON wallet destination address
         .storeAddress(destinationAddress)   // response excess destination
         .storeBit(0)                        // no custom payload
@@ -257,12 +261,12 @@ The `assets-sdk` library works out of the box with `ton-connect`.
         .endCell();
     ```
 
-    Next, send the transaction with this body to the sender's `jettonWalletContract` executed:
+    Next, send the transaction with this body to the sender's `jettonWalletContract`:
 
     <Tabs groupId="JettonTransferCommentUI">
     <TabItem value="tonconnect-react-ui" label="@tonconnect/react-ui">
 
-        ```js
+        ```ts
         import { useTonConnectUI } from '@tonconnect/ui-react';
         import { toNano } from '@ton/ton'
 
@@ -297,7 +301,7 @@ The `assets-sdk` library works out of the box with `ton-connect`.
 
         <TabItem value="tonconnect-ui" label="@tonconnect/ui">
 
-        ```js
+        ```ts
         import TonConnectUI from '@tonconnect/ui'
         import { toNano } from '@ton/ton'
 
@@ -318,21 +322,21 @@ The `assets-sdk` library works out of the box with `ton-connect`.
         </TabItem>
     </Tabs>
 
-    - `validUntil` - UNIX-time until message valid
-    - `jettonWalletAddress` - Address, JettonWallet address, that defined based on JettonMaser and Wallet contracts
-    - `balance` - Integer, the amount of Toncoin used for gas payments in nanotons.
-    - `body` - payload for the `jettonContract`
+    - `validUntil` - UNIX timestamp until the message is valid
+    - `jettonWalletAddress` - Address, Jetton wallet address that is defined based on JettonMaster and wallet contracts
+    - `amount` - Integer, the amount of Toncoin used for gas payments in nanotons.
+    - `body` - payload for the jetton wallet contract
 
     <details>
         <summary>Jetton wallet state init and address preparation example</summary>
 
-        ```js
+        ```ts
         import { Address, TonClient, beginCell, StateInit, storeStateInit } from '@ton/ton'
 
         async function main() {
         const client = new TonClient({
         endpoint: 'https://toncenter.com/api/v2/jsonRPC',
-        apiKey: 'put your api key'
+        apiKey: 'enter your API key'
         })
 
         const jettonWalletAddress = Address.parse('Sender_Jetton_Wallet');
@@ -372,7 +376,9 @@ The `assets-sdk` library works out of the box with `ton-connect`.
 
     For more examples, check [documentation](https://github.com/ton-community/assets-sdk)
 
-    ```js
+    Note: `tonConnectUI` refers to an existing `TonConnectUI` instance created earlier (for example, `const provider = new TonConnectUI({...})`).
+
+    ```ts
     const NETWORK = "testnet";
     const api = await createApi(NETWORK);
     const provider = new TonConnectUI(); // OR you can use tonConnectUI as a provider from @tonconnect/ui-react
@@ -408,12 +414,12 @@ The `assets-sdk` library works out of the box with `ton-connect`.
 
 <Tabs groupId="JettonBurn">
   <TabItem value="@ton/ton" label="@ton/ton">
-    The `body` for jetton burn is based on the ([TEP-74](https://github.com/ton-blockchain/TEPs/blob/master/text/0074-jettons-standard.md#1-transfer)) standard. Please note that the number of decimals can vary between different tokens:
+    The `body` for jetton burn is based on the [TEP-74](https://github.com/ton-blockchain/TEPs/blob/master/text/0074-jettons-standard.md#1-transfer) standard. Please note that the number of decimals can vary between different tokens:
 
     - 9 decimals: 1 TON = 1 × 10<sup>9</sup> typically for various jettons and always for Toncoin
     - 6 decimals: 1 USDT = 1 × 10<sup>6</sup> specific jettons, like USDT
 
-    ```js
+    ```ts
     import { beginCell, Address } from '@ton/ton'
     // burn#595f07bc query_id:uint64 amount:(VarUInteger 16)
     // response_destination:MsgAddress custom_payload:(Maybe ^Cell)
@@ -422,18 +428,18 @@ The `assets-sdk` library works out of the box with `ton-connect`.
     const body = beginCell()
         .storeUint(0x595f07bc, 32)                // jetton burn op code
         .storeUint(0, 64)                         // query_id:uint64
-        .storeCoins(toNano("0.001"))              // amount:(VarUInteger 16) - Jetton amount in decimal (decimals = 6 - USDT, 9 - default). Function toNano use decimals = 9 (remember it)
+        .storeCoins(toNano("0.001"))              // amount:(VarUInteger 16) - Jetton amount in decimal (decimals = 6 - USDT, 9 - default). Function `toNano` uses 9 decimals (remember it)
         .storeAddress(Address.parse(Wallet_SRC))  // response_destination:MsgAddress - owner's wallet
         .storeUint(0, 1)                          // custom_payload:(Maybe ^Cell) - w/o payload typically
         .endCell();
     ```
 
-    Message places into the following request:
+    Place the message body into the following transaction:
 
     <Tabs groupId="JettonBurnUI">
       <TabItem value="tonconnect-react-ui" label="@tonconnect/react-ui">
 
-        ```js
+        ```ts
         import { useTonConnectUI } from '@tonconnect/ui-react';
         import { toNano } from '@ton/ton'
 
@@ -465,7 +471,7 @@ The `assets-sdk` library works out of the box with `ton-connect`.
 
       <TabItem value="tonconnect-ui" label="@tonconnect/ui">
 
-        ```js
+        ```ts
         import TonConnectUI from '@tonconnect/ui'
         import { toNano } from '@ton/ton'
 
@@ -486,8 +492,8 @@ The `assets-sdk` library works out of the box with `ton-connect`.
       </TabItem>
     </Tabs>
 
-    - `jettonWalletAddress` - Jetton Wallet contract address, that defined based on JettonMaser and Wallet contracts
-    - `amount` - Integer, amount of Toncoin for gas payments in nanotons.
+    - `jettonWalletAddress` - Jetton wallet contract address that is defined based on JettonMaster and wallet contracts
+    - `amount` - Integer, the amount of Toncoin used for gas payments in nanotons.
     - `body` - payload for the jetton wallet with the `burn#595f07bc` op code
 
   </TabItem>
@@ -500,7 +506,7 @@ The `assets-sdk` library works out of the box with `ton-connect`.
 
     For more examples, check [documentation](https://github.com/ton-community/assets-sdk)
 
-    ```js
+    ```ts
     const NETWORK = "testnet";
     const api = await createApi(NETWORK);
     const provider = new TonConnectUI(); // OR you can use tonConnectUI as a provider from @tonconnect/ui-react
@@ -564,6 +570,6 @@ The `assets-sdk` library works out of the box with `ton-connect`.
 ## Next steps
 
 1. Work with NFTs → [NFT transfer](/v3/guidelines/ton-connect/cookbook/nft-transfer)  
-2. Search your transaction → [Transaction lookup](/v3/guidelines/ton-connect/guidelines/transaction-by-external-message)
+2. Search for your transaction → [Transaction lookup](/v3/guidelines/ton-connect/guidelines/transaction-by-external-message)
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-ton-connect-cookbook-jetton-transfer.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx`

Related issues (from issues.normalized.md):
- [ ] **3308. Clarify Toncoin decimals and jetton precision**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/nodes/faq.mdx?plain=1

Replace “Mainnet supports a 9-digit accuracy for currencies” with “Toncoin uses 9 decimals; jettons define decimals per token (often 9),” and add citations to docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx and docs/v3/guidelines/dapps/asset-processing/nft-processing/metadata-parsing.mdx#properties.

---

- [ ] **4133. Fix TEP‑74 parenthesis and decimals agreement**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx?plain=1#L21

Remove the stray parenthesis in “based on the ([TEP‑74]) standard” to “based on the [TEP‑74] standard” and change “jettons and Toncoin uses 9 decimals” to “jettons and Toncoin use 9 decimals”.

---

- [ ] **4134. Fix toNano comment grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx?plain=1#L40, L250, L425

Change “Function toNano use decimals = 9 (remember it)” to “Function `toNano` uses 9 decimals (remember it)”.

---

- [ ] **4135. Correct forward payload encoding or amount**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx?plain=1#L44-L46

If `forward_ton_amount` is non‑zero, encode a proper `forward_payload` (e.g., `.storeBit(1).storeRef(beginCell().endCell())`); otherwise set `forward_ton_amount` to `0` when no notification is needed.

---

- [ ] **4136. Rewrite “Next, sending…” sentences**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx?plain=1#L49, L260

Change “Next, sending the transaction … executed:” to “Next, send the transaction with this body to the sender’s `jettonWalletContract`:” and remove “executed” in the comment example.

---

- [ ] **4137. Use “UNIX timestamp” phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx?plain=1#L107, L321

Change “UNIX-time until message valid” to “UNIX timestamp until the message is valid”.

---

- [ ] **4138. Fix “JettonMaser” to “JettonMaster”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx?plain=1#L108, L322, L489

Correct the typo and keep the full phrase as “Jetton wallet address that is defined based on JettonMaster and wallet contracts.”

---

- [ ] **4139. Replace `balance` with `amount` in field docs**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx?plain=1#L109, L323

The bullet should read “`amount` – Integer, the amount of Toncoin used for gas payments in nanotons.”

---

- [ ] **4140. Clarify payload target and naming consistency**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx?plain=1#L110, L324

Change “`body` – payload for the `jettonContract`” to “`body` – payload for the jetton wallet contract”, and align bullet wording with the code’s variable naming (e.g., sender’s `jettonWalletContract`).

---

- [ ] **4141. Retag TS code blocks**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx?plain=1#L115, L161, L503

These blocks use TypeScript syntax; change their code fences from ```js to ```ts for proper highlighting.

---

- [ ] **4142. Capitalize API key placeholder**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx?plain=1#L121

Change “apiKey: 'put your api key'” to “apiKey: 'enter your API key'”.

---

- [ ] **4143. Fix placeholder spelling: RECEIVER_ADDRESS**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx?plain=1#L181

Rename `RECIEVER_ADDRESS` to `RECEIVER_ADDRESS`.

---

- [ ] **4144. Use jetton minter address placeholder**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx?plain=1#L198-L205, L540-L545

`JettonMinter.createFromAddress(...)` must receive the jetton minter (master) address; replace `[JETTON_WALLET]` with `[JETTON_MASTER]` in transfer and burn examples.

---

- [ ] **4145. Fix destination placeholder in `send`**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx?plain=1#L215

Change `Address.parse("[SENDER_WALLET]")` to `Address.parse("[RECEIVER_WALLET]")` to reflect the recipient address parameter.

---

- [ ] **4146. Clarify transfer-with-comment prose and use `forward_payload`**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx?plain=1#L226-L229

Rewrite to: “For a jetton transfer with a comment (TEP‑74), in addition to the regular transfer body, serialize the comment and place it into the `forward_payload`.”

---

- [ ] **4147. Fix `response_destination` in comment example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx?plain=1#L251-L253

Set `response_destination` to the sender’s wallet (excess address), not the recipient; replace the second `.storeAddress(destinationAddress)` with the sender’s address (e.g., `.storeAddress(Address.parse(Wallet_SRC))`).

---

- [ ] **4148. Add missing imports and define `RECEIVER_ADDRESS` in UI snippet**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx?plain=1#L396-L401

Import `beginCell` and `Address` and declare `const RECEIVER_ADDRESS = Address.parse("RECEIVER_ADDRESS");` before usage to make the snippet complete.

---

- [ ] **4149. Update TEP‑74 burn anchor**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx?plain=1#L411

Change the link target to `https://github.com/ton-blockchain/TEPs/blob/master/text/0074-jettons-standard.md#2-burn`.

---

- [ ] **4150. Import `toNano` in burn example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx?plain=1#L416-L425

Update import to `import { beginCell, Address, toNano } from '@ton/ton'` since `toNano` is used in the body.

---

- [ ] **4151. Improve burn transaction lead-in**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx?plain=1#L431

Replace “Message places into the following request:” with “Place the message body into the following transaction:”.

---

- [ ] **4152. Fix “Search your transaction” phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx?plain=1#L566

Change to “Search for your transaction”.

---

- [ ] **4153. Declare or quote `Wallet_DST`/`Wallet_SRC` placeholders**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx?plain=1

In the first code sample, replace `Address.parse(Wallet_DST)`/`Address.parse(Wallet_SRC)` with string placeholders (e.g., `Address.parse('WALLET_DST')`) or declare these constants above.

---

- [ ] **4154. Note decimals handling for jetton amounts**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx?plain=1

Add a note that `toNano` assumes 9 decimals; for jettons with other decimals (e.g., 6), compute amounts using the token’s `decimals` (e.g., `BigInt(value * 10 ** jettonDecimals)`) or retrieve `jettonDecimals` first and use it consistently in examples.

---

- [ ] **4155. Define provider instance in TS example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/jetton-transfer.mdx?plain=1

Where `const provider = tonConnectUi;` is used, either instantiate it (e.g., `const provider = new TonConnectUI(...)`) or add a note that `tonConnectUi` is an existing instance from the earlier setup.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.