### PR TITLE
Split: update docs/v3/guidelines/web3/ton-dns/subresolvers.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/web3/ton-dns/subresolvers.mdx
+++ b/docs/v3/guidelines/web3/ton-dns/subresolvers.mdx
@@ -8,8 +8,8 @@ TON DNS is a powerful tool for assigning TON Sites or Storage bags to domains an
 
 ## Relevant links
 
-1. [TON smart contract address system](/v3/documentation/smart-contracts/addresses)
-1. [TEP-0081 - TON DNS standard](https://github.com/ton-blockchain/TEPs/blob/master/text/0081-dns-standard.md)
+1. [Smart contract addresses](/v3/documentation/smart-contracts/addresses/address)
+1. [TON DNS standard](https://github.com/ton-blockchain/TIPs/issues/81)
 1. [Source code of .ton DNS collection](https://tonscan.org/address/EQC3dNlesgVD8YbAazcauIrXBPfiVhMMr5YYk2in0Mtsz0Bz#source)
 1. [Source code of .t.me DNS collection](https://tonscan.org/address/EQCA14o1-VWhS2efqoh_9M1b_A9DtKTuoqfmkn83AbJzwnPi#source)
 1. [Domain contracts searcher](https://tonscan.org/address/EQDkAbAZNb4uk-6pzTPDO2s0tXZweN-2R08T2Wy6Z3qzH_Zp#source)
@@ -35,7 +35,7 @@ Some repetitive parts are omitted.
   int subdomain_bits = slice_bits(subdomain);
   throw_unless(70, (subdomain_bits % 8) == 0);
   
-  int starts_with_zero_byte = subdomain.preload_int(8) == 0;  ;; Assuming that 'subdomain' is not empty.
+  int starts_with_zero_byte = subdomain.preload_int(8) == 0;  ;; assuming that 'subdomain' is not empty
   if (starts_with_zero_byte) {
     subdomain~load_uint(8);
     if (subdomain.slice_bits() == 0) {   ;; Current contract has no DNS records by itself.
@@ -126,13 +126,13 @@ How `dnsresolve()` works:
 
 
 1. It takes the subdomain and category as inputs. 
-2. It is skipped if the subdomain begins with zero byte. 
+2. If the subdomain begins with a zero byte, the function skips that leading byte. 
 3. It checks if the subdomain starts with `"ton\0"`. If it does:
    - The first 32 bits are skipped (`subdomain = "resolve-contract\0"`).  
    - A suffix variable `subdomain_sfx` is set to the `subdomain`. It reads bytes until the zero byte.
-   - At this point: `subdomain = "resolve-contract\0", subdomain_sfx = "")`.
+   - At this point: `subdomain = "resolve-contract\0", subdomain_sfx = ""`.
    - The zero byte and suffix are trimmed, resulting in `subdomain = "resolve-contract"`.
-   - The domain name is converted into a contract address using helper functions `slice_hash` and `get_ton_dns_nft_address_by_index`. See [Appendix 1](subresolvers#appendix-1-code-of-resolve-contractton) for implementation details.
+   - The domain name is converted into a contract address using helper functions `slice_hash` and `get_ton_dns_nft_address_by_index`. See [Appendix 1](#appendix-1-code-of-resolve-contractton) for implementation details.
 4. If the subdomain starts with `"address\0"`:
    - The prefix is skipped, and the rest is interpreted as a base64-encoded address.
 5. If the subdomain doesn't match any known prefix:
@@ -154,17 +154,17 @@ The `dnsresolve()` function can:
 - Return a "domain not found" result if the subdomain is unknown.
 
 :::warning
-Base64 address parsing is currently not functional. Suppose you attempt to resolve a domain like `<some-address>.address.resolve-contract.ton`, you will receive an error indicating that the domain is misconfigured or does not exist. This issue arises because domain names are case-insensitive—a behavior inherited from traditional DNS, which results in the lowercase. Consequently, the resolver may attempt to query a non-existent or invalid WorkChain address.
+Base64 address parsing is currently not functional. If you attempt to resolve a domain like `<some-address>.address.resolve-contract.ton`, you will receive an error indicating that the domain is misconfigured or does not exist. This limitation results in lowercase domain labels, which may cause the resolver to query a non-existent or invalid WorkChain address.
 :::
 
 ### Binding the resolver
 
-Now that the subresolver contract is deployed, the next step is to point the domain to it by updating domain `dns_next_resolver` record. This is done by sending a message with the following TL-B structure to the domain contract:
-```
-`change_dns_record#4eb1f0f9 query_id:uint64 record_key#19f02441ee588fdb26ee24b2568dd035c3c9206e11ab979be62e55558a1d17ff record:^[dns_next_resolver#ba93 resolver:MsgAddressInt]`
+Now that the subresolver contract is deployed, the next step is to point the domain to it by updating the domain’s `dns_next_resolver` record. This is done by sending a message with the following TL-B structure to the domain contract:
+```text
+change_dns_record#4eb1f0f9 query_id:uint64 record_key#19f02441ee588fdb26ee24b2568dd035c3c9206e11ab979be62e55558a1d17ff record:^[dns_next_resolver#ba93 resolver:MsgAddressInt]
 ```
 
-## Creating own subdomains manager
+## Creating your own subdomain manager
 Subdomains can be helpful for everyday users. For example, they can associate multiple projects with a single domain or link to friends' wallet addresses.
 
 ### Contract data
@@ -184,7 +184,7 @@ global cell domains;
 }
 ```
 
-### Processing records update
+### Processing record updates
 
 ```func
 const int op::update_record = 0x537a3491;
@@ -238,7 +238,7 @@ Finally, we update the record associated with the specified domain and write the
 (slice, slice) ~parse_sd(slice subdomain) {
   ;; "test\0qwerty\0" -> "test" "qwerty\0"
   slice subdomain_sfx = subdomain;
-  while (subdomain_sfx~load_uint(8)) { }  ;; Searching zero byte.
+  while (subdomain_sfx~load_uint(8)) { }  ;; Searching for a zero byte.
   subdomain~skip_last_bits(slice_bits(subdomain_sfx));
   return (subdomain, subdomain_sfx);
 }
@@ -248,11 +248,11 @@ Finally, we update the record associated with the specified domain and write the
   throw_unless(70, subdomain_bits % 8 == 0);
   if (subdomain.preload_uint(8) == 0) { subdomain~skip_bits(8); }
   
-  slice subdomain_suffix = subdomain~parse_sd();  ;; "test\0" -> "test" ""
+  (slice top, slice subdomain_suffix) = subdomain~parse_sd();  ;; "test\0" -> "test" ""
   int subdomain_suffix_bits = slice_bits(subdomain_suffix);
 
   load_data();
-  (cell records, _) = domains.udict_get_ref?(256, string_hash(subdomain));
+  (cell records, _) = domains.udict_get_ref?(256, string_hash(top));
 
   if (subdomain_suffix_bits > 0) { ;; More than "<SUBDOMAIN>\0" requested.
     category = "dns_next_resolver"H;
@@ -275,12 +275,13 @@ If a non-empty subdomain suffix remains, the function returns the number of byte
 
 While this function could be improved to handle errors more gracefully, such enhancements are not strictly required.
 
+<a id="appendix-1-code-of-resolve-contractton" />
 ## Appendix 1: code of resolve-contract.ton
 
 <details>
 <summary>subresolver.fc</summary>
 
-```func showLineNumbers
+```func
 (builder, ()) ~store_slice(builder to, slice s) asm "STSLICER";
 int starts_with(slice a, slice b) asm "SDPFXREV";
 
@@ -389,7 +390,7 @@ slice decode_base64_address(slice readable) method_id {
     
     domain_nft_address = get_ton_dns_nft_address_by_index(slice_hash(subdomain));
   } elseif (subdomain.starts_with("6D65007400"s)) {
-    ;; "t" \\0 "me" \\0 <subdomain> \\0 [subdomain_sfx]
+    ;; "me" \\0 "t" \\0 <subdomain> \\0 [subdomain_sfx]
     subdomain~skip_bits(40);
     
     ;; reading domain name
@@ -459,4 +460,3 @@ slice decode_base64_address(slice readable) method_id {
 </details>
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-web3-ton-dns-subresolvers.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/web3/ton-dns/subresolvers.mdx`

Related issues (from issues.normalized.md):
- [ ] **4335. Fix addresses link target and text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/subresolvers.mdx?plain=1#L11

Update the “TON smart contract address system” link to point directly to /v3/documentation/smart-contracts/addresses/address and change the link text to “Smart contract addresses” to match the destination heading.

---

- [ ] **4336. Align capitalization in identical comments**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/subresolvers.mdx?plain=1#L38 and #L365

Make both identical comments use the same sentence case: `;; assuming that 'subdomain' is not empty`.

---

- [ ] **4337. Clarify leading zero byte sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/subresolvers.mdx?plain=1#L129

Replace “It is skipped if the subdomain begins with zero byte.” with “If the subdomain begins with a zero byte, the function skips that leading byte.”

---

- [ ] **4338. Remove stray parenthesis in example state**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/subresolvers.mdx?plain=1#L133

Fix the example to `subdomain_sfx = ""` (remove the extra `)`).

---

- [ ] **4339. Use self-anchor for Appendix link**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/subresolvers.mdx?plain=1#L135

Change the link `subresolvers#appendix-1-code-of-resolve-contractton` to a same-page anchor `#appendix-1-code-of-resolve-contractton` or add an explicit heading ID `{#appendix-1-code-of-resolve-contractton}`.

---

- [ ] **4340. Rephrase warning and fix lowercase wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/subresolvers.mdx?plain=1#L157

Reword the note to state the limitation without attributing it to case-insensitivity, change “results in the lowercase” to “results in lowercase,” and ensure “WorkChain” is capitalized if mentioned.

---

- [ ] **4341. Use possessive in dns_next_resolver sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/subresolvers.mdx?plain=1#L162

Change to “by updating the domain’s `dns_next_resolver` record.”

---

- [ ] **4342. Fix TL‑B code block formatting**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/subresolvers.mdx?plain=1#L162-L165

Remove the inner backticks and use a single fenced block with a language hint (e.g., text) containing the TL‑B line.

---

- [ ] **4343. Retitle “Creating own” section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/subresolvers.mdx?plain=1#L167

Change the heading to “Creating your own subdomain manager.”

---

- [ ] **4344. Retitle “Processing records update” section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/subresolvers.mdx?plain=1#L187

Change the heading to “Processing record updates.”

---

- [ ] **4345. Fix comment: “Searching for a zero byte”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/subresolvers.mdx?plain=1#L241

Change `;; Searching zero byte.` to `;; Searching for a zero byte.`

---

- [ ] **4346. Use TIP‑81 link for TON DNS standard**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/subresolvers.mdx?plain=1

Update the standard reference to use the TIPs link and naming: link text “TON DNS standard” pointing to https://github.com/ton-blockchain/TIPs/issues/81.

---

- [ ] **4347. Remove unsupported code fence tokens**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/subresolvers.mdx?plain=1

Change code fences like ```func showLineNumbers to ```func; configure line numbers via site settings if needed.

---

- [ ] **4348. Correct FunC multi-return assignment**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/subresolvers.mdx?plain=1

In “Resolving domains,” destructure `parse_sd`’s two returns and use the top label for lookup, e.g., `(slice top, slice subdomain_suffix) = subdomain~parse_sd(); (cell records, _) = domains.udict_get_ref?(256, string_hash(top));`.

---

- [ ] **4349. Align t.me branch comment with pattern**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/subresolvers.mdx?plain=1

Update the inline comment to reflect the checked pattern `"me"\0"t"\0<subdomain>\0[...]`, matching the `starts_with("6D65007400"s)` logic.

---

- [ ] **4350. Standardize leading zero byte representation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-dns/subresolvers.mdx?plain=1

Use one consistent subdomain string representation across the walkthrough (either include the leading zero byte or not) and note that a leading zero, if present, is skipped by the resolver.

---

- [ ] **4411. Link to DNS subresolvers reference**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management.mdx?plain=1#L40-L46

Append: “See TON DNS resolvers for details.” linking to docs/v3/guidelines/web3/ton-dns/subresolvers.mdx.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.