### PR TITLE
Split: update docs/v3/guidelines/web3/ton-proxy-sites/how-to-run-ton-site.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/web3/ton-proxy-sites/how-to-run-ton-site.mdx
+++ b/docs/v3/guidelines/web3/ton-proxy-sites/how-to-run-ton-site.mdx
@@ -4,40 +4,40 @@ import Feedback from '@site/src/components/Feedback';
 
 ## Introduction
 
-[TON Sites](https://blog.ton.org/ton-sites) work similarly to regular websites but require additional steps to start. This guide walks you through the setup process.
+[TON Sites](https://blog.ton.org/ton-sites) work similarly to regular websites but require additional steps to set up. This guide walks you through the setup process.
 
-## Running TON Site
+## Running a TON Site
 
-Install the [Tonutils reverse proxy](https://github.com/tonutils/reverse-proxy) to use TON Proxy for your website.
+Install the [Tonutils Reverse Proxy](https://github.com/tonutils/reverse-proxy) to serve your website via TON Sites.
 
-### Installation on any Linux
+### Installation on Linux
 
-##### Download
+#### Download
 
 ```bash
 wget https://github.com/tonutils/reverse-proxy/releases/latest/download/tonutils-reverse-proxy-linux-amd64
 chmod +x tonutils-reverse-proxy-linux-amd64
 ```
 
-##### Run
+#### Run
 
-Run with domain configuration and follow the following steps:
+Run with your TON DNS domain:
 
-```
-./tonutils-reverse-proxy-linux-amd64 --domain your-domain.ton 
+```bash
+./tonutils-reverse-proxy-linux-amd64 --domain <your-domain.ton>
 ```
 
 Scan the QR code shown in your terminal using Tonkeeper, Tonhub, or any other wallet. Confirm the transaction to link your domain to the site.
 
-###### Run without domain
+##### Run without domain
 
-Alternatively, you can run the proxy in simple mode with an .adnl domain if you do not have a `.ton` or `.t.me` domain:
+Alternatively, you can run the proxy in simple mode with an ADNL address (suffix `.adnl`) if you do not have a `.ton` or `.t.me` domain:
 
-```
+```bash
 ./tonutils-reverse-proxy-linux-amd64
 ```
 
-##### Use
+##### Usage
 
 Your TON Site is now accessible via the ADNL address or the domain.
 
@@ -50,9 +50,7 @@ The proxy also adds the following headers:
 
 ### Installation on any other OS
 
-Build it from sources, and run it as in step 2 for linux. Go environment is required to build.
-
-To install it on other systems, build the project from the source and run it as in step 2 for Linux. A `Go` environment is required.
+Build it from sources and run it using the same command shown for Linux. A `Go` environment is required to build.
 
 ```bash
 git clone https://github.com/tonutils/reverse-proxy.git
@@ -66,7 +64,7 @@ To build for other operating systems, run `make all`.
 
 ### Checking site availability
 
-After completing the setup, the TON Proxy should be running. If the setup is successful, your site will be available at the ADNL address generated during the configuration.
+After completing the setup, the reverse proxy should be running. If the setup is successful, your site will be available at the ADNL address generated during the configuration.
 
 You can check availability by opening the address with the `.adnl` suffix. Ensure that a TON Proxy is active in your browser, such as via the [MyTonWallet](https://mytonwallet.io/) browser extension.
 
@@ -74,10 +72,10 @@ You can check availability by opening the address with the `.adnl` suffix. Ensur
 
 - [TON Sites, TON WWW and TON Proxy](https://blog.ton.org/ton-sites)
 - [Tonutils reverse proxy](https://github.com/tonutils/reverse-proxy)
-- Authors: [_Andrew Burnosov_](https://github.com/AndreyBurnosov) (TG: [@AndrewBurnosov](https://t.me/AndreyBurnosov)), [_Daniil Sedov_](https://gusarich.com) (TG: [@sedov](https://t.me/sedov)), [_George Imedashvili_](https://github.com/drforse)
+- Authors: [_Andrey Burnosov_](https://github.com/AndreyBurnosov) (TG: [@AndreyBurnosov](https://t.me/AndreyBurnosov)), [_Daniil Sedov_](https://gusarich.com) (TG: [@sedov](https://t.me/sedov)), [_George Imedashvili_](https://github.com/drforse)
 
 ## See also
 
-- [Run C++ implementation](/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy)
+- [Running your TON Proxy](/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy)
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-web3-ton-proxy-sites-how-to-run-ton-site.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/web3/ton-proxy-sites/how-to-run-ton-site.mdx`

Related issues (from issues.normalized.md):
- [ ] **4368. Clarify intro wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-run-ton-site.mdx?plain=1#L7

Change "require additional steps to start" to "require additional steps to set up" for clearer phrasing.

---

- [ ] **4369. Fix H2: "Running a TON Site"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-run-ton-site.mdx?plain=1#L9

Change "Running TON Site" to "Running a TON Site" for proper grammar and consistency with related pages.

---

- [ ] **4370. Clarify reverse proxy terminology and capitalize product name**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-run-ton-site.mdx?plain=1#L11

Rephrase to avoid conflating the client TON Proxy with the server reverse proxy and capitalize the product: "Install the Tonutils Reverse Proxy to serve your website via TON Sites."

---

- [ ] **4371. Simplify H3 title: "Installation on Linux"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-run-ton-site.mdx?plain=1#L13

Change "Installation on any Linux" to "Installation on Linux" for natural phrasing.

---

- [ ] **4372. Fix heading hierarchy under Linux section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-run-ton-site.mdx?plain=1#L13-L41

Use H4 for "Download", "Run", and "Use"; nest "Run without domain" as an H5 under "Run" to maintain a proper hierarchy.

---

- [ ] **4373. Rephrase domain run instruction and update placeholder**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-run-ton-site.mdx?plain=1#L24-L28

Replace "Run with domain configuration and follow the following steps:" with "Run with your TON DNS domain:" and change the placeholder to "<your-domain.ton>".

---

- [ ] **4374. Add bash language tags to command blocks**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-run-ton-site.mdx?plain=1#L26-L28, #L36-L38

Add the bash language specifier to both unlabeled code fences for consistent syntax highlighting.

---

- [ ] **4375. Remove trailing space in domain command**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-run-ton-site.mdx?plain=1#L27

Delete the trailing space after "your-domain.ton" to prevent copy-paste errors.

---

- [ ] **4376. Use correct term: "ADNL address"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-run-ton-site.mdx?plain=1#L34

Replace ".adnl domain" with "ADNL address (suffix .adnl)" for terminology consistency.

---

- [ ] **4377. Rename "Use" to "Usage"**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-run-ton-site.mdx?plain=1#L40

Change the subheading "Use" to "Usage" to follow common documentation conventions.

---

- [ ] **4378. Specify config.json path and creation**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-run-ton-site.mdx?plain=1#L44

State where config.json is located or generated by default and how to point the binary to a custom path, so users know where to edit it.

---

- [ ] **4379. Confirm and document added HTTP headers**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-run-ton-site.mdx?plain=1#L46-L49

Verify the header names (e.g., X-Adnl-Ip, X-Adnl-Id) and document their meanings or link to a reference.

---

- [ ] **4380. Deduplicate and correct other OS instructions**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-run-ton-site.mdx?plain=1#L53-L55

Remove the duplicated sentence, capitalize "Linux," and replace "as in step 2 for Linux" with "using the same command shown for Linux"; keep a single corrected note that a Go environment is required.

---

- [ ] **4381. Clarify which proxy is running**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-run-ton-site.mdx?plain=1#L69-L71

Replace "the TON Proxy should be running" with "the reverse proxy should be running" to avoid ambiguity with the client entry proxy.

---

- [ ] **4382. Explain how to find the generated ADNL address**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-run-ton-site.mdx?plain=1#L69-L71

Specify where the generated ADNL address is shown and how to copy it (e.g., printed in the proxy output).

---

- [ ] **4383. Update "See also" link text to match target page**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-run-ton-site.mdx?plain=1#L79-L81

Change the link text from "Run C++ implementation" to "Running your TON Proxy" to match the target page title.

---

- [ ] **4384. Standardize author name and handle**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/how-to-run-ton-site.mdx?plain=1

Use "Andrey Burnosov" and "@AndreyBurnosov" to match the linked profiles consistently.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.