### PR TITLE
Split: update docs/v3/guidelines/web3/ton-proxy-sites/connect-with-ton-proxy.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/web3/ton-proxy-sites/connect-with-ton-proxy.mdx
+++ b/docs/v3/guidelines/web3/ton-proxy-sites/connect-with-ton-proxy.mdx
@@ -27,25 +27,25 @@ Google Chrome does not have its own proxy settings. Configure the proxy at the *
 3. Enter the public entry proxy in **Address** and `8080` in **Port**.  
 4. Click **Save**.
 
-### macOS
-1. Go to **Settings → Network → Advanced → Web proxy (HTTP)**.  
-2. In **Web proxy server**, enter the public entry proxy, followed by `:8080`.  
-3. Click **OK**.
-
 ### Ubuntu (Linux)
 1. Open **Settings → Network**.  
 2. Click **Network Proxy → Manual**.  
 3. Enter the public entry proxy in **HTTP Proxy** and `8080` in **Port**.
 
-### iOS
-1. Go to **Settings → Wi-Fi** and tap your current network.  
-2. Under **HTTP Proxy**, choose **Manual**.  
-3. Enter the public entry proxy in **Server** and `8080` in **Port**.  
-4. Tap **Save**.
-
 ### Android
 1. Go to **Settings → Wi-Fi** and long-press your network.  
 2. Select **Modify network → Advanced options → Manual**.  
+3. Enter the public entry proxy in **Server** and `8080` in **Port**.  
+4. Tap **Save**.
+
+### macOS
+1. Go to **Settings → Network → Advanced → Web proxy (HTTP)**.  
+2. In **Web proxy server**, enter the public entry proxy, followed by `:8080`.  
+3. Click **OK**.
+
+### iOS
+1. Go to **Settings → Wi-Fi** and tap your current network.  
+2. Under **HTTP Proxy**, choose **Manual**.  
 3. Enter the public entry proxy in **Server** and `8080` in **Port**.  
 4. Tap **Save**.
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-web3-ton-proxy-sites-connect-with-ton-proxy.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/web3/ton-proxy-sites/connect-with-ton-proxy.mdx`

Related issues (from issues.normalized.md):
- [x] **4351. Use correct Firefox labels: 'Settings...' and 'Manual proxy configuration'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/connect-with-ton-proxy.mdx?plain=1#L13-L17

In the Firefox section, use the correct labels—Settings → General → Network Settings → Settings... and Manual proxy configuration—and remove the unnecessary article before the option name.

---

- [x] **4352. Standardize UI styling; remove quotes**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/connect-with-ton-proxy.mdx?plain=1#L13-L61

UI labels and fields are inconsistently quoted and styled; consistently use bold for UI elements (e.g., Settings, Manual proxy configuration, HTTP Proxy, Server, Port, OK), remove quotation marks and “without quotes,” and use plain numerals like 8080.

---

- [x] **4353. Restrict Safari guidance to macOS/iOS**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/connect-with-ton-proxy.mdx?plain=1#L20-L23

Safari is only on Apple platforms; change the text to direct users to macOS or iOS instructions below with in‑page links to #macos and #ios.

---

- [x] **4354. Add Android 'Proxy' step before 'Manual'**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/connect-with-ton-proxy.mdx?plain=1#L35-L40

Explicitly include the Proxy selection so the flow reads Modify Network → Advanced options → Proxy → Manual.

---

- [x] **4355. Separate Windows address and port fields**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/connect-with-ton-proxy.mdx?plain=1#L44-L48

Clarify that the entry proxy address goes in Address and the value 8080 goes in Port (do not enter the address in the Port field).

---

- [x] **4356. Correct macOS path and separate port field**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/connect-with-ton-proxy.mdx?plain=1#L50-L54

Use System Settings/Preferences → Network → [Interface] → Details/Advanced → Proxies → Web Proxy (HTTP), and enter the proxy in Server with 8080 in the Port field (not host:port in one field).

---

- [x] **4357. Define 'entry proxy' and add cross-reference**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/connect-with-ton-proxy.mdx?plain=1

Replace the undefined phrase “public entry proxy” with clear guidance—e.g., “Enter the address of your entry proxy (for a local proxy, use 127.0.0.1)”—and add a first‑mention cross‑reference to docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx#running-an-entry-proxy and docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx#accessing-ton-sites.

---

- [x] **4358. Link Chrome section to OS anchors**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/connect-with-ton-proxy.mdx?plain=1

Update the Chrome section to link directly to this page’s OS sections (Windows, macOS, Ubuntu, iOS, Android) using in‑page anchors (#windows, #macos, #ubuntu, #ios, #android).

---

- [x] **4393. Align Firefox proxy steps with canonical page**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx?plain=1#accessing-ton-sites

Match wording/labels to docs/v3/guidelines/web3/ton-proxy-sites/connect-with-ton-proxy.mdx#firefox: Settings → General → Network Settings → Configure; choose Manual proxy settings; set HTTP Proxy 127.0.0.1, Port 8080.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.