### PR TITLE
Split: update docs/v3/guidelines/ton-connect/frameworks/web.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/ton-connect/frameworks/web.mdx
+++ b/docs/v3/guidelines/ton-connect/frameworks/web.mdx
@@ -68,10 +68,12 @@ You can also open the connect modal programmatically; for example, from a custom
         await tonConnectUI.openModal();
     }
 
-    // Call the function
-    connectToWallet().catch(error => {
-        console.error("Error connecting to wallet:", error);
-    });
+    // Attach to a button click
+    document.getElementById('connect-btn').onclick = () => {
+        connectToWallet().catch(error => {
+            console.error("Error connecting to wallet:", error);
+        });
+    };
 </script>
 ```
 
@@ -86,20 +88,20 @@ To redirect the user to a specific URL after connection, you can [customize your
 To redirect the user to a [Telegram Mini App](/v3/guidelines/dapps/tma/overview) after wallet connection, use the `twaReturnUrl` option:
 
 ```js
-tonConnectUI.uiOptions = {
+tonConnectUI.setOptions({
   actionsConfiguration: {
-    twaReturnUrl: 'https://t.me/YOUR_APP_NAME'
+    twaReturnUrl: 'https://t.me/<YOUR_APP_NAME>'
   }
-};
+});
 ```
 
-[Read more in SDK documentation](https://github.com/ton-connect/sdk/tree/main/packages/ui#use-inside-twa-telegram-web-app)
+[Read more in SDK documentation](https://github.com/ton-connect/sdk/tree/main/packages/ui#use-inside-tma-telegram-mini-apps)
 
 ### UI customization
 
 TON Connect UI provides an interface that should be familiar and recognizable to the user when using various apps. However, the app developer can modify this interface to keep it consistent with the app's interface.
 
-- [TonConnect UI documentation](https://github.com/ton-connect/sdk/tree/main/packages/ui#ui-customisation)
+- [TON Connect UI documentation](https://github.com/ton-connect/sdk/tree/main/packages/ui#ui-customisation)
 
 ## SDK documentation
 
@@ -115,9 +117,9 @@ Let's look at an example of using TON Connect UI in an app.
 Here's an example of sending a transaction using the TON Connect UI:
 
 ```js
-import { TonConnectUI } from '@tonconnect/ui';
+import TonConnectUI from '@tonconnect/ui';
 
-const tonConnectUI = new TonConnectUI({ //connect application
+const tonConnectUI = new TonConnectUI({ // connect application
     manifestUrl: 'https://<YOUR_APP_URL>/tonconnect-manifest.json',
     buttonRootId: '<YOUR_CONNECT_BUTTON_ANCHOR_ID>'
 });
@@ -127,21 +129,23 @@ const transaction = {
   messages: [
         {
             address: "EQABa48hjKzg09hN_HjxOic7r8T1PleIy1dRd8NvZ3922MP0", // destination address
-            amount: "20000000" //Toncoin in nanotons
+            amount: "20000000" // Toncoin in nanotons
         }
     ]
 }
 
-const result = await tonConnectUI.sendTransaction(transaction)
+async function sendTransactionHandler() {
+  const result = await tonConnectUI.sendTransaction(transaction);
+}
 ```
 
 :::tip
-Get more examples on the [Sending messages](/v3/guidelines/ton-connect/cookbook/ton-transfer) page.
+Get more examples on the [TON transfer](/v3/guidelines/ton-connect/cookbook/ton-transfer) page.
 :::
 
 ### Understanding transaction status by hash
 
-Learn the principle explained in [payment processing](/v3/guidelines/dapps/asset-processing/payments-processing#check-contracts-transactions) using the tonweb library.
+Learn the principle explained in [payment processing](/v3/guidelines/ton-connect/guidelines/transaction-by-external-message).
 
 ### Signing and verification
 
@@ -154,7 +158,7 @@ This feature is particularly useful for verifying ownership of off-chain assets 
 
 ### Wallet disconnection
 
-Call to disconnect from the wallet:
+To disconnect from the wallet, call:
 
 ```js
 await tonConnectUI.disconnect();


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-ton-connect-frameworks-web.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/ton-connect/frameworks/web.mdx`

Related issues (from issues.normalized.md):
- [ ] **4241. Fix GitHub README anchor for TMA section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/web.mdx?plain=1

Update the “Read more in SDK documentation” link from "https://github.com/ton-connect/sdk/tree/main/packages/ui#use-inside-twa-telegram-web-app" to "https://github.com/ton-connect/sdk/tree/main/packages/ui#use-inside-tma-telegram-mini-apps".

---

- [ ] **4242. Standardize TWA placeholder format**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/web.mdx?plain=1

Change the example URL from "https://t.me/YOUR_APP_NAME" to "https://t.me/<YOUR_APP_NAME>" (e.g., for twaReturnUrl) to match the page’s angle‑bracket placeholder convention.

---

- [ ] **4243. Wrap top-level await in async context or note ESM**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/web.mdx?plain=1

In “Sending messages,” move "const result = await tonConnectUI.sendTransaction(transaction)" into an async function or event handler, or state that the snippet runs in an ES module.

---

- [ ] **4244. Use click handler for programmatic connect modal**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/web.mdx?plain=1

Remove the immediate "connectToWallet()" call and attach the function to a button click (e.g., "document.getElementById('connect-btn').onclick = connectToWallet") to match the text.

---

- [ ] **4245. Fix comment spacing in code sample**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/web.mdx?plain=1

Add a space after "//" in the “Sending messages” comments (e.g., "// connect application", "// Toncoin in nanotons") for readability.

---

- [ ] **4246. Use “TON Connect UI” consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/web.mdx?plain=1

Change the link label “TonConnect UI documentation” to “TON Connect UI documentation” (URL unchanged) to match the naming used elsewhere on the page.

---

- [ ] **4247. Improve disconnect instruction phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/web.mdx?plain=1

Replace “Call to disconnect from the wallet:” with “To disconnect from the wallet, call:” for clarity.

---

- [ ] **4248. Use default import for TonConnectUI**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/web.mdx?plain=1

Change "import { TonConnectUI } from '@tonconnect/ui';" to "import TonConnectUI from '@tonconnect/ui';" for consistency with the rest of the docs.

---

- [ ] **4249. Fix broken payments-processing link and wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/web.mdx?plain=1

Replace "/v3/guidelines/dapps/asset-processing/payments-processing#check-contracts-transactions" with "/v3/guidelines/ton-connect/guidelines/transaction-by-external-message" and remove the “using the tonweb library” reference to align with the target page.

---

- [ ] **4250. Align link text with target page title**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/web.mdx?plain=1

Change the link text “Sending messages” to “TON transfer” while keeping the URL pointing to docs/v3/guidelines/ton-connect/cookbook/ton-transfer.mdx.

---

- [ ] **4251. Update UI options via setter instead of direct assignment**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/frameworks/web.mdx?plain=1

Replace "tonConnectUI.uiOptions = { actionsConfiguration: { twaReturnUrl: 'https://t.me/<YOUR_APP_NAME>' } }" with "tonConnectUI.setOptions({ actionsConfiguration: { twaReturnUrl: 'https://t.me/<YOUR_APP_NAME>' } })" (or the documented plain JS options setter) to avoid unsupported direct assignment.

---

- [ ] **4265. Replace vague framework support statement**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/guidelines/developers.mdx?plain=1

Replace “Standard frontend frameworks are supported…” with “See framework guides for React and client-side JS: docs/v3/guidelines/ton-connect/frameworks/react.mdx and docs/v3/guidelines/ton-connect/frameworks/web.mdx.”

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.