### PR TITLE
Split: update docs/v3/guidelines/ton-connect/verifying-signed-in-users.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/ton-connect/verifying-signed-in-users.mdx
+++ b/docs/v3/guidelines/ton-connect/verifying-signed-in-users.mdx
@@ -108,252 +108,338 @@ Note: The helper used in the example to extract a public key from `stateInit` is
 
 ## React example
 
-1. Add a token provider to the root of your app:
-
-```tsx
-import { useState } from 'react';
-
-function App() {
-    const [token, setToken] = useState<string | null>(null);
-
-  return (
-      <BackendTokenContext.Provider value={{token, setToken}}>
-            { /* Your app */ }
-      </BackendTokenContext.Provider>
-  )
-}
-```
-
-2. Implement authentication on the front end with backend integration:
+The example below is the same logic used in [`demo-dapp-with-wallet`](https://github.com/ton-connect/demo-dapp-with-wallet) `TonProofDemo` component.
 
 <details>
   <summary>Example</summary>
 
   ```tsx
-  import {useContext, useEffect, useRef} from "react";
-  import {BackendTokenContext} from "./BackendTokenContext";
-  import {useIsConnectionRestored, useTonConnectUI, useTonWallet} from "@tonconnect/ui-react";
-  import {backendAuth} from "./backend-auth";
+  import React, {useCallback, useEffect, useRef, useState} from 'react';
+  import ReactJson from 'react-json-view';
+  import './style.scss';
+  import {TonProofDemoApi} from '../../TonProofDemoApi';
+  import {useTonConnectUI, useTonWallet} from '@tonconnect/ui-react';
+  import {CHAIN} from '@tonconnect/ui-react';
+  import useInterval from '../../hooks/useInterval';
 
-  const localStorageKey = 'my-dapp-auth-token';
-  const payloadTTLMS = 1000 * 60 * 20;
+  export const TonProofDemo = () => {
+    const firstProofLoading = useRef<boolean>(true);
 
-  export function useBackendAuth() {
-      const { setToken } = useContext(BackendTokenContext);
-      const isConnectionRestored = useIsConnectionRestored();
-      const wallet = useTonWallet();
-      const [tonConnectUI] = useTonConnectUI();
-      const interval = useRef<ReturnType<typeof setInterval> | undefined>();
+    const [data, setData] = useState({});
+    const wallet = useTonWallet();
+    const [authorized, setAuthorized] = useState(false);
+    const [tonConnectUI] = useTonConnectUI();
 
-      useEffect(() => {
-          if (!isConnectionRestored || !setToken) {
-              return;
-          }
+    const recreateProofPayload = useCallback(async () => {
+      if (firstProofLoading.current) {
+        tonConnectUI.setConnectRequestParameters({ state: 'loading' });
+        firstProofLoading.current = false;
+      }
 
-          if (interval.current) {
-              clearInterval(interval.current);
-          }
+      const payload = await TonProofDemoApi.generatePayload();
 
-          if (!wallet) {
-              localStorage.removeItem(localStorageKey);
-              setToken(null);
+      if (payload) {
+        tonConnectUI.setConnectRequestParameters({ state: 'ready', value: payload });
+      } else {
+        tonConnectUI.setConnectRequestParameters(null);
+      }
+    }, [tonConnectUI, firstProofLoading])
 
-              const refreshPayload = async () => {
-                  tonConnectUI.setConnectRequestParameters({ state: 'loading' });
+    if (firstProofLoading.current) {
+      recreateProofPayload();
+    }
 
-                  const value = await backendAuth.generatePayload();
-                  if (!value) {
-                      tonConnectUI.setConnectRequestParameters(null);
-                  } else {
-                      tonConnectUI.setConnectRequestParameters({state: 'ready', value});
-                  }
-              }
+    useInterval(recreateProofPayload, TonProofDemoApi.refreshIntervalMs);
 
-              refreshPayload();
-              interval.current = setInterval(refreshPayload, payloadTTLMS);
-              return () => {
-                  if (interval.current) {
-                      clearInterval(interval.current);
-                  }
-              };
-          }
+    useEffect(() =>
+      tonConnectUI.onStatusChange(async w => {
+        if (!w || w.account.chain === CHAIN.TESTNET) {
+          TonProofDemoApi.reset();
+          setAuthorized(false);
+          return;
+        }
 
-          const token = localStorage.getItem(localStorageKey);
-          if (token) {
-              setToken(token);
-              return;
-          }
+        if (w.connectItems?.tonProof && 'proof' in w.connectItems.tonProof) {
+          await TonProofDemoApi.checkProof(w.connectItems.tonProof.proof, w.account);
+        }
 
-          if (wallet.connectItems?.tonProof && ('proof' in wallet.connectItems.tonProof)) {
-              backendAuth.checkProof(wallet.connectItems.tonProof.proof, wallet.account.address).then(result => {
-                  if (result) {
-                      setToken(result);
-                      localStorage.setItem(localStorageKey, result);
-                  } else {
-                      alert('Please try another wallet');
-                      tonConnectUI.disconnect();
-                  }
-              })
-          } else {
-              alert('Please try another wallet');
-              tonConnectUI.disconnect();
-          }
+        if (!TonProofDemoApi.accessToken) {
+          tonConnectUI.disconnect();
+          setAuthorized(false);
+          return;
+        }
 
-      }, [wallet, isConnectionRestored, setToken])
+        setAuthorized(true);
+      }), [tonConnectUI]);
+
+
+    const handleClick = useCallback(async () => {
+      if (!wallet) {
+        return;
+      }
+      const response = await TonProofDemoApi.getAccountInfo(wallet.account);
+
+      setData(response);
+    }, [wallet]);
+
+    if (!authorized) {
+      return null;
+    }
+
+    return (
+      <div className="ton-proof-demo">
+        <h3>Demo backend API with ton_proof verification</h3>
+        {authorized ? (
+          <button onClick={handleClick}>
+            Call backend getAccountInfo()
+          </button>
+        ) : (
+          <div className="ton-proof-demo__error">Connect wallet to call API</div>
+        )}
+        <ReactJson src={data} name="response" theme="ocean" />
+      </div>
+    );
   }
   ```
 </details>
 
 ## Backend example
 
-The following example is adapted from the [demo dApp with React UI](https://github.com/ton-connect/demo-dapp-with-react-ui/tree/master/src/server) and demonstrates a complete server-side verification implementation. For this code to function, your project must replicate a similar structure.
-
-You can review our example showcasing the key methods:
-- [generatePayload](https://github.com/ton-connect/demo-dapp-with-react-ui/blob/master/src/server/api/generate-payload.ts): Generates a payload for `ton_proof`.
-- [checkProof](https://github.com/ton-connect/demo-dapp-with-react-ui/blob/master/src/server/api/check-proof.ts): Checks the proof and returns `Promise<boolean>`.
+The following code is copied from the local [`demo dApp with React UI`](https://github.com/ton-connect/demo-dapp-with-react-ui/tree/master/src/server) repository, making the example identical to the demo implementation.
 
 <details>
   <summary>Full backend verification example</summary>
 
-```typescript
-import { Address, Cell, contractAddress, loadStateInit } from '@ton/core';
-import { sign } from 'tweetnacl';
-import { sha256 } from 'js-sha256';
+File: `src/server/dto/check-proof-request-dto.ts`
 
-// This DTO is simplified for demonstration.
-// `walletStateInit` and `publicKey` come from TonAddressItemReply.
-// `proof` mirrors the ton_proof fields.
-interface CheckProofRequestDto {
-  address: string;
-  walletStateInit?: string; // base64 (optional, but preferred)
-  publicKey?: string;       // hex (optional; compare if provided)
-  proof: {
-    timestamp: string;      // string; backend must parse to BigInt/number
-    domain: {
-      lengthBytes: number;
-      value: string;
-    };
-    signature: string;
-    payload: string;
-  };
-}
+```ts
+import {CHAIN} from "@tonconnect/ui-react";
+import zod from "zod";
+
+export const CheckProofRequest = zod.object({
+  address: zod.string(),
+  network: zod.enum([CHAIN.MAINNET, CHAIN.TESTNET]),
+  public_key: zod.string(),
+  proof: zod.object({
+    timestamp: zod.number(),
+    domain: zod.object({
+      lengthBytes: zod.number(),
+      value: zod.string(),
+    }),
+    payload: zod.string(),
+    signature: zod.string(),
+    state_init: zod.string(),
+  }),
+  payloadToken: zod.string(),
+});
+
+export type CheckProofRequestDto = zod.infer<typeof CheckProofRequest>;
+```
+
+File: `src/server/services/ton-proof-service.ts`
+
+```ts
+import {getSecureRandomBytes, sha256} from "@ton/crypto";
+import {Address, Cell, contractAddress, loadStateInit} from "@ton/ton";
+import {Buffer} from "buffer";
+import {sign} from "tweetnacl";
+import {CheckProofRequestDto} from "../dto/check-proof-request-dto";
+import {tryParsePublicKey} from "../wrappers/wallets-data";
 
 const tonProofPrefix = 'ton-proof-item-v2/';
 const tonConnectPrefix = 'ton-connect';
-const allowedDomains = ['YOUR_APP_DOMAIN.com']; // Replace with your app's domain
-const validAuthTime = 600; // 10 minutes
+const allowedDomains = [
+  'tonconnect-demo-dapp-with-react-ui.vercel.app',
+  'ton-connect.github.io',
+  'localhost:5173'
+];
+const validAuthTime = 15 * 60; // 15 minute
 
-// Attempts to extract the public key from a wallet's stateInit.
-function tryParsePublicKey(stateInit: Cell): Buffer | null {
+export class TonProofService {
+
+  /**
+   * Generate a random bytes.
+   */
+  public async generateRandomBytes(): Promise<Buffer> {
+    return await getSecureRandomBytes(32);
+  }
+
+  /**
+   * Reference implementation of the checkProof method:
+   * https://github.com/ton-blockchain/ton-connect/blob/main/requests-responses.md#address-proof-signature-ton_proof
+   */
+  public async checkProof(payload: CheckProofRequestDto, getWalletPublicKey: (address: string) => Promise<Buffer | null>): Promise<boolean> {
     try {
-        const stateInitData = loadStateInit(stateInit.beginParse());
-        if (stateInitData.data) {
-            const reader = stateInitData.data.beginParse();
-            reader.skip(32); // seqno
-            return reader.loadBuffer(32); // public key
-        }
-    } catch (e) {
-        console.error("Failed to parse public key from stateInit", e);
-    }
-    return null;
-}
+      const stateInit = loadStateInit(Cell.fromBase64(payload.proof.state_init).beginParse());
 
-// This function checks the proof and is based on the implementation
-// in the official demo dApp.
-export async function checkProof(payload: CheckProofRequestDto, getWalletPublicKey: (address: string) => Promise<Buffer | null>): Promise<boolean> {
-  try {
-    const stateInitCell = payload.walletStateInit ? Cell.fromBase64(payload.walletStateInit) : null;
-    const stateInit = stateInitCell ? loadStateInit(stateInitCell.beginParse()) : null;
+      // 1. First, try to obtain public key via get_public_key get-method on smart contract deployed at Address.
+      // 2. If the smart contract is not deployed yet, or the get-method is missing, you need:
+      //  2.1. Parse TonAddressItemReply.walletStateInit and get public key from stateInit. You can compare the walletStateInit.code
+      //  with the code of standard wallets contracts and parse the data according to the found wallet version.
+      let publicKey = tryParsePublicKey(stateInit) ?? await getWalletPublicKey(payload.address);
+      if (!publicKey) {
+        return false;
+      }
 
-    // Obtain the public key from stateInit or via a get method call.
-    let publicKey = (stateInitCell ? tryParsePublicKey(stateInitCell) : null) ?? await getWalletPublicKey(payload.address);
-    if (!publicKey) {
-      return false;
-    }
-
-    // Verify that the public key matches the one from the payload.
-    if (payload.publicKey) {
-      const wantedPublicKey = Buffer.from(payload.publicKey, 'hex');
+      // 2.2. Check that TonAddressItemReply.publicKey equals to obtained public key
+      const wantedPublicKey = Buffer.from(payload.public_key, 'hex');
       if (!publicKey.equals(wantedPublicKey)) {
         return false;
       }
-    }
 
-    // Verify that the wallet address matches the one derived from stateInit.
-    const wantedAddress = Address.parse(payload.address);
-    if (stateInit) {
-      const derived = contractAddress(wantedAddress.workChain, stateInit);
-      if (!derived.equals(wantedAddress)) {
+      // 2.3. Check that TonAddressItemReply.walletStateInit.hash() equals to TonAddressItemReply.address. .hash() means BoC hash.
+      const wantedAddress = Address.parse(payload.address);
+      const address = contractAddress(wantedAddress.workChain, stateInit);
+      if (!address.equals(wantedAddress)) {
         return false;
       }
-    }
 
-    // Verify that the request originates from an allowed domain.
-    if (!allowedDomains.includes(payload.proof.domain.value)) {
+      if (!allowedDomains.includes(payload.proof.domain.value)) {
+        return false;
+      }
+
+      const now = Math.floor(Date.now() / 1000);
+      if (now - validAuthTime > payload.proof.timestamp) {
+        return false;
+      }
+
+      const message = {
+        workchain: address.workChain,
+        address: address.hash,
+        domain: {
+          lengthBytes: payload.proof.domain.lengthBytes,
+          value: payload.proof.domain.value,
+        },
+        signature: Buffer.from(payload.proof.signature, 'base64'),
+        payload: payload.proof.payload,
+        stateInit: payload.proof.state_init,
+        timestamp: payload.proof.timestamp
+      };
+
+      const wc = Buffer.alloc(4);
+      wc.writeUInt32BE(message.workchain, 0);
+
+      const ts = Buffer.alloc(8);
+      ts.writeBigUInt64LE(BigInt(message.timestamp), 0);
+
+      const dl = Buffer.alloc(4);
+      dl.writeUInt32LE(message.domain.lengthBytes, 0);
+
+      // message = utf8_encode("ton-proof-item-v2/") ++
+      //           Address ++
+      //           AppDomain ++
+      //           Timestamp ++
+      //           Payload
+      const msg = Buffer.concat([
+        Buffer.from(tonProofPrefix),
+        wc,
+        message.address,
+        dl,
+        Buffer.from(message.domain.value),
+        ts,
+        Buffer.from(message.payload),
+      ]);
+
+      const msgHash = Buffer.from(await sha256(msg));
+
+      // signature = Ed25519Sign(privkey, sha256(0xffff ++ utf8_encode("ton-connect") ++ sha256(message)))
+      const fullMsg = Buffer.concat([
+        Buffer.from([0xff, 0xff]),
+        Buffer.from(tonConnectPrefix),
+        msgHash,
+      ]);
+
+      const result = Buffer.from(await sha256(fullMsg));
+
+      return sign.detached.verify(result, message.signature, publicKey);
+    } catch (e) {
       return false;
     }
-
-    // Verify that the proof's timestamp is recent.
-    const now = Math.floor(Date.now() / 1000);
-    const tsNumber = Number(payload.proof.timestamp);
-    if (!Number.isFinite(tsNumber)) {
-      return false;
-    }
-    if (now - validAuthTime > tsNumber) {
-      return false;
-    }
-
-    const message = {
-      workchain: wantedAddress.workChain,
-      address: wantedAddress.hash,
-      domain: {
-        lengthBytes: payload.proof.domain.lengthBytes,
-        value: payload.proof.domain.value,
-      },
-      signature: Buffer.from(payload.proof.signature, 'base64'),
-      payload: payload.proof.payload,
-      stateInit: payload.walletStateInit,
-      timestamp: payload.proof.timestamp
-    };
-
-    // Reconstruct the message that was signed.
-    const wc = Buffer.alloc(4);
-    wc.writeUInt32BE(message.workchain, 0);
-
-    const ts = Buffer.alloc(8);
-    ts.writeBigUInt64LE(BigInt(message.timestamp), 0);
-
-    const dl = Buffer.alloc(4);
-    dl.writeUInt32LE(message.domain.lengthBytes, 0);
-
-    const msg = Buffer.concat([
-      Buffer.from(tonProofPrefix),
-      wc,
-      message.address,
-      dl,
-      Buffer.from(message.domain.value),
-      ts,
-      Buffer.from(message.payload),
-    ]);
-
-    // Hash the message and verify the signature.
-    const msgHash = Buffer.from(sha256.create().update(msg).digest());
-
-    const fullMsg = Buffer.concat([
-      Buffer.from([0xff, 0xff]),
-      Buffer.from(tonConnectPrefix),
-      msgHash,
-    ]);
-
-    const result = Buffer.from(sha256.create().update(fullMsg).digest());
-
-    return sign.detached.verify(result, message.signature, publicKey);
-  } catch (e) {
-    console.error(e);
-    return false;
   }
+
 }
 ```
+
+File: `src/server/api/check-proof.ts`
+
+```ts
+import {sha256} from "@ton/crypto";
+import {HttpResponseResolver} from "msw";
+import {CheckProofRequest} from "../dto/check-proof-request-dto";
+import {TonApiService} from "../services/ton-api-service";
+import {TonProofService} from "../services/ton-proof-service";
+import {badRequest, ok} from "../utils/http-utils";
+import {createAuthToken, verifyToken} from "../utils/jwt";
+
+/**
+ * Checks the proof and returns an access token.
+ *
+ * POST /api/check_proof
+ */
+export const checkProof: HttpResponseResolver = async ({request}) => {
+  try {
+    const body = CheckProofRequest.parse(await request.json());
+
+    const client = TonApiService.create(body.network);
+    const service = new TonProofService();
+
+    const isValid = await service.checkProof(body, (address) => client.getWalletPublicKey(address));
+    if (!isValid) {
+      return badRequest({error: 'Invalid proof'});
+    }
+
+    const payloadTokenHash = body.proof.payload;
+    const payloadToken = body.payloadToken;
+    if (!await verifyToken(payloadToken)) {
+      return badRequest({error: 'Invalid token'});
+    }
+    if ((await sha256(payloadToken)).toString('hex') !== payloadTokenHash) {
+      return badRequest({error: 'Invalid payload token hash'})
+    }
+
+    const token = await createAuthToken({address: body.address, network: body.network});
+
+    return ok({token: token});
+  } catch (e) {
+    return badRequest({error: 'Invalid request', trace: e});
+  }
+};
+```
+
+File: `src/server/api/generate-payload.ts`
+
+```ts
+import {sha256} from "@ton/crypto";
+import {HttpResponseResolver} from "msw";
+import {TonProofService} from "../services/ton-proof-service";
+import {badRequest, ok} from "../utils/http-utils";
+import {createPayloadToken} from "../utils/jwt";
+
+/**
+ * Generates a payload for ton proof.
+ *
+ * POST /api/generate_payload
+ */
+export const generatePayload: HttpResponseResolver = async () => {
+  try {
+    const service = new TonProofService();
+
+    const randomBytes = await service.generateRandomBytes();
+    const payloadToken = await createPayloadToken({
+      randomBytes: randomBytes.toString('hex')
+    });
+    const payloadTokenHash = (await sha256(payloadToken)).toString('hex');
+
+    return ok({
+      payloadToken: payloadToken,
+      payloadTokenHash: payloadTokenHash,
+    });
+  } catch (e) {
+    return badRequest({error: 'Invalid request', trace: e});
+  }
+};
+```
+
 </details>
 
 ## Conclusion


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-ton-connect-verifying-signed-in-users.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/ton-connect/verifying-signed-in-users.mdx`

Related issues (from issues.normalized.md):
- [x] **4294. Fix capitalization in type comments**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/verifying-signed-in-users.mdx?plain=1

Change "64-bit unix epoch time" to "64-bit Unix epoch time" and "as url part" to "as URL part" in the TonProofItemReplySuccess comments.

---

- [x] **4295. Correct signature description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/verifying-signed-in-users.mdx?plain=1

Replace "The final signature is a hash of the assembled message..." with "The signature is an Ed25519 signature over sha256(0xffff ++ utf8_encode('ton-connect') ++ sha256(message))."

---

- [ ] **4296. Rephrase verification steps (not “in reverse”)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/verifying-signed-in-users.mdx?plain=1

Replace "perform these steps in reverse" with instructions to recompute sha256(message), prepend the fixed prefixes, hash again, and verify the Ed25519 signature using the user’s public key.

---

- [x] **4297. Specify endianness and widths in message assembly**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/verifying-signed-in-users.mdx?plain=1

Document that timestamp is a 64‑bit little‑endian integer (seconds) and domain.lengthBytes is a 32‑bit little‑endian integer (bytes) to match the example implementation.

---

- [ ] **4298. Align DTO structure and field naming with TonConnect**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/verifying-signed-in-users.mdx?plain=1

Use camelCase names (e.g., publicKey), keep walletStateInit (from TonAddressItemReply) alongside address instead of inside proof, and limit proof to the ton_proof fields; clarify the source of walletStateInit if shown in the DTO.

---

- [ ] **4299. Standardize timestamp type (string) across examples**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/verifying-signed-in-users.mdx?plain=1

Show timestamp as a string in TonProofItemReplySuccess and DTOs, and note that the backend must parse it (e.g., to BigInt/number) for verification.

---

- [ ] **4300. Fix React example interval handling**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/verifying-signed-in-users.mdx?plain=1

Store the timer handle and clean up: interval.current = setInterval(refreshPayload, payloadTTLMS); and return () => clearInterval(interval.current) from useEffect.

---

- [x] **4301. Label the message-assembly pseudocode block**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/verifying-signed-in-users.mdx?plain=1

Add a language hint like ```text to the pseudocode block to avoid misleading syntax highlighting.

---

- [x] **4302. Use “get method” terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/verifying-signed-in-users.mdx?plain=1

Change occurrences of "get-method" to "get method" for consistency with TON terminology.

---

- [x] **4303. Clarify address integrity check**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/verifying-signed-in-users.mdx?plain=1

Replace the hash‑matching phrasing with: derive the address as contractAddress(workchain, walletStateInit) and ensure it equals the user’s address.

---

- [ ] **4304. Fix React ton_proof presence check**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/verifying-signed-in-users.mdx?plain=1

Replace wallet.connectItems?.tonProof && !('error' in wallet.connectItems.tonProof) with wallet.connectItems?.tonProof && ('proof' in wallet.connectItems.tonProof).

---

- [ ] **4305. Pass address string to backend check**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/verifying-signed-in-users.mdx?plain=1

Change backendAuth.checkProof(wallet.connectItems.tonProof.proof, wallet.account) to backendAuth.checkProof(wallet.connectItems.tonProof.proof, wallet.account.address).

---

- [ ] **4306. Reconcile backend return type description**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/verifying-signed-in-users.mdx?plain=1

Update the bullet describing checkProof to match the sample (returns Promise<boolean>) or clarify that the demo returns a boolean while production returns an access token.

---

- [x] **4307. Add missing React useState import**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/verifying-signed-in-users.mdx?plain=1

Add import { useState } from 'react'; at the top of the App snippet so it runs standalone.

---

- [ ] **4308. Add caveat to public key extraction helper**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/verifying-signed-in-users.mdx?plain=1

Note that tryParsePublicKey is simplified and must be replaced with version‑aware parsing after determining the wallet type (e.g., via code hash) as described in the primary method.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.