### PR TITLE
Split: update docs/v3/guidelines/web3/ton-dns/dns.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/web3/ton-dns/dns.mdx
+++ b/docs/v3/guidelines/web3/ton-dns/dns.mdx
@@ -20,7 +20,7 @@ const address: Address = await tonweb.dns.getWalletAddress('test.ton');
 const address: Address = await tonweb.dns.resolve('test.ton', TonWeb.dns.DNS_CATEGORY_WALLET);
 ```
 
-Also, `lite-client` and `tonlib-cli` are supported by DNS queries..
+Also, `lite-client` and `tonlib-cli` are supported by DNS queries.
 
 ## First-level domain
 
@@ -39,8 +39,6 @@ The source code for `.ton` domains is available [here](https://github.com/ton-bl
 The `.ton` domain resolver acts as an NFT collection, while each individual `.ton` domain functions as an NFT item.
 
 Primary sales of `.ton` domains occur through a decentralized open auction at [dns.ton.org](https://dns.ton.org). The auction's source code can be found [here](https://github.com/ton-blockchain/dns).
-
-
 
 ## Subdomains
 Domain owners can create subdomains by setting the smart contract address responsible for subdomain resolution in the DNS record using the key `sha256("dns_next_resolver")`.


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-web3-ton-dns-dns.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/web3/ton-dns/dns.mdx`

Related issues (from issues.normalized.md):
- [x] **4323. Use TypeScript fence for typed snippet**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/dns.mdx?plain=1#L15-L21

The snippet contains TypeScript annotations but is fenced as js; change the code fence language to ts for correct syntax highlighting.

---

- [ ] **4324. Fix tooling support sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/dns.mdx?plain=1#L23

The sentence reverses subject and object; rewrite it to: "Also, lite-client and tonlib-cli support DNS queries."

---

- [ ] **4325. Rename header to Top-level domains (TLD)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/dns.mdx?plain=1#L25-L31

The H2 uses "First-level domain" while the text uses "top-level"; rename the header to "Top-level domains" (TLD) for consistency.

---

- [x] **4326. Rename *.ton domains heading**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/dns.mdx?plain=1#L34

The heading uses a wildcard asterisk that can misparse; rename it to ".ton domains" to avoid ambiguity.

---

- [ ] **4327. Remove unnecessary escapes in inline code**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/dns.mdx?plain=1#L47

Inline code unnecessarily escapes quotes; change sha256(\"dns_next_resolver\") to sha256("dns_next_resolver").

---

- [x] **4328. Update link to TON DNS standard to TEP-81**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/dns.mdx?plain=1#standard

The page links to a TIPs issue; replace it with https://github.com/ton-blockchain/TEPs/blob/master/text/0081-dns-standard.md.

---

- [ ] **4329. Clarify TonWeb initialization context**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/dns.mdx?plain=1#sdk

The example assumes an initialized TonWeb instance; add a brief note or one-line initialization indicating that a TonWeb instance (e.g., tonweb) is created before use.

---

- [ ] **4330. Broaden supported domains to .ton and .t.me**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/dns.mdx?plain=1#first-level-domain

The text claims only .ton domains are recognized; update it to state that TON DNS currently supports .ton and .t.me domains.

---

- [ ] **4331. Add internal link for configuration parameter 4**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/dns.mdx?plain=1#first-level-domain

The mention of network config #4 links externally; add an internal cross‑reference to docs/v3/documentation/network/configs/blockchain-configs.mdx#param-4 (optionally keep the external link).

---

- [ ] **4332. Clarify .ton contract as DNS collection, not resolver**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/dns.mdx?plain=1#-ton-domains

“The .ton domain resolver acts as an NFT collection” is ambiguous; replace with “The .ton DNS collection contract acts as an NFT collection, while each .ton domain is an NFT item.”

---

- [ ] **4333. Replace 'community vote' with 'validator vote'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/dns.mdx?plain=1#first-level-domain

The governance phrasing is inaccurate; change it to “a validator vote to update configuration parameter 4.”

---

- [ ] **4334. Remove speculative phrasing about future changes**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/dns.mdx?plain=1#first-level-domain

Replace “This may change in the future.” with the neutral conditional “If new top‑level domains are added, it would require deploying a new root DNS smart contract and a validator vote to update configuration parameter 4.”

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.