### PR TITLE
Split: update docs/v3/guidelines/ton-connect/frameworks/python.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/ton-connect/frameworks/python.mdx
+++ b/docs/v3/guidelines/ton-connect/frameworks/python.mdx
@@ -19,11 +19,11 @@ To store user wallet connection data, you need to implement a storage interface.
 pip install aiofiles
 ```
 
-### Creating the Manifest
+### Creating the manifest
 
-Create the `tonconnect-manifest.json` file for your application according to the [guidelines](https://docs.ton.org/v3/guidelines/ton-connect/creating-manifest), and host it at a publicly accessible URL.
+Create the `tonconnect-manifest.json` file for your application according to the [guidelines](/v3/guidelines/ton-connect/creating-manifest), and host it at a publicly accessible URL.
 
-### Implementing Storage
+### Implementing storage
 
 To store connection data with user wallets, a storage interface must be implemented.
 
@@ -105,7 +105,7 @@ tc = TonConnect(
 The `wallets_fallback_file_path` parameter is used as a fallback source of wallet data (e.g., Tonkeeper, Wallet) in case the external API is unavailable.
 You can find all input parameters at the following [link](https://github.com/nessshon/tonutils/blob/064a58f32c0c872feed37f49a6af7113268bbc7b/tonutils/tonconnect/tonconnect.py#L40).
 
-### Initializing the Connector
+### Initializing the connector
 
 Create a `Connector` instance to work with a specific user:
 
@@ -121,9 +121,9 @@ connector = await tc.init_connector(user_id)
   user_id = connector.user_id
   ```
 
-## Connecting a Wallet
+### Connect to a wallet
 
-### Retrieving the List of Wallets
+#### Retrieve the list of wallets
 
 To display available wallets in the user interface, retrieve the list of supported wallets:
 
@@ -133,7 +133,7 @@ wallets = await tc.get_wallets()
 
 You can then display the list using each wallet’s name via `wallet.name`.
 
-### Connecting to a Wallet
+#### Connect to a wallet
 
 After the user selects a wallet from the list, initiate the connection (for example, selecting the wallet at index 1):
 
@@ -144,7 +144,7 @@ connect_url = await connector.connect_wallet(selected_wallet)
 
 You should present the `connect_url` to the user in your application.
 
-#### With Redirect URL
+##### With redirect URL
 
 If you want to automatically redirect the user after a successful connection, pass the `redirect_url` parameter:
 
@@ -153,7 +153,7 @@ redirect_url = "https://example.com/"
 connect_url = await connector.connect_wallet(selected_wallet, redirect_url=redirect_url)
 ```
 
-#### With TON Proof
+##### With TON proof
 
 To ensure that the user truly owns the specified address, you can enable address ownership verification using `ton_proof`.
 This feature is particularly useful for verifying ownership of off-chain assets such as Telegram usernames or virtual phone numbers on platforms like Fragment.
@@ -174,7 +174,7 @@ connect_url = await connector.connect_wallet(
 )
 ```
 
-### Handling the Connection
+#### Handle the connection
 
 To handle the result of a wallet connection, use the `connect_wallet_context` context manager.
 
@@ -218,12 +218,12 @@ The context manager will pause execution until:
 - a timeout occurs;
 - or an error is raised.
 
