### PR TITLE
Split: update docs/v3/guidelines/ton-connect/guidelines/developers.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/ton-connect/guidelines/developers.mdx
+++ b/docs/v3/guidelines/ton-connect/guidelines/developers.mdx
@@ -5,10 +5,10 @@ import Feedback from '@site/src/components/Feedback';
 ## SDK List
 
 :::info
-We recommend using the [@tonconnect/ui-react](https://github.com/ton-connect/sdk/tree/main/packages/ui-react) kit for your DApps. Only switch to lower‑level packages (such as `@tonconnect/ui` or `@tonconnect/sdk`) or implement the protocol yourself if your product requires it.
+We recommend using the [@tonconnect/ui-react](https://github.com/ton-connect/sdk/tree/main/packages/ui-react) kit for your DApps. Only switch to lower-level packages (such as `@tonconnect/ui` or `@tonconnect/sdk`) or implement the protocol yourself if your product requires it.
 :::
 
-This page contains the list of useful libraries for TON Connect.
+This page contains a list of useful libraries for TON Connect.
 
 - [TON Connect React](/v3/guidelines/ton-connect/guidelines/developers#ton-connect-react)
 - [TON Connect JS SDK](/v3/guidelines/ton-connect/guidelines/developers#ton-connect-js-sdk)
@@ -17,12 +17,12 @@ This page contains the list of useful libraries for TON Connect.
 
 - [@tonconnect/ui-react](https://github.com/ton-connect/sdk/tree/main/packages/ui-react) - TON Connect User Interface (UI) for React applications
 
-`@tonconnect/ui-react` is a React UI kit for the TON Connect SDK. Use it to connect your app to TON wallets through the TON Connect protocol in React.
+`@tonconnect/ui-react` is a React UI kit for the TON Connect SDK. Use it to connect your React app to TON wallets via the TON Connect protocol.
 
 - Example of a DApp with `@tonconnect/ui-react`: [GitHub](https://github.com/ton-connect/demo-dapp-with-react-ui)
 - Example of deployed `demo-dapp-with-react-ui`: [Live demo](https://ton-connect.github.io/demo-dapp-with-react-ui/)
 
-```bash
+```bash npm2yarn
 npm i @tonconnect/ui-react
 ```
 
@@ -35,14 +35,14 @@ npm i @tonconnect/ui-react
 The TON Connect repository contains the following main packages:
 
 - [@tonconnect/ui](/v3/guidelines/ton-connect/guidelines/developers#ton-connect-ui) - TON Connect User Interface (UI)
-- [@tonconnect/sdk](/v3/guidelines/ton-connect/guidelines/developers#ton-connect-sdk)  - TON Connect SDK
+- [@tonconnect/sdk](/v3/guidelines/ton-connect/guidelines/developers#ton-connect-sdk) - TON Connect SDK
 - [@tonconnect/protocol](/v3/guidelines/ton-connect/guidelines/developers#ton-connect-protocol-models) - TON Connect protocol models (TypeScript)
 
 ### TON Connect UI
 
 TON Connect UI is a UI kit for TON Connect SDK. Use it to connect your app to TON wallets via the TON Connect protocol. It allows you to integrate TON Connect into your app more efficiently using our UI elements, such as the **connect wallet** button, **select wallet** dialog, and **confirmation** modals.
 
-```bash
+```bash npm2yarn
 npm i @tonconnect/ui
 ```
 
@@ -54,12 +54,11 @@ The TON Connect **User Interface (UI)** is a UI kit that allows developers to im
 
 Developers can easily integrate TON Connect with apps using simple UI elements such as the connect wallet button, select wallet dialog, and confirmation modals. Here are related resources and examples:
 
-- Example of app functionality in the DApp browser: [Live demo](https://ton-connect.github.io/demo-dapp/)
-- Example of the backend part for the DApp above: [GitHub](https://github.com/ton-connect/demo-dapp-backend)
-- Example of a bridge server using Go: [GitHub](https://github.com/ton-connect/bridge)
+- Example app live demo: [Live demo](https://ton-connect.github.io/demo-dapp/)
+- Example backend for the demo DApp: [GitHub](https://github.com/ton-connect/demo-dapp-backend)
+- Example bridge server (Go): [GitHub](https://github.com/ton-connect/bridge)
 
-This kit simplifies the implementation of TON Connect in apps built for TON Blockchain.
-Standard frontend frameworks are supported, as well as applications built without specific frameworks.
+This kit simplifies the implementation of TON Connect in apps built for the TON Blockchain. See framework guides for React and client-side JS: [React](/v3/guidelines/ton-connect/frameworks/react) and [Web](/v3/guidelines/ton-connect/frameworks/web).
 
 ### TON Connect SDK
 
@@ -68,6 +67,7 @@ The TON Connect SDK is the middle layer between the UI kit and the protocol mode
 
 - [GitHub](https://github.com/ton-connect/sdk/tree/main/packages/sdk)
 - [npm](https://www.npmjs.com/package/@tonconnect/sdk)
+- [API Documentation](https://ton-connect.github.io/sdk/modules/_tonconnect_sdk.html)
 
 ### TON Connect Protocol Models
 
@@ -75,16 +75,17 @@ This package contains protocol requests, protocol responses, event models, and e
 
 - [GitHub](https://github.com/ton-connect/sdk/tree/main/packages/protocol)
 - [npm](https://www.npmjs.com/package/@tonconnect/protocol)
+- [API Documentation](https://ton-connect.github.io/sdk/modules/_tonconnect_protocol.html)
 
 ## General Questions and Concerns
 
-If you encounter any additional issues during the implementation of TON Connect, open an issue on [GitHub](https://github.com/ton-blockchain/ton-connect/issues).
+If you encounter any additional issues during the implementation of TON Connect, open an issue on [GitHub](https://github.com/ton-connect/sdk/issues).
 
 ## See also
 
 - [Step-by-step guide for building your first web client](https://helloworld.tonstudio.io/03-client/)
-- [\[YouTube\] TON Smart Contracts | 10 | Telegram DApp\[EN\]](https://www.youtube.com/watch?v=D6t3eZPdgAU&t=254s&ab_channel=AlefmanVladimir%5BEN%5D)
+- [[YouTube] TON Smart Contracts | 10 | Telegram DApp [EN]](https://www.youtube.com/watch?v=D6t3eZPdgAU&t=254s&ab_channel=AlefmanVladimir%5BEN%5D)
 - [TON Connect SDK](https://github.com/ton-connect/sdk/tree/main/packages/sdk)
-- [\[YouTube\] TON Dev Study TON Connect Protocol \[RU\]](https://www.youtube.com/playlist?list=PLyDBPwv9EPsCJ226xS5_dKmXXxWx1CKz_)
+- [[YouTube] TON Dev Study TON Connect Protocol [RU]](https://www.youtube.com/playlist?list=PLyDBPwv9EPsCJ226xS5_dKmXXxWx1CKz_)
 
 <Feedback />

--- a/docs/v3/guidelines/ton-connect/guidelines/developers.mdx
+++ b/docs/v3/guidelines/ton-connect/guidelines/developers.mdx
@@ -28,7 +28,7 @@ npm i @tonconnect/ui-react
 
 - [GitHub](https://github.com/ton-connect/sdk/tree/main/packages/ui-react)
 - [npm](https://www.npmjs.com/package/@tonconnect/ui-react)
-- [API Documentation](https://ton-connect.github.io/sdk/modules/_tonconnect_ui-react.html)
+- [Additional documentation](https://ton-connect.github.io/sdk/modules/_tonconnect_ui-react.html)
 
 ## TON Connect JS SDK
 
@@ -40,7 +40,7 @@ The TON Connect repository contains the following main packages:
 
 ### TON Connect UI
 
-TON Connect UI is a UI kit for TON Connect SDK. Use it to connect your app to TON wallets via the TON Connect protocol. It allows you to integrate TON Connect into your app more efficiently using our UI elements, such as the **connect wallet** button, **select wallet** dialog, and **confirmation** modals.
+TON Connect UI is a UI kit for TON Connect SDK. Use it to connect your app to TON wallets via the TON Connect protocol. It allows you to integrate TON Connect into your app more efficiently using our UI elements, such as the **connect wallet** button, **select wallet** dialog, and **confirmation** modals. It improves and unifies the user **experience (UX)** for TON application users.
 
 ```bash npm2yarn
 npm i @tonconnect/ui
@@ -48,11 +48,9 @@ npm i @tonconnect/ui
 
 - [GitHub](https://github.com/ton-connect/sdk/tree/main/packages/ui)
 - [npm](https://www.npmjs.com/package/@tonconnect/ui)
-- [API Documentation](https://ton-connect.github.io/sdk/modules/_tonconnect_ui.html)
+- [Additional documentation](https://ton-connect.github.io/sdk/modules/_tonconnect_ui.html)
 
-The TON Connect **User Interface (UI)** is a UI kit that allows developers to improve and unify the user **experience (UX)** for TON application users.
-
-Developers can easily integrate TON Connect with apps using simple UI elements such as the connect wallet button, select wallet dialog, and confirmation modals. Here are related resources and examples:
+Here are related resources and examples:
 
 - Example app live demo: [Live demo](https://ton-connect.github.io/demo-dapp/)
 - Example backend for the demo DApp: [GitHub](https://github.com/ton-connect/demo-dapp-backend)


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-ton-connect-guidelines-developers.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/ton-connect/guidelines/developers.mdx`

Related issues (from issues.normalized.md):
- [x] **4113. Resolve SDK availability inconsistency**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/business/ton-connect-for-business.mdx?plain=1#L39-L40

Remove unverified future claims and mobile SDK listings; state currently supported SDKs (e.g., JavaScript and Python) and link to the canonical list (docs/v3/guidelines/ton-connect/guidelines/developers.mdx).

---

- [x] **4252. Use indefinite article in intro sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/guidelines/developers.mdx?plain=1

Change “This page contains the list of useful libraries for TON Connect.” to “This page contains a list of useful libraries for TON Connect.”

---

- [x] **4253. Add API docs link for SDK**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/guidelines/developers.mdx?plain=1#ton-connect-sdk

Add an “API Documentation” link alongside GitHub and npm: https://ton-connect.github.io/sdk/modules/_tonconnect_sdk.html.

---

- [ ] **4254. Use “the TON blockchain”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/guidelines/developers.mdx?plain=1

Change “apps built for TON Blockchain.” to “apps built for the TON blockchain.”

---

- [x] **4255. Replace “backend part” with “backend”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/guidelines/developers.mdx?plain=1

Change “Example of the backend part for the DApp above” to “Example of the backend for the DApp above.”

---

- [x] **4256. Remove redundant UI kit description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/guidelines/developers.mdx?plain=1

The second paragraph repeats “TON Connect UI is a UI kit for TON Connect SDK.”; remove it or merge any unique details into the first to avoid repetition.

---

- [x] **4257. Replace non-breaking hyphen in “lower-level”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/guidelines/developers.mdx?plain=1

Replace the non‑breaking hyphen (U+2011) in “lower‑level” with a standard hyphen for consistency: “lower-level.”

---

- [x] **4258. Remove extra space before list dash**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/guidelines/developers.mdx?plain=1

In the “main packages” list, fix the “@tonconnect/sdk” item by removing the extra space before the dash so it reads “) - TON Connect SDK.”

---

- [x] **4259. Clarify React usage sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/guidelines/developers.mdx?plain=1

Replace “Use it to connect your app to TON wallets through the TON Connect protocol in React.” with “Use it to connect your React app to TON wallets via the TON Connect protocol.”

---

- [x] **4260. Remove unnecessary escapes in link labels**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/guidelines/developers.mdx?plain=1

In “See also,” remove backslash escapes from square brackets in link text (e.g., “[YouTube] TON Smart Contracts | 10 | Telegram DApp [EN]” and “[YouTube] TON Dev Study TON Connect Protocol [RU]”).

---

- [x] **4261. Point issues link to SDK repo**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/guidelines/developers.mdx?plain=1

In “General Questions and Concerns,” change the issues link from https://github.com/ton-blockchain/ton-connect/issues to https://github.com/ton-connect/sdk/issues to align with other links to the ton-connect org.

---

- [x] **4262. Add npm2yarn tag to install snippets**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/guidelines/developers.mdx?plain=1

Update both installation code fences to use “bash npm2yarn” so Yarn equivalents auto-render (for @tonconnect/ui-react and @tonconnect/ui).

---

- [x] **4263. Remove ambiguous “DApp browser” phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/guidelines/developers.mdx?plain=1

Drop “in the DApp browser” and keep a neutral phrasing, e.g., “Example app live demo: Live demo (https://ton-connect.github.io/demo-dapp/).”

---

- [x] **4264. Add API docs link for Protocol Models**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/guidelines/developers.mdx?plain=1#ton-connect-protocol-models

Add an “API Documentation” link: https://ton-connect.github.io/sdk/modules/_tonconnect_protocol.html.

---

- [x] **4265. Replace vague framework support statement**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/guidelines/developers.mdx?plain=1

Replace “Standard frontend frameworks are supported…” with “See framework guides for React and client-side JS: docs/v3/guidelines/ton-connect/frameworks/react.mdx and docs/v3/guidelines/ton-connect/frameworks/web.mdx.”

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.