### PR TITLE
Split: update docs/v3/guidelines/web3/ton-proxy-sites/how-to-open-any-ton-site.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/web3/ton-proxy-sites/how-to-open-any-ton-site.mdx
+++ b/docs/v3/guidelines/web3/ton-proxy-sites/how-to-open-any-ton-site.mdx
@@ -24,7 +24,7 @@ A more reliable and private method is to use a browser extension that connects d
 Currently:
 
 - [MyTonWallet](https://mytonwallet.io/) supports TON Proxy in its browser extension.
-- [TON Wallet](https://chrome.google.com/webstore/detail/ton-wallet/nphplpgoakhhjchkkhmiggakijnkhfnd) will support it soon.
+- [TON Wallet](https://chrome.google.com/webstore/detail/ton-wallet/nphplpgoakhhjchkkhmiggakijnkhfnd).
 
 This method requires installing a browser extension and is suitable for regular use by most users.
 


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-web3-ton-proxy-sites-how-to-open-any-ton-site.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/web3/ton-proxy-sites/how-to-open-any-ton-site.mdx`

Related issues (from issues.normalized.md):
- [x] **4359. Fix H1 to declarative plural form**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-open-any-ton-site.mdx?plain=1#L3

Change "How to open any TON Site?" to a statement without a question mark and use plural: "How to open TON Sites".

---

- [x] **4360. Reword heading for browsing domains**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-open-any-ton-site.mdx?plain=1#L11

Change "Browse through the ton.run or tonp.io" to the more natural "Browse via ton.run or tonp.io".

---

- [x] **4361. Link both domains and use plural consistently**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-open-any-ton-site.mdx?plain=1#L13

Link both ton.run and tonp.io and remove the definite article; use plural "TON Sites" (e.g., "... open [ton.run](https://ton.run) or [tonp.io](https://tonp.io) and browse TON Sites.").

---

- [ ] **4362. Remove time-sensitive “soon” about TON Wallet**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-open-any-ton-site.mdx?plain=1#L27

Replace "TON Wallet ... will support it soon" with a time-agnostic statement: "TON Wallet support for TON Proxy is planned; check the extension page for current status."

---

- [x] **4363. Soften superlative security claims**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-open-any-ton-site.mdx?plain=1#L35

Change "This is the most secure way of accessing TON Sites." to a neutral form such as "This is a secure way to access TON Sites," and remove similar "most secure" phrasing elsewhere.

---

- [x] **4364. Replace non-descriptive “from here” link text**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-open-any-ton-site.mdx?plain=1#L37

Change the anchor text "from here" to descriptive text: "Download the latest version from GitHub" linking to https://github.com/xssnick/Tonutils-Proxy#download-precompiled-version.

---

- [x] **4365. Consolidate duplicated Tonutils-Proxy steps**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-open-any-ton-site.mdx?plain=1#L37-L49

Remove the redundant instruction list and its introductory sentence, and keep a single concise two-step list: 1) Download the latest release from GitHub; 2) Launch the app and click `Start Gateway`.

---

- [x] **4366. Normalize “Start Gateway” label formatting**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-open-any-ton-site.mdx?plain=1#L39,L48

Format the button label consistently using backticks in all instances: `Start Gateway`.

---

- [x] **4367. Match “See also” link text to target page**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-open-any-ton-site.mdx?plain=1#L52

Change the link text "Run C++ implementation" to "Running your TON Proxy" while keeping the same URL.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.