-On success, you will receive a [WalletInfo](https://github.com/nessshon/tonutils/blob/064a58f32c0c872feed37f49a6af7113268bbc7b/tonutils/tonconnect/models/wallet.py#L118) object containing the connected wallet's data.
+On success, you will receive a [WalletInfo](https://github.com/nessshon/tonutils/blob/064a58f32c0c872feed37f49a6af7113268bbc7b/tonutils/tonconnect/models/wallet.py#L115) object containing the connected wallet's data.
 On failure, a `TonConnectError` instance will be returned, which you can handle as described in the [connection errors](#connection-errors) section.
 
-## Sending Requests
+## Sending requests
 
-### Sending a Transaction
+### Send a transaction
 
 To send Toncoin to a specific address, use the `send_transaction` method:
 
@@ -250,7 +250,7 @@ rpc_request_id = await connector.send_transaction(
 
 The method returns `rpc_request_id`, a unique identifier for tracking the request.
 
-### Sending a Simplified Transfer
+### Send a simplified transfer
 
 The `tonutils` library also provides higher-level methods for sending transactions more conveniently.
 
@@ -262,7 +262,7 @@ The `tonutils` library also provides higher-level methods for sending transactio
   - a `Cell` object — for passing a custom payload.
   - a string — used as a comment or memo.
 
-#### Single Transfer
+#### Single transfer
 
 ```python
 rpc_request_id = await connector.send_transfer(
@@ -272,7 +272,7 @@ rpc_request_id = await connector.send_transfer(
 )
 ```
 
-#### Batch Transfer
+#### Batch transfer
 
 Before sending multiple messages in one transaction, ensure the wallet supports the required number of messages:
 
@@ -304,7 +304,7 @@ rpc_request_id = await connector.send_batch_transfer(
 
 These methods also return an `rpc_request_id`.
 
-### Sending a Sign Data Request
+### Send a sign data request
 
 The `sign_data` method allows requesting a cryptographic signature from the user’s wallet for arbitrary content.
 This signature confirms explicit consent and can be verified off-chain or passed into a smart contract.
@@ -386,7 +386,7 @@ If the feature is supported, proceed to send the request:
 rpc_request_id = await connector.sign_data(payload)
 ```
 
-### Handling Request Results
+### Handle request results
 
 Use the `pending_request_context` context manager to wait for a user’s response to both transaction and signing requests.
 
@@ -403,7 +403,7 @@ On success, it returns a response object specific to the request type:
 
 On failure, a `TonConnectError` is returned and can be handled as described in the [request errors](#request-errors) section.
 
-#### Handling Signed Data
+#### Handle signed data
 
 ```python
 from tonutils.tonconnect.utils.exceptions import TonConnectError, UserRejectsError
@@ -422,7 +422,7 @@ async with connector.pending_request_context(rpc_request_id) as response:
             print("Failed to verify sign data!")
 ```
 
-#### Handling the Transaction
+#### Handle the transaction
 
 ```python
 from tonutils.tonconnect.utils.exceptions import TonConnectError, UserRejectsError
@@ -437,7 +437,7 @@ async with connector.pending_request_context(rpc_request_id) as response:
         print(f"Transaction sent successfully! Hash: {response.normalized_hash}")
 ```
 
-### Checking Request Status
+### Check request status
 
 To check whether a request is still waiting for user confirmation:
 
@@ -447,7 +447,7 @@ is_pending = connector.is_request_pending(rpc_request_id)
 
 This method returns `True` if the request has not yet been confirmed in the user's wallet; otherwise, it returns `False`.
 
-### Canceling a Request
+### Cancel a request
 
 If you need to cancel a request for any reason, use:
 
@@ -457,7 +457,7 @@ connector.cancel_pending_request(rpc_request_id)
 
 This completely stops processing the request at the application level, even if the user later confirms it in the wallet.
 
-## Disconnecting the Wallet
+## Disconnecting the wallet
 
 To disconnect the user's wallet, call the `disconnect_wallet` method:
 
@@ -465,16 +465,16 @@ To disconnect the user's wallet, call the `disconnect_wallet` method:
 await connector.disconnect_wallet()
 ```
 
-## Event Handling
+## Event handling
 
 In addition to context managers, **tonutils** provides a unified event-driven interface for reacting to wallet actions.
 This allows you to handle events such as wallet connection, disconnection, transaction execution, and data signing through registered handlers.
 
-### Event Types
+### Event types
 
 TON Connect emits two categories of events:
 
-#### Success Events
+#### Success events
 
 These events are triggered when an action completes successfully:
 
@@ -490,7 +490,7 @@ These events are triggered when an action completes successfully:
 * `Event.SIGN_DATA` — emitted when a sign data request is approved.
   **Parameters:** `user_id: int`, `sign_data: SignDataResponse`, `rpc_request_id: int`
 
-#### Error Events
+#### Error events
 
 These events are triggered **if the corresponding action fails** due to user rejection, timeout, or internal wallet/app errors:
 
@@ -509,7 +509,7 @@ These events are triggered **if the corresponding action fails** due to user rej
 You can handle these errors the same way as standard events using `register_event` or decorators.
 This separation allows you to keep success and failure logic cleanly isolated.
 
-### Handling Events
+### Handling events
 
 You can register event handlers in two ways:
 
@@ -530,11 +530,11 @@ async def on_transaction(user_id: int, transaction: SendTransactionResponse):
     print(f"Transaction confirmed for user {user_id}")
 ```
 
-### Additional Parameters
+### Additional parameters
 
 In addition to standard event arguments, you can pass custom parameters (e.g., database session, context objects, comments) to your event handlers.
 
-#### Attaching parameters to a specific event:
+#### Attach parameters to a specific event:
 
 Use `add_event_kwargs` before entering the context manager or triggering the request:
 
@@ -554,7 +554,7 @@ async def on_connect(user_id: int, wallet: WalletInfo, comment: str, db_session:
     ...
 ```
 
-#### Defining global parameters for all events:
+#### Define global parameters for all events:
 
 You can define default parameters for all events at the TonConnect instance level:
 
@@ -576,11 +576,11 @@ async def on_sign_data(user_id: int, sign_data: SignDataResponse, db_session: Se
     ...
 ```
 
-## Error Handling
+## Error handling
 
 When working with TON Connect, errors may occur both during wallet connection and when sending requests.
 
-### Connection Errors
+### Connection errors
 
 These errors can occur during the wallet connection initialization process:
 
@@ -595,7 +595,7 @@ These errors can occur during the wallet connection initialization process:
 | 400  | `MethodNotSupportedError` | The selected wallet does not support the requested operation or method.   |
 | 500  | `RequestTimeoutError`     | The user did not complete the connection within the allotted time.        |
 
-### Request Errors
+### Request errors
 
 These errors may occur when processing requests.
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-ton-connect-frameworks-python.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/ton-connect/frameworks/python.mdx`

Related issues (from issues.normalized.md):
- [x] **4208. Fix broken SDK link anchor**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/python.mdx?plain=1#L5

The "tonutils" link points to a non-existent developers#ton-connect-python anchor; change its href to https://github.com/nessshon/tonutils.

---

- [ ] **4209. Clarify FileStorage import path**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/python.mdx?plain=1#L90

Add an instruction to save the example FileStorage implementation as storage.py so from storage import FileStorage works as shown.

---

- [ ] **4210. Replace brittle GitHub line-anchored links with permalinks**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/python.mdx?plain=1#L104, #L219, #L398-#L400

Update external source links that include default-branch line anchors to use commit‑pinned permalinks (blob/<commit>…#LNN) to avoid breakage.

---

- [ ] **4211. Add missing time import in transaction example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/python.mdx?plain=1#L233

Import the time module (import time) at the top of the snippet before other imports so time.time() resolves.

---

- [x] **4212. Standardize bullet punctuation under body parameter**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/python.mdx?plain=1#L259-#L260

Change the trailing semicolons in the two body bullets to periods for consistency.

---

- [x] **4213. Correct TL‑B type casing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/python.mdx?plain=1#L351

Replace Snakedata with SnakeData in the schema string (e.g., schema = "text_comment#00000000 text:SnakeData = InMsgBody;").

---

- [x] **4214. Fix grammar in unsupported feature message**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/python.mdx?plain=1#L376

Change "Wallet does not support sign data feature!" to "Wallet does not support the sign data feature!".

---

- [x] **4215. Use American spelling in heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/python.mdx?plain=1#L447

Change the heading "Cancelling a Request" to "Canceling a Request" for consistency with the page’s American English.

---

- [x] **4216. Improve subsection title grammar**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/python.mdx?plain=1#L513

Change "Using method" to "Using a method".

---

- [ ] **4217. Add missing imports for typed handler examples**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/python.mdx?plain=1#L515, #L525, #L549, #L571

Add imports for SendTransactionResponse, SignDataResponse, WalletInfo, and Session in the examples so the type annotations resolve.

---

- [x] **4218. Fix manifest filename**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/python.mdx?plain=1#creating-the-manifest

Replace "Create the manifest.json file" with "Create the tonconnect-manifest.json file" to match the canonical manifest definition.

---

- [ ] **4219. Include rpc_request_id in handler signatures**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/python.mdx?plain=1#success-events

Update handler examples to accept (user_id, transaction, rpc_request_id) and (user_id, sign_data, rpc_request_id) to match the documented event parameters.

---

- [ ] **4220. Use consistent async style for handlers**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/python.mdx?plain=1#handling-events

Convert all handler examples to async def for consistency with the decorator-based example.

---

- [x] **4221. Clarify "connector level" wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/python.mdx?plain=1#defining-global-parameters-for-all-events

Replace "at the connector level" with "at the TonConnect instance level" to reflect setting tc[...] on a TonConnect object.

---

- [x] **4222. Add terminal periods to transaction parameter bullets**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/python.mdx?plain=1#sending-a-transaction

Add periods at the end of the valid_until, address, and amount bullet items for consistency with nearby lists.

---

- [x] **4223. Explain wallets_fallback_file_path expectations**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/python.mdx?plain=1#initializing-ton-connect

Add a brief note describing the expected structure and source of wallets_fallback_file_path (wallets.json) so readers know how to provide it or omit the parameter.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.