### PR TITLE
Split: update docs/v3/guidelines/ton-connect/overview.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/ton-connect/overview.mdx
+++ b/docs/v3/guidelines/ton-connect/overview.mdx
@@ -44,7 +44,7 @@ This separation of responsibilities enables rapid innovation and enhances securi
 - **User-friendly experience**: no extra logins required—users interact with DApps directly through their wallets.
 - **Cross-platform compatibility**: supports web, mobile, and desktop environments.
 - **Developer-friendly tools**: provides APIs and tooling for secure, consistent integration.
-- **Open-source development**: developed openly and open to community contributions.
+- **Open-source development**: maintained by the TonTech team and open to community contributions.
 
 ### For DApp developers
 
@@ -53,7 +53,7 @@ TON Connect enables tighter integration and better user engagement:
 - **Traffic**: attract more users via wallets that support TON Connect.
 - **Built-in authentication**: use wallets as user identities—no registration flows needed.
 - **Payments**: process Toncoin and USD₮ payments securely through the TON Blockchain.
-- **Retention**: some wallets may let users revisit recently opened or favorite apps (wallet UX, not a protocol feature).
+- **Retention**: let users save and revisit recently opened or favorite apps.
 
 ### For wallet developers
 

--- a/docs/v3/guidelines/ton-connect/overview.mdx
+++ b/docs/v3/guidelines/ton-connect/overview.mdx
@@ -1,13 +1,13 @@
 import Feedback from '@site/src/components/Feedback';
 import ThemedImage from '@theme/ThemedImage';
-import Button from '@site/src/components/button'
+import Button from '@site/src/components/button';
 
 # About TON Connect
 
 **TON Connect** is an open-source protocol that enables users to access TON-based apps securely, seamlessly, and without passwords by connecting their wallets.
 
 <div style={{width: '100%', textAlign:'center', margin: '10pt auto'}}>
-  <video style={{width: '100%',maxWidth: '600px', borderRadius: '10pt'}} muted={true} autoPlay={true} loop={true}>
+  <video style={{width: '100%',maxWidth: '600px', borderRadius: '10pt'}} muted={true} autoPlay={true} loop={true} playsInline>
     <source src="/files/TonConnect.mp4" type="video/mp4" />
     Your browser does not support the video tag.
   </video>
@@ -16,24 +16,24 @@ import Button from '@site/src/components/button'
 
 ## How TON Connect works
 
-TON Connect enables communication between **wallets** and **DApps** (Decentralized Applications) within the TON ecosystem.
+TON Connect enables communication between **wallets** and **decentralized applications (DApps)** within the TON ecosystem.
 
-<br></br>
+<br />
 <ThemedImage
-    alt=""
+    alt="TON Connect architecture showing wallet–DApp communication"
     sources={{
         light: '/img/docs/ton-connect/ton-connect_1.svg?raw=true',
         dark: '/img/docs/ton-connect/ton-connect_1-dark.svg?raw=true',
     }}
 />
-<br></br>
+<br />
 
 ### Interaction model
 
 * **Wallets** provide user interfaces for approving transactions and securely store cryptographic keys on users’ devices.
 * **DApps** built on TON offer rich functionality and secure user funds through the use of smart contracts.
 
-This separation of responsibilities enables rapid innovation and enhances security: _wallets are not tied to closed ecosystems, and DApps do not hold users’ accounts_.
+This separation of responsibilities enables rapid innovation and enhances security: _wallets are not tied to closed ecosystems, and DApps do not custody users’ private keys or accounts_.
 
 **TON Connect** bridges wallets and apps, providing users with a seamless and secure connection experience.
 
@@ -44,7 +44,7 @@ This separation of responsibilities enables rapid innovation and enhances securi
 - **User-friendly experience**: no extra logins required—users interact with DApps directly through their wallets.
 - **Cross-platform compatibility**: supports web, mobile, and desktop environments.
 - **Developer-friendly tools**: provides APIs and tooling for secure, consistent integration.
-- **Open-source development**: maintained by the TonTech team and open to community contributions.
+- **Open-source development**: developed openly and open to community contributions.
 
 ### For DApp developers
 
@@ -53,7 +53,7 @@ TON Connect enables tighter integration and better user engagement:
 - **Traffic**: attract more users via wallets that support TON Connect.
 - **Built-in authentication**: use wallets as user identities—no registration flows needed.
 - **Payments**: process Toncoin and USD₮ payments securely through the TON Blockchain.
