### PR TITLE
Split: update docs/v3/guidelines/web3/overview.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/web3/overview.mdx
+++ b/docs/v3/guidelines/web3/overview.mdx
@@ -6,16 +6,16 @@ import Feedback from '@site/src/components/Feedback';
 
 Learn more about the core ideas:
 
-- [Payments on TON](https://blog.ton.org/ton-payments)
+- [TON Payments](/v3/documentation/dapps/defi/ton-payments)
 - [TON DNS & domains](/v3/guidelines/web3/ton-dns/dns)
-- [TON Sites, TON WWW and TON Proxy](https://blog.ton.org/ton-sites)
+- [TON Sites and TON Proxy](https://blog.ton.org/ton-sites)
 
 ## Use cases
 
-- [\*.ton user-friendly domains for any smart contract](/v3/guidelines/web3/ton-dns/dns)
-- [Connect to the TON Sites using the TON Proxy](/v3/guidelines/web3/ton-proxy-sites/connect-with-ton-proxy)
-- [Run your own TON Proxy to connect to TON Sites](/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy)
-- [Link your TON Wallet or TON Site to a domain](/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management)
-- [How to make a subdomain using TON DNS smart contracts](/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management#how-to-set-up-subdomains)
+- [Use .ton domains for any smart contract](/v3/guidelines/web3/ton-dns/dns)
+- [Connect with TON Proxy](/v3/guidelines/web3/ton-proxy-sites/connect-with-ton-proxy)
+- [Running your TON Proxy](/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy)
+- [Site & domain management](/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management)
+- [How to set up subdomains](/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management#how-to-set-up-subdomains)
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-web3-overview.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/web3/overview.mdx`

Related issues (from issues.normalized.md):
- [ ] **4561. Use internal canonical page for TON Payments**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/overview.mdx?plain=1

In “Key concepts”, replace the external “[Payments on TON](https://blog.ton.org/ton-payments)” link with the internal “[TON Payments](/v3/documentation/dapps/defi/ton-payments)” to use the canonical docs page.

---

- [ ] **4562. Remove undefined “TON WWW” from link text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/overview.mdx?plain=1

In “Key concepts”, change the link text “TON Sites, TON WWW and TON Proxy” to “TON Sites and TON Proxy” while keeping the URL https://blog.ton.org/ton-sites to avoid using the undefined term “TON WWW”.

---

- [ ] **4563. Match link text to page title: Connect with TON Proxy**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/overview.mdx?plain=1

In “Use cases”, change the link text to “[Connect with TON Proxy](/v3/guidelines/web3/ton-proxy-sites/connect-with-ton-proxy)” to match the target page title.

---

- [ ] **4564. Match link text to page title: Running your TON Proxy**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/overview.mdx?plain=1

In “Use cases”, change the link text to “[Running your TON Proxy](/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy)” to match the target page title.

---

- [ ] **4565. Match link text to section heading: How to set up subdomains**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/overview.mdx?plain=1

Change the bullet text to “[How to set up subdomains](/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management#how-to-set-up-subdomains)” to match the destination section heading.

---

- [ ] **4566. Make first “Use cases” item imperative and fix *.ton escaping**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/overview.mdx?plain=1

Rewrite the first item to the imperative “Use .ton domains for any smart contract” (keep target /v3/guidelines/web3/ton-dns/dns), which also removes the over-escaped “\\\\*.ton”.

---

- [ ] **4567. Match link text to page title: Site & domain management**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/overview.mdx?plain=1

In “Use cases”, change the link text to “[Site & domain management](/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management)” to match the target page title.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.