### PR TITLE
Split: update docs/v3/guidelines/ton-connect/guidelines/transaction-by-external-message.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/ton-connect/guidelines/transaction-by-external-message.mdx
+++ b/docs/v3/guidelines/ton-connect/guidelines/transaction-by-external-message.mdx
@@ -7,6 +7,8 @@ This article describes how to find a transaction associated with an external-in 
 In TON, messages may contain fields such as `init`, `src`, and `importFee`. These fields should be removed or zeroed out before calculating the message hash, as described in [TEP-467](https://github.com/ton-blockchain/TEPs/blob/8b3beda2d8611c90ec02a18bec946f5e33a80091/text/0467-normalized-message-hash.md).
 
 ```ts
+import { beginCell, storeMessage, Message } from '@ton/ton';
+
 export function getNormalizedExtMessageHash(message: Message) {
     if (message.info.type !== 'external-in') {
         throw new Error(`Message must be "external-in", got ${message.info.type}`);
@@ -55,6 +57,8 @@ export async function retry<T>(fn: () => Promise<T>, options: { retries: number;
 The `getTransactionByInMessage` function searches the account’s transaction history for a match by normalized external message hash:
 
 ```ts
+import { TonClient, Transaction, Cell, loadMessage } from '@ton/ton';
+
 async function getTransactionByInMessage(
     inMessageBoc: string,
     client: TonClient,
@@ -186,12 +190,13 @@ if (tx) {
 
 ### Wait for transaction confirmation
 
-```ts
+```tsx
 import { TonClient } from '@ton/ton';
+import { useTonConnectUI } from '@tonconnect/ui-react';
 
 const client = new TonClient({ endpoint: 'https://toncenter.com/api/v2/jsonRPC' });
 
-const [tonConnectUI, setOptions] = useTonConnectUI();
+const [tonConnectUI] = useTonConnectUI();
 
 // Obtain ExternalInMessage boc
 const { boc } = await tonConnectUI.sendTransaction({


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-ton-connect-guidelines-transaction-by-external-message.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/ton-connect/guidelines/transaction-by-external-message.mdx`

Related issues (from issues.normalized.md):
- [x] **4266. Replace TEP-467 PR link with canonical text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/guidelines/transaction-by-external-message.mdx?plain=1#message-normalization

The section links to a GitHub PR instead of the canonical TEP text; update the inline link target to https://github.com/ton-blockchain/TEPs/blob/8b3beda2d8611c90ec02a18bec946f5e33a80091/text/0467-normalized-message-hash.md to match “See also” and ensure stability.

---

- [x] **4267. Correct React hook usage and imports in example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/guidelines/transaction-by-external-message.mdx?plain=1#wait-for-transaction-confirmation

The example calls useTonConnectUI at top level without import and destructures unused setOptions; add import { useTonConnectUI } from '@tonconnect/ui-react', move hook usage into a component handler (or use the non-React TonConnectUI API), destructure as const [tonConnectUI] = useTonConnectUI(), and mark the code block as tsx.

---

- [x] **4268. Fix BoC capitalization in comment**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/guidelines/transaction-by-external-message.mdx?plain=1#wait-for-transaction-confirmation

The comment says “Obtain ExternalInMessage boc”; change to “Obtain external-in message BoC” for terminology consistency.

---

- [x] **4269. Add missing imports to normalization helper**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/guidelines/transaction-by-external-message.mdx?plain=1#message-normalization

The getNormalizedExtMessageHash snippet references beginCell, storeMessage, and Message without imports; prepend import { beginCell, storeMessage, Message } from '@ton/ton'.

---

- [x] **4270. Remove unused imports in hash normalization example**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/guidelines/transaction-by-external-message.mdx?plain=1#hash-normalization

The example imports beginCell, storeMessage, and Message but only uses Cell and loadMessage; reduce to import { Cell, loadMessage } from '@ton/ton'.

---

- [x] **4271. Ensure retry throws a defined error**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/guidelines/transaction-by-external-message.mdx?plain=1#retrying-api-calls

retry throws lastError, which may be undefined; change the final throw to throw lastError ?? new Error('Retry attempts exhausted').

---

- [x] **4272. Align link text with target title**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/guidelines/transaction-by-external-message.mdx?plain=1#see-also

The link labeled “TON Connect: Sending messages” points to the “TON transfer” page; change the link text to “TON transfer” for consistency.

---

- [x] **4273. Add missing type imports in transaction lookup snippet**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/guidelines/transaction-by-external-message.mdx?plain=1#finding-a-transaction-by-incoming-message

getTransactionByInMessage uses TonClient and Transaction without imports; add import { TonClient, Transaction, Cell, loadMessage } from '@ton/ton' at the top of the snippet.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.