### PR TITLE
Split: update docs/v3/guidelines/ton-connect/creating-manifest.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/ton-connect/creating-manifest.mdx
+++ b/docs/v3/guidelines/ton-connect/creating-manifest.mdx
@@ -50,13 +50,13 @@ The manifest is a JSON file named `tonconnect-manifest.json`, and it must follow
   <tr>
     <td><code>termsOfUseUrl</code></td>
     <td>Optional</td>
-    <td>Optional for most apps, but mandatory for apps listed on Tonkeeper’s Recommended Apps list.</td>
+    <td>Optional for most apps, but mandatory for apps listed on Tonkeeper’s recommended apps list.</td>
   </tr>
 
   <tr>
     <td><code>privacyPolicyUrl</code></td>
     <td>Optional</td>
-    <td>Optional for most apps, but mandatory for apps listed on Tonkeeper’s Recommended Apps list.</td>
+    <td>Optional for most apps, but mandatory for apps listed on Tonkeeper’s recommended apps list.</td>
   </tr>
   </tbody>
 </table>
@@ -81,13 +81,8 @@ For reference, see the [TON Connect specification](https://github.com/ton-blockc
 
 > For example: `https://myapp.com/tonconnect-manifest.json`. This helps wallets discover your app more reliably and enhances the overall user experience when users connect to it.
 
-2. The fields `iconUrl`, `termsOfUseUrl`, and `privacyPolicyUrl` must be publicly accessible from any origin without CORS restrictions.
+2. The fields `url`, `iconUrl`, `termsOfUseUrl`, and `privacyPolicyUrl` must be publicly accessible from any origin without CORS restrictions.
 3. Ensure the `tonconnect-manifest.json` is accessible and can be retrieved via a `GET` request to its URL (without requiring authentication or special CORS headers).
-
-## See also
-- [Create a manifest](
-  /v3/guidelines/ton-connect/quick-start#create-a-manifest
-  )
 
 ## Next steps
 Add the SDK to the project and explore the Transaction cookbook to start building with TON Connect.

--- a/src/components/Tables/manifest-table.css
+++ b/src/components/Tables/manifest-table.css
@@ -18,4 +18,16 @@
   font-family: monospace;
   background: #f5f5f5;
   padding: 0.2em 0.4em;
+  color: #111111;
+}
+
+/* Dark theme overrides */
+html[data-theme='dark'] .manifest-table th,
+html[data-theme='dark'] .manifest-table td {
+  border-bottom: 1px solid #333333;
+}
+
+html[data-theme='dark'] .manifest-table td code {
+  background: #2c2c2c;
+  color: #f5f5f5;
 }


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-ton-connect-creating-manifest.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/ton-connect/creating-manifest.mdx`

Related issues (from issues.normalized.md):
- [x] **4198. Use JSON code fence and valid JSON**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/creating-manifest.mdx?plain=1#L13-L21

The first manifest example uses a jsonc fence and comments; switch the fence to json and remove inline comments or move them to explanatory text so the example is valid JSON and highlights correctly.

---

- [x] **4199. Standardize on “app” in table**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/creating-manifest.mdx?plain=1#L35,L41

In the table, change “Defines the DApp’s base URL” to “Defines the app’s base URL” to match the rest of the terminology.

---

- [x] **4200. Replace markdown bold with <strong> in HTML table**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/creating-manifest.mdx?plain=1#L47

Markdown bold inside JSX/HTML table cells renders literally; replace instances like **PNG**, **ICO**, **SVG**, and **180x180px PNG** with <strong>...</strong>.

---

- [ ] **4201. Clarify Tonkeeper requirement or remove it; fix wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/creating-manifest.mdx?plain=1#L53,L59

Update to “mandatory for apps listed on Tonkeeper’s Recommended Apps list” and either add an internal citation for this policy or remove the Tonkeeper-specific clause and keep these fields optional.

---

- [x] **4202. Remove duplicate link to the same spec**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/creating-manifest.mdx?plain=1#L65-L67,L87-L88

Both the info block and the See also section link to the same “App manifest” spec; remove the duplicate in See also or replace it with an internal link (e.g., /v3/guidelines/ton-connect/quick-start#create-a-manifest).

---

- [x] **4203. Fix filename to tonconnect-manifest.json**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/creating-manifest.mdx?plain=1#L85

Change “Ensure the manifest.json is accessible…” to “Ensure the tonconnect-manifest.json is accessible and can be retrieved via a GET request to its URL.”

---

- [x] **4204. Use “Transaction cookbook” consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/creating-manifest.mdx?plain=1#L91,L99

Replace “payload cookbook” in the text and button label with “Transaction cookbook.”

---

- [ ] **4205. Remove url from CORS requirement**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/creating-manifest.mdx?plain=1

Best practices item 2 should not include url in the list of resources requiring cross-origin fetch access; keep the requirement for iconUrl, termsOfUseUrl, and privacyPolicyUrl, and clarify that the manifest itself must be fetchable without CORS/auth.

---

- [x] **4206. Fix broken “Install SDK” link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/creating-manifest.mdx?plain=1

Update the Next steps button href from /guidelines/install-ton-connect (404) to /v3/guidelines/ton-connect/quick-start#install-ton-connect.

---

- [ ] **4207. Soften or cite trailing-slash rule**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/creating-manifest.mdx?plain=1

The url field’s “should not include a trailing slash” constraint lacks a citation; either cite the spec that mandates it or rephrase as a recommendation (with rationale) if not required.

---

- [x] **4224. Use correct manifest filename**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/react.mdx?plain=1#L20

Change “manifest.json” to “tonconnect-manifest.json” to match the manifest guide (see docs/v3/guidelines/ton-connect/creating-manifest.mdx#manifest-definition).

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.