### PR TITLE
Split: update docs/v3/guidelines/ton-connect/cookbook/ton-transfer.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/ton-connect/cookbook/ton-transfer.mdx
+++ b/docs/v3/guidelines/ton-connect/cookbook/ton-transfer.mdx
@@ -66,7 +66,12 @@ Examples created based on `@tonconnect/ui-react` and `@tonconnect/ui`:
         //transaction body
     }
 
-    const result = await tonConnectUI.sendTransaction(transaction)
+    async function sendTransaction() {
+        const result = await tonConnectUI.sendTransaction(transaction);
+        return result;
+    }
+
+    sendTransaction();
 
     ```
 
@@ -82,6 +87,7 @@ Pass the `address` in a [user-friendly format](/v3/documentation/smart-contracts
 By the way, there is a limit to the number of messages sent in one transaction:
 
 - standard ([v3](/v3/documentation/smart-contracts/contracts-specs/wallet-contracts#wallet-v3)/[v4](/v3/documentation/smart-contracts/contracts-specs/wallet-contracts#wallet-v4)) wallets: 4 outgoing messages;
+- wallet v5: up to 255 messages;
 - highload wallets: 255 outgoing messages (close to blockchain limitations).
 
 A regular TON transfer using the TON Connect JS SDKs can be executed as follows:
@@ -153,7 +159,12 @@ A regular TON transfer using the TON Connect JS SDKs can be executed as follows:
         ]
     }
 
-    const result = await tonConnectUI.sendTransaction(transaction)
+    async function sendTransaction() {
+        const result = await tonConnectUI.sendTransaction(transaction);
+        return result;
+    }
+
+    sendTransaction();
     ```
 
   </TabItem>
