### PR TITLE
Split: update docs/v3/guidelines/ton-connect/frameworks/react.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/ton-connect/frameworks/react.mdx
+++ b/docs/v3/guidelines/ton-connect/frameworks/react.mdx
@@ -17,9 +17,9 @@ npm i @tonconnect/ui-react
 
 ### Set up TON Connect
 
-After installing the package, you should create a `manifest.json` file for your application. More information on creating a manifest.json file can be found [here](/v3/guidelines/ton-connect/creating-manifest).
+After installing the package, you should create a `tonconnect-manifest.json` file for your application. More information on creating a `tonconnect-manifest.json` file can be found [here](/v3/guidelines/ton-connect/creating-manifest).
 
-After creating the manifest file, import `TonConnectUIProvider` into the root of your Mini App and pass the manifest URL:
+After creating the manifest file, import `TonConnectUIProvider` into the root of your app and pass the manifest URL:
 
 ```tsx
 import { TonConnectUIProvider } from '@tonconnect/ui-react';
@@ -53,9 +53,9 @@ export const Header = () => {
 
 The `TonConnectButton` is a universal UI component for initializing a connection. After the wallet is connected, it transforms into a wallet menu. Place the **Connect** button in the top right corner of your app.
 
-You can add the `className` and style props to the button:
+You can add the `className` and `style` props to the button:
 
-```js
+```tsx
 <TonConnectButton className="my-button-class" style={{ float: "right" }}/>
 ```
 
