### PR TITLE
Split: update docs/v3/guidelines/ton-connect/wallet.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/ton-connect/wallet.mdx
+++ b/docs/v3/guidelines/ton-connect/wallet.mdx
@@ -1,18 +1,15 @@
 import Feedback from '@site/src/components/Feedback';
 
-import Button from '@site/src/components/button'
-
 # Connect a wallet
 
-If you're a wallet developer, you can connect your wallet to TON Connect, allowing your users to interact with TON apps securely and conveniently.
+If you're a wallet developer, you can connect your wallet to TON Connect, allowing your users to interact with TON DApps securely and conveniently.
 
 ## Integration
 
 Follow these steps to connect your wallet to TON Connect:
 
-1. Carefully read the [Protocol specifications](/v3/guidelines/ton-connect/overview/).
-2. Implement the protocol using one of the [SDKs](/v3/guidelines/ton-connect/guidelines/developers).
+1. Carefully read the [TON Connect specification](https://github.com/ton-blockchain/ton-connect/blob/main/requests-responses.md).
+2. Implement the protocol using one of the [protocol models](/v3/guidelines/ton-connect/guidelines/developers#ton-connect-protocol-models).
 3. Add your wallet to the [wallets-list](https://github.com/ton-blockchain/wallets-list) with a pull request.
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-ton-connect-wallet.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/ton-connect/wallet.mdx`

Related issues (from issues.normalized.md):
- [ ] **4309. Remove unused Button import**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/wallet.mdx?plain=1#L3

Button is imported but never used; remove the line `import Button from '@site/src/components/button'`.

---

- [ ] **4310. Use “TON DApps” instead of “TON apps”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/wallet.mdx?plain=1#L7

The text says “TON apps” contrary to site terminology; replace it with “TON DApps”.

---

- [ ] **4311. Link to TON Connect specification (not Overview)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/wallet.mdx?plain=1#L13

The “Protocol specifications” link points to the Overview; change the link text to “TON Connect specification” and target https://github.com/ton-blockchain/ton-connect/blob/main/requests-responses.md.

---

- [ ] **4312. Point SDK link to Protocol Models section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/ton-connect/wallet.mdx?plain=1#L14

The SDK link is too general; update it to /v3/guidelines/ton-connect/guidelines/developers#ton-connect-protocol-models and set the anchor text to “protocol models”.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.