-- **Retention**: let users save and revisit recently opened or favorite apps.
+- **Retention**: some wallets may let users revisit recently opened or favorite apps (wallet UX, not a protocol feature).
 
 ### For wallet developers
 
@@ -78,7 +78,7 @@ See how to [integrate TON Connect into your wallet](/v3/guidelines/ton-connect/w
   - [tonconsole.com/jetton/minter](https://tonconsole.com/jetton/minter)
   - [dedust.io](https://dedust.io/swap)
   - [vesting.ton.org](https://vesting.ton.org/)
-  - [tonverifier.live](https://verifier.ton.org/)
+  - [verifier.ton.org](https://verifier.ton.org/)
   - [tonstarter.com](https://tonstarter.com/)
   - [dns.ton.org](https://dns.ton.org/)
   - [daolama.co](https://daolama.co/)
@@ -91,7 +91,7 @@ To integrate your service with the TON ecosystem, complete the following steps:
 
 * **Implement TON Connect**: integrate the TON Connect protocol into your application.
 * **Make a transfer**: use TON libraries to create and send messages. See [Sending messages](/v3/guidelines/ton-connect/cookbook/ton-transfer) for implementation details.
-* **Enable payments**: process payments using [TonAPI](https://tonapi.io/) or a custom indexer (e.g., [gobicycle](https://github.com/gobicycle/bicycle)). See the [Payments processing guide](/v3/guidelines/DApps/asset-processing/payments-processing) for more details.
+* **Enable payments**: process payments using [TonAPI](https://tonapi.io/) or a custom indexer (e.g., [gobicycle](https://github.com/gobicycle/bicycle)). See the [Payments processing guide](/v3/guidelines/dapps/asset-processing/payments-processing) for more details.
 
 
 ### Start with a template


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-ton-connect-overview.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/ton-connect/overview.mdx`

Related issues (from issues.normalized.md):
- [x] **4274. Add missing semicolon to Button import**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/overview.mdx?plain=1#L3

The import statement for Button lacks a trailing semicolon; add it for consistency: import Button from '@site/src/components/button';.

---

- [x] **4275. Add playsInline to video for iOS autoplay**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/overview.mdx?plain=1#L10-L14

The video may not autoplay inline on iOS Safari; add playsInline to the <video> element (e.g., <video ... muted={true} autoPlay={true} loop={true} playsInline>).

---

- [x] **4276. Fix DApps acronym introduction casing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/overview.mdx?plain=1#L19

The phrase capitalizes “Decentralized Applications”; change to “decentralized applications (DApps)” to match style.

---

- [x] **4277. Use self-closing <br /> tags**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/overview.mdx?plain=1#L21-L29

Replace nonstandard <br></br> with self-closing <br /> to follow JSX/HTML semantics.

---

- [x] **4278. Add descriptive alt text to diagram image**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/overview.mdx?plain=1#L22-L28

The ThemedImage uses alt=""; set a concise alt, e.g., alt="TON Connect architecture showing wallet–DApp communication", for accessibility.

---

- [x] **4279. Clarify “DApps do not hold users’ accounts”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/overview.mdx?plain=1#L36

The statement is ambiguous; rephrase to “DApps do not custody users’ private keys or accounts.”

---

- [x] **4280. Align tonverifier link text with destination**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/overview.mdx?plain=1#L81

The link text is “tonverifier.live” but points to https://verifier.ton.org/; change the label to “verifier.ton.org” to match the URL.

---

- [x] **4281. Fix internal link casing to payments-processing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/overview.mdx?plain=1#L94

The “Payments processing guide” link uses uppercase in the path; update href to /v3/guidelines/dapps/asset-processing/payments-processing to match the actual route.

---

- [ ] **4282. Remove undefined “TonTech team” maintainer claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/overview.mdx?plain=1

The attribution “maintained by the TonTech team” is undefined in the docs; remove that clause and use a neutral phrasing: “Open‑source development: developed openly and open to community contributions.”

---

- [ ] **4283. Rephrase unsubstantiated “Retention” claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/overview.mdx?plain=1

The “Retention” bullet implies a protocol capability without reference; reword to “Retention: some wallets may let users revisit recently opened or favorite apps (wallet UX, not a protocol feature).”

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.