@@ -81,7 +81,7 @@ export const Header = () => {
 
 #### Connect with a specific wallet
 
-To open a modal window for a specific wallet, use the `openSingleWalletModal()` method. This method takes the wallet's `app_name` as a parameter (refer to the [wallets-list.json](https://github.com/ton-blockchain/wallets-list/blob/main/wallets-v2.json) file) and opens the corresponding wallet modal. It returns a promise that resolves once the modal window opens successfully.
+To open a modal window for a specific wallet, use the `openSingleWalletModal()` method. This method takes the wallet's `app_name` as a parameter (refer to the [wallets-v2.json](https://github.com/ton-blockchain/wallets-list/blob/main/wallets-v2.json) file) and opens the corresponding wallet modal.
 
 ```tsx
 <button onClick={() => tonConnectUI.openSingleWalletModal('tonwallet')}>
@@ -107,7 +107,7 @@ If you want to redirect the user to a [Telegram Mini App](/v3/guidelines/dapps/t
       </TonConnectUIProvider>
 ```
 
-[Open example on GitHub](https://github.com/ton-connect/demo-dapp-with-wallet/blob/master/src/App.tsx)
+[Open example on GitHub](https://github.com/ton-connect/demo-dapp-with-react-ui)
 
 ### UI customization
 
@@ -119,7 +119,7 @@ If you want to use some low-level TON Connect UI SDK features in your React app,
 
 ### useTonAddress
 
-Use it to get the user's current TON wallet address. Pass the boolean parameter `isUserFriendly` to choose the address format, where the `isUserFriendly` is `true` by default. The hook will return an empty string if the wallet is not connected.
+Use it to get the user's current TON wallet address. Pass the boolean parameter `isUserFriendly` to choose the address format, where `isUserFriendly` is `true` by default. The hook will return an empty string if the wallet is not connected.
 
 ```tsx
 import { useTonAddress } from '@tonconnect/ui-react';
@@ -193,7 +193,7 @@ export const Wallet = () => {
 
 ### useTonConnectUI
 
-Access the `TonConnectUI` instance and update the UI options function.
+Access the `TonConnectUI` instance and a function to update UI options.
 
 [See more about TonConnectUI instance methods](https://github.com/ton-connect/sdk/tree/main/packages/ui#send-transaction)
 
@@ -248,7 +248,7 @@ Let's look at how to use the React UI SDK in practice.
 
 Send Toncoin to a specific address:
 
-```js
+```ts
 import { useTonConnectUI } from '@tonconnect/ui-react';
 
 const transaction: SendTransactionRequest = {
@@ -399,7 +399,7 @@ Deploying a contract using TON Connect is pretty straightforward. You must:
 
 - Obtain the contract `code` and `data`
 - Store them as a `stateInit` cell
-- Send a transaction using the `statement` field provided
+ - Send a transaction using the `stateInit` field provided
 
 Note that `CONTRACT_CODE` and `CONTRACT_INIT_DATA` may be found in wrappers.
 
@@ -465,7 +465,7 @@ Let's take a look at the default `Blueprint` counter wrapper example and how we 
       increase: 0x7e8764ef,
   };
 
-  export class Counter implements contract {
+  export class Counter implements Contract {
       constructor(
           readonly address: Address,
           readonly init?: { code: Cell; data: Cell },
@@ -607,7 +607,6 @@ Let's take a look at the default `Blueprint` counter wrapper example and how we 
       // Use the TonConnect UI to send the message and wait for the sending
       await this.provider.sendTransaction({
         validUntil: validUntil,
-        from: from,
         messages: [
           {
             address: address,
@@ -688,7 +687,7 @@ This SDK provides wrappers that simplify interaction with these assets. Please c
 
 ## API documentation
 
-[Latest API documentation](https://ton-connect.github.io/sdk/modules/_tonconnect_ui_react.html)
+[Latest API documentation](https://ton-connect.github.io/sdk/modules/_tonconnect_ui-react.html)
 
 ## Examples
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-ton-connect-frameworks-react.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/ton-connect/frameworks/react.mdx`

Related issues (from issues.normalized.md):
- [ ] **4224. Use correct manifest filename**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/react.mdx?plain=1#L20

Change “manifest.json” to “tonconnect-manifest.json” to match the manifest guide (see docs/v3/guidelines/ton-connect/creating-manifest.mdx#manifest-definition).

---

- [ ] **4225. Replace “Mini App” with “app”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/react.mdx?plain=1#L22

Replace “Mini App” with “app” or “React app” to avoid confusion with Telegram Mini Apps.

---

- [ ] **4226. Add backticks around style prop**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/react.mdx?plain=1#L56

Change “className and style props” to “className and `style` props” for consistency.

---

- [ ] **4227. Fix language tag for JSX snippet**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/react.mdx?plain=1#L58-L60

Change the code fence from ```js to ```tsx (or ```jsx) to correctly highlight JSX.

---

- [ ] **4228. Fix wallets list filename in link text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/react.mdx?plain=1#L84

Update the link text from “wallets-list.json” to “wallets-v2.json” (or a neutral “wallets list”) to match the actual target.

---

- [ ] **4229. Clarify isUserFriendly sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/react.mdx?plain=1#L122

Rephrase to: “Pass the boolean parameter `isUserFriendly` to choose the address format, where `isUserFriendly` is `true` by default.”

---

- [ ] **4230. Clarify useTonConnectUI description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/react.mdx?plain=1#L196

Rephrase to: “Access the `TonConnectUI` instance and a function to update UI options.”

---

- [ ] **4231. Fix language tag for TypeScript snippet**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/react.mdx?plain=1

In “Sending transactions,” the snippet uses TypeScript types but is fenced as `js`; change the code fence to `ts`/`tsx` (or remove the type annotation) for correct syntax highlighting.

---

- [ ] **4232. Update Telegram Mini Apps example link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/react.mdx?plain=1

Change the “Open example on GitHub” link from the `demo-dapp-with-wallet` repo to the React-focused `demo-dapp-with-react-ui` repo for consistency.

---

- [ ] **4233. Avoid promising openSingleWalletModal return semantics**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/react.mdx?plain=1

Rephrase to describe that `openSingleWalletModal()` opens the modal without asserting a specific promise/resolve behavior unless a documented reference is provided.

---

- [ ] **4234. Show hook initialization in specific wallet snippet**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/react.mdx?plain=1

Add `const [tonConnectUI] = useTonConnectUI();` (with the corresponding import) in the “Connect with a specific wallet” example so `tonConnectUI` is defined.

---

- [ ] **4235. Standardize TMA URL placeholder style**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/react.mdx?plain=1

Change `'https://t.me/<YOUR_APP_NAME>'` to `'https://t.me/YOUR_APP_NAME'` (no angle brackets) to match other pages.

---

- [ ] **4236. Use seconds for validUntil**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/react.mdx?plain=1

Replace `Date.now() + 5 * 60 * 1000` with `Math.floor(Date.now() / 1000) + 600` for `validUntil` in “Sending transactions” and “Deploying contract” to use seconds consistently.

---

- [ ] **4237. Replace “statement” with stateInit**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/react.mdx?plain=1

Fix the “Deploying contract” text to reference the `stateInit` field (not “statement”) to match the code sample.

---

- [ ] **4238. Fix wrapper to implements Contract**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/react.mdx?plain=1

Change `export class Counter implements contract { ... }` to `export class Counter implements Contract { ... }` to match the imported type.

---

- [ ] **4239. Use canonical API docs link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/react.mdx?plain=1

Update the “Latest API documentation” link to `modules/_tonconnect_ui-react.html` (hyphen) to match canonical URLs used elsewhere.

---

- [ ] **4240. Remove or document transaction from property**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/react.mdx?plain=1

In the `TonConnectProvider` example, remove the undocumented `from` field from `sendTransaction` (or add a reference documenting it), for consistency with other examples.

---

- [ ] **4265. Replace vague framework support statement**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/guidelines/developers.mdx?plain=1

Replace “Standard frontend frameworks are supported…” with “See framework guides for React and client-side JS: docs/v3/guidelines/ton-connect/frameworks/react.mdx and docs/v3/guidelines/ton-connect/frameworks/web.mdx.”

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.