@@ -173,7 +184,7 @@ Check out the [Transaction lookup](/v3/guidelines/ton-connect/guidelines/transac
 
 It's pretty easy to handle request rejection, but it's better to know what would happen in advance when you're developing some project.
 
-When a user clicks **Cancel** in the popup in the wallet application, an exception is thrown:
+When a user clicks **Cancel** in the popup in the wallet application, an exception is thrown. Example error (message may vary):
 
 ```ts
 Error: [TON_CONNECT_SDK_ERROR] The Wallet declined the request 
@@ -203,6 +214,8 @@ The transaction is created as follows:
 <Tabs groupId="Transfer With a Comment">
   <TabItem value="tonconnect-react-ui" label="@tonconnect/react-ui">
 
+    Note: replace the placeholder with the destination address in a user-friendly format (see /v3/documentation/smart-contracts/addresses/address-formats#user-friendly-address).
+
     ```js
     import { useTonConnectUI } from '@tonconnect/ui-react';
     import { toNano } from '@ton/ton'
@@ -211,7 +224,7 @@ The transaction is created as follows:
         validUntil: Math.floor(Date.now() / 1000) + 360,
         messages: [
             {
-                address: destination,
+                address: '<DESTINATION_ADDRESS>',
                 amount: toNano("0.05").toString(),
                 payload: body.toBoc().toString("base64")
                 // payload with the comment in body
@@ -236,6 +249,8 @@ The transaction is created as follows:
 
   <TabItem value="tonconnect-ui" label="@tonconnect/ui">
 
+    Note: replace the placeholder with the destination address in a user-friendly format (see /v3/documentation/smart-contracts/addresses/address-formats#user-friendly-address).
+
     ```js
     import TonConnectUI from '@tonconnect/ui'
     import { toNano } from '@ton/ton'
@@ -244,7 +259,7 @@ The transaction is created as follows:
         validUntil: Math.floor(Date.now() / 1000) + 360,
         messages: [
             {
-                address: destination,
+                address: '<DESTINATION_ADDRESS>',
                 amount: toNano("0.05").toString(),
                 payload: body.toBoc().toString("base64")
                 // payload with the comment in body
@@ -252,8 +267,13 @@ The transaction is created as follows:
         ]
     }
 
-    const result = await tonConnectUI.sendTransaction(transaction)
-    ```
+    async function sendTransaction() {
+        const result = await tonConnectUI.sendTransaction(transaction);
+        return result;
+    }
+
+    sendTransaction();
+```
 
   </TabItem>
 </Tabs>

--- a/docs/v3/guidelines/ton-connect/cookbook/ton-transfer.mdx
+++ b/docs/v3/guidelines/ton-connect/cookbook/ton-transfer.mdx
@@ -80,7 +80,7 @@ Examples created based on `@tonconnect/ui-react` and `@tonconnect/ui`:
 
 ## Simple TON transfer
 
-TON Connect SDKs include wrappers for sending messages, making it easy to prepare regular transfers of Toncoins between two wallets as default transaction without payload. For specific custom transactions, a particular payload must be defined.
+TON Connect SDKs include wrappers for sending messages, making it easy to prepare regular transfers of Toncoin between two wallets as a default transaction without a payload. For specific custom transactions, a particular payload must be defined.
 
 Pass the `address` in a [user-friendly format](/v3/documentation/smart-contracts/addresses/address-formats#user-friendly-address), not in raw form. When you send the message to a smart contract, use a bounceable address; when you send it to a wallet, use a non-bounceable address.
 
@@ -97,28 +97,28 @@ A regular TON transfer using the TON Connect JS SDKs can be executed as follows:
 
     ```js
     import { useTonConnectUI } from '@tonconnect/ui-react';
-    const [tonConnectUI] = useTonConnectUI();
-
-    const transaction = {
-        messages: [
-            {
-                address: tonConnectUI.account.address,
-                amount: '200000000' // 0.2 TON (in nanotons)
-            },
-            {            // Bounceable address
-                address: 'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c',
-                amount: '100000000'
-            },
-            {            // Non-bounceable address
-                address: 'UQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJKZ',
-                amount: '100000000'
-            }
-        ]
-
-    }
 
     export const Settings = () => {
         const [tonConnectUI, setOptions] = useTonConnectUI();
+
+        const transaction = {
+            validUntil: Math.floor(Date.now() / 1000) + 300,
+            messages: [
+                {
+                    address: tonConnectUI.account.address,
+                    amount: '200000000' // 0.2 TON (in nanotons)
+                },
+                {            // Bounceable address
+                    address: 'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c',
+                    amount: '100000000'
+                },
+                {            // Non-bounceable address
+                    address: 'UQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJKZ',
+                    amount: '100000000'
+                }
+            ]
+
+        }
 
         return (
             <div>
@@ -143,6 +143,7 @@ A regular TON transfer using the TON Connect JS SDKs can be executed as follows:
     });
 
     const transaction = {
+        validUntil: Math.floor(Date.now() / 1000) + 300,
         messages: [
             {
                 address: tonConnectUI.account.address,
@@ -186,7 +187,7 @@ It's pretty easy to handle request rejection, but it's better to know what would
 
 When a user clicks **Cancel** in the popup in the wallet application, an exception is thrown. Example error (message may vary):
 
-```ts
+```text
 Error: [TON_CONNECT_SDK_ERROR] The Wallet declined the request 
 ```
 
@@ -219,20 +220,19 @@ The transaction is created as follows:
     import { useTonConnectUI } from '@tonconnect/ui-react';
     import { toNano } from '@ton/ton'
 
-    const myTransaction = {
-        validUntil: Math.floor(Date.now() / 1000) + 360,
-        messages: [
-            {
-                address: '<DESTINATION_ADDRESS>',
-                amount: toNano("0.05").toString(),
-                payload: body.toBoc().toString("base64")
-                // payload with the comment in body
-            }
-        ]
-    }
-
     export const Settings = () => {
         const [tonConnectUI, setOptions] = useTonConnectUI();
+        const myTransaction = {
+            validUntil: Math.floor(Date.now() / 1000) + 360,
+            messages: [
+                {
+                    address: '<DESTINATION_ADDRESS>',
+                    amount: toNano("0.05").toString(),
+                    payload: body.toBoc().toString("base64")
+                    // payload with the comment in body
+                }
+            ]
+        }
 
         return (
             <div>
@@ -278,7 +278,7 @@ The transaction is created as follows:
 
 ### Smart contract deployment
 
-As more complex example, we'll deploy an instance of the simple [chatbot Doge](https://github.com/LaDoger/doge.fc) smart contract, which is featured as one of the [smart-contract examples](/v3/documentation/smart-contracts/overview#examples-of-smart-contracts). To create our own unique instance, we'll load the contract code and store a unique value in the data section. Finally, we'll combine the code and data into a `stateInit` structure.
+As a more complex example, we'll deploy an instance of the simple [chatbot Doge](https://github.com/LaDoger/doge.fc) smart contract, which is featured as one of the [smart-contract examples](/v3/documentation/smart-contracts/overview#examples-of-smart-contracts). To create our own unique instance, we'll load the contract code and store a unique value in the data section. Finally, we'll combine the code and data into a `stateInit` structure.
 
 ```ts
 import { Cell, beginCell, contractAddress, storeStateInit } from "@ton/ton";
@@ -323,7 +323,7 @@ const transaction = {
         {
             address: contractData.address,
             amount: toNano("0.069").toString(),
-            payload: contractData.stateInit
+            stateInit: contractData.stateInit
         }
     ]
 }
@@ -344,7 +344,7 @@ Continue exploring TON Connect features and workflows by choosing one of the fol
 </Button>
 
 <Button href="/v3/guidelines/ton-connect/guidelines/transaction-by-external-message" colorType="secondary" sizeType={'sm'}>
-  Search your transaction
+  Search for your transaction
 </Button>
 
 <Feedback />

--- a/docs/v3/guidelines/ton-connect/cookbook/ton-transfer.mdx
+++ b/docs/v3/guidelines/ton-connect/cookbook/ton-transfer.mdx
@@ -28,7 +28,7 @@ No matter what level of task a developer is solving, it is typically necessary t
 Examples created based on `@tonconnect/ui-react` and `@tonconnect/ui`:
 
 <Tabs groupId="TON Connect template">
-  <TabItem value="tonconnect-react" label="@tonconnect/ui-react">
+  <TabItem value="tonconnect-ui-react" label="@tonconnect/ui-react">
 
     ```js
     import { useTonConnectUI } from '@tonconnect/ui-react';
@@ -82,7 +82,7 @@ Examples created based on `@tonconnect/ui-react` and `@tonconnect/ui`:
 
 TON Connect SDKs include wrappers for sending messages, making it easy to prepare regular transfers of Toncoins between two wallets as default transaction without payload. For specific custom transactions, a particular payload must be defined.
 
-Pass the `address` in a [user-friendly format](/v3/documentation/smart-contracts/addresses#user-friendly-address), not in raw form. When you send the message to a smart contract, use a bounceable address; when you send it to a wallet, use a non-bounceable address.
+Pass the `address` in a [user-friendly format](/v3/documentation/smart-contracts/addresses/address-formats#user-friendly-address), not in raw form. When you send the message to a smart contract, use a bounceable address; when you send it to a wallet, use a non-bounceable address.
 
 By the way, there is a limit to the number of messages sent in one transaction:
 
@@ -93,7 +93,7 @@ By the way, there is a limit to the number of messages sent in one transaction:
 A regular TON transfer using the TON Connect JS SDKs can be executed as follows:
 
 <Tabs groupId="Regular Transfer">
-  <TabItem value="tonconnect-react-ui" label="@tonconnect/react-ui">
+  <TabItem value="tonconnect-ui-react" label="@tonconnect/ui-react">
 
     ```js
     import { useTonConnectUI } from '@tonconnect/ui-react';
@@ -171,7 +171,7 @@ A regular TON transfer using the TON Connect JS SDKs can be executed as follows:
 </Tabs>
 
 :::tip
-Learn more about [TON smart contract addresses](/v3/documentation/smart-contracts/addresses).
+Learn more about [TON smart contract addresses](/v3/documentation/smart-contracts/addresses/address).
 :::
 
 ### Getting the result
@@ -212,9 +212,8 @@ See more details on [this page](/v3/documentation/smart-contracts/message-manage
 The transaction is created as follows:
 
 <Tabs groupId="Transfer With a Comment">
-  <TabItem value="tonconnect-react-ui" label="@tonconnect/react-ui">
+  <TabItem value="tonconnect-ui-react" label="@tonconnect/ui-react">
 
-    Note: replace the placeholder with the destination address in a user-friendly format (see /v3/documentation/smart-contracts/addresses/address-formats#user-friendly-address).
 
     ```js
     import { useTonConnectUI } from '@tonconnect/ui-react';
@@ -249,7 +248,6 @@ The transaction is created as follows:
 
   <TabItem value="tonconnect-ui" label="@tonconnect/ui">
 
-    Note: replace the placeholder with the destination address in a user-friendly format (see /v3/documentation/smart-contracts/addresses/address-formats#user-friendly-address).
 
     ```js
     import TonConnectUI from '@tonconnect/ui'


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-ton-connect-cookbook-ton-transfer.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/ton-connect/cookbook/ton-transfer.mdx`

Related issues (from issues.normalized.md):
- [x] **4184. Fix broken anchor to user-friendly address**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/ton-transfer.mdx?plain=1

Update the "user-friendly format" link to /v3/documentation/smart-contracts/addresses/address-formats#user-friendly-address because the current target points to a non-existent anchor.

---

- [x] **4185. Correct package name in tab labels**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/ton-transfer.mdx?plain=1

Change TabItem labels from "@tonconnect/react-ui" to "@tonconnect/ui-react" under "Simple TON transfer" and "Transfer with a comment" to match the actual package.

---

- [x] **4186. Move React hook usage inside component and remove duplicate call**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/ton-transfer.mdx?plain=1

Ensure useTonConnectUI() is called only inside a React component and not at module scope, and keep a single hook call; move transaction creation into the component/click handler before calling sendTransaction.

---

- [ ] **4187. Use stateInit for deployment, not payload**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/ton-transfer.mdx?plain=1

In "Smart contract deployment", replace payload: contractData.stateInit with stateInit: contractData.stateInit in the transaction message.

---

- [x] **4188. Use text fence for error snippet**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/ton-transfer.mdx?plain=1

Change the error example code block language from ts to text since it contains plain runtime output, not TypeScript.

---

- [x] **4189. Fix article: "As a more complex example"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/ton-transfer.mdx?plain=1

Replace "As more complex example" with "As a more complex example."

---

- [x] **4190. Standardize Toncoin naming and articles**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/ton-transfer.mdx?plain=1

Use the official asset name "Toncoin" (not "Toncoins") and add missing articles; e.g., "...transfers of Toncoin between two wallets as a default transaction without a payload."

---

- [x] **4191. Improve button label phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/ton-transfer.mdx?plain=1

Change the button text "Search your transaction" to "Search for your transaction" for natural phrasing.

---

- [ ] **4192. Point "TON smart contract addresses" to a real page**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/ton-transfer.mdx?plain=1

Update the "TON smart contract addresses" link from the directory path to /v3/documentation/smart-contracts/addresses/address-formats.

---

- [x] **4193. Add validUntil to simple transfer examples**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/ton-transfer.mdx?plain=1

Include validUntil (e.g., Math.floor(Date.now()/1000) + 300) in transaction objects to follow the documented pattern and avoid stale transactions.

---

- [x] **4194. Define destination address in comment transfer**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/ton-transfer.mdx?plain=1

Replace the undefined variable destination with a placeholder like "<DESTINATION_ADDRESS>" and note it must be a user-friendly address (see /v3/documentation/smart-contracts/addresses/address-formats#user-friendly-address).

---

- [x] **4195. Add Wallet v5 message limit to limits section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/ton-transfer.mdx?plain=1

Extend the limits list to include "wallet v5: up to 255 messages" alongside existing v3/v4 and highload entries.

---

- [x] **4196. Qualify or generalize the reject error string**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/ton-transfer.mdx?plain=1

Label the shown error as an example (e.g., "Example error") or replace with a general note that an exception is thrown when the user cancels, since the exact string is not guaranteed.

---

- [x] **4197. Avoid top-level await in non-React snippets**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/cookbook/ton-transfer.mdx?plain=1

Wrap await tonConnectUI.sendTransaction(transaction) in an async function or event handler instead of using it at the top level.

---

- [ ] **4250. Align link text with target page title**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/web.mdx?plain=1

Change the link text “Sending messages” to “TON transfer” while keeping the URL pointing to docs/v3/guidelines/ton-connect/cookbook/ton-transfer.mdx.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.