### PR TITLE
Split: update docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx
+++ b/docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx
@@ -4,10 +4,11 @@ import Feedback from '@site/src/components/Feedback';
 
 This document briefly introduces TON Sites — websites accessed through the TON Network. TON Sites can serve as convenient entry points to other TON Services. For instance, HTML pages loaded from TON Sites may contain `ton://...` URIs, such as payment links. When clicked, these links can trigger actions like making a payment, provided the user has a TON Wallet installed on their device.
 
-From a technical standpoint, TON Sites function similarly to standard websites. Still, they are accessed via the [TON Network](/v3/concepts/dive-into-ton/ton-blockchain/ton-networking) — an overlay network that operates within the Internet — rather than directly through the Internet itself. Instead of using standard IPv4 or IPv6 addresses, TON Sites are addressed via [ADNL](/v3/documentation/network/protocols/adnl/overview) addresses. They receive HTTP requests over the [RLDP](/v3/documentation/network/protocols/rldp) protocol, a high-level RPC protocol built on top of ADNL, the TON Network's primary protocol, instead of the usual TCP/IP.
+From a technical standpoint, TON Sites function similarly to standard websites. Still, they are accessed via the [TON Network](/v3/concepts/dive-into-ton/ton-blockchain/ton-networking) which is an overlay network that operates within the Internet rather than directly through the Internet itself. Instead of using standard IPv4 or IPv6 addresses, TON Sites are addressed via [ADNL](/v3/documentation/network/protocols/adnl/overview) addresses. They receive HTTP requests over the [RLDP](/v3/documentation/network/protocols/rldp) protocol, a high-level RPC protocol built on top of ADNL, the TON Network's primary protocol, instead of the usual TCP/IP.
 Since encryption is handled at the ADNL level, there’s no need for HTTPS (TLS), mainly when the entry proxy is hosted locally on the user's device.
 
 A gateway between the "ordinary" Internet and the TON Network is required to access existing sites or create new TON Sites. In practice, this involves:
+
 - A HTTP → RLDP proxy running locally on the client's machine to access TON Sites. 
 - A reverse RLDP → HTTP proxy running on a remote web server to serve your content through the TON Network.
 
@@ -20,9 +21,7 @@ To access existing TON Sites, you need to run an RLDP-HTTP proxy on your local m
 1. Download the proxy.
     
    You can either:
-   - Download the precompiled **rldp-http-proxy** from [TON auto builds](https://github.com/ton-blockchain/ton/releases/latest).
-  
-   or 
+   - Download the precompiled **rldp-http-proxy** from [TON auto builds](https://github.com/ton-blockchain/ton/releases/latest), or 
    - Compile it yourself by following these [instructions](/v3/guidelines/smart-contracts/howto/compile/compilation-instructions#rldp-http-proxy).
 
 2. Download the [TON global config](/v3/guidelines/smart-contracts/howto/compile/compilation-instructions#download-global-config).
@@ -47,9 +46,7 @@ To stop the proxy, press `Ctrl+C` or close the terminal window.
 1. Download the proxy.
 
 You can either:
-- Download **rldp-http-proxy** from [TON auto builds](https://github.com/ton-blockchain/ton/releases/latest).
-  
-  or
+- Download **rldp-http-proxy** from [TON auto builds](https://github.com/ton-blockchain/ton/releases/latest), or
 - Compile it yourself by following these [instructions](/v3/guidelines/smart-contracts/howto/compile/compilation-instructions#rldp-http-proxy).
 
 2. Download the [TON global config](/v3/guidelines/smart-contracts/howto/compile/compilation-instructions#download-global-config).
@@ -162,9 +159,7 @@ We assume that you already know how to set up a regular website and that:
 1. Download the proxy.
 
 You can either:
-- Download **rldp-http-proxy** from [TON auto builds](https://github.com/ton-blockchain/ton/releases/latest).
-
-  or
+- Download **rldp-http-proxy** from [TON auto builds](https://github.com/ton-blockchain/ton/releases/latest), or
 - Compile it yourself by following these [instructions](/v3/guidelines/smart-contracts/howto/compile/compilation-instructions#rldp-http-proxy).
 
 2. Download the [TON global config](/v3/guidelines/smart-contracts/howto/compile/compilation-instructions#download-global-config).


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-web3-ton-proxy-sites-running-your-own-ton-proxy.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx`

Related issues (from issues.normalized.md):
- [ ] **4357. Define 'entry proxy' and add cross-reference**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/connect-with-ton-proxy.mdx?plain=1

Replace the undefined phrase “public entry proxy” with clear guidance—e.g., “Enter the address of your entry proxy (for a local proxy, use 127.0.0.1)”—and add a first‑mention cross‑reference to docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx#running-an-entry-proxy and docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx#accessing-ton-sites.

---

- [x] **4385. Fix typo: ANDL → ADNL**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx?plain=1

Replace every occurrence of “ANDL” with the correct term “ADNL” in step titles and descriptions (e.g., “Generate a persistent ADNL address”) to match canonical usage (see docs/v3/documentation/network/protocols/adnl/overview.mdx).

---

- [x] **4386. Fix fragment and wrong link in “Accessing TON Sites”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx?plain=1#accessing-ton-sites

Rewrite the opening line as a complete sentence and link to the local section: “Once your RLDP-HTTP proxy is running on localhost:8080, as described in Running an entry proxy (#running-an-entry-proxy), you can verify your setup with curl.”

---

- [ ] **4387. Replace invalid example IPs**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx?plain=1

Replace invalid addresses like 777.777.777.777 and 333.333.333.333 with placeholders (<your_public_ip>, <YOUR_WEB_SERVER_HTTP_IP>) or reserved documentation IPs (e.g., 203.0.113.10) to avoid impossible IPv4 values.

---

- [ ] **4388. Make ADNL hex/file name consistent (…E2BD)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx?plain=1

The sample ADNL ends with …E2BD but the text says the private key is saved to 45061…2DB; correct the transposed characters to 45061…E2BD everywhere this sample pair appears.

---

- [x] **4389. Number the “Run rldp-http-proxy” step**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx?plain=1#running-an-entry-proxy

After “2. Download the TON global config”, prefix “Run rldp-http-proxy” with “3.” to keep the ordered steps consistent.

---

- [x] **4390. Add language tags to code fences**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx?plain=1

Add bash to shell command fences and html to the HTML snippet; use text for output-only blocks. Update at least: the first curl example under “Accessing TON Sites”; the rldp-http-proxy “Example” under “Running an entry proxy on a remote computer”; the rldp-http-proxy “Example” under “Run the proxy in reverse mode”; the -R '*'@<IP>:<PORT> snippet and its example.

---

- [x] **4391. Use “an HTTP” (article before acronym)**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx?plain=1

Change “a HTTP …” to “an HTTP …” wherever applicable to follow standard article usage before vowel sounds.

---

- [x] **4392. Prefer “HTTP requests” over “HTTP queries”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx?plain=1

Replace “HTTP queries” with “HTTP requests” for consistency with RLDP documentation (see docs/v3/documentation/network/protocols/rldp.mdx#rldp-http).

---

- [ ] **4393. Align Firefox proxy steps with canonical page**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx?plain=1#accessing-ton-sites

Match wording/labels to docs/v3/guidelines/web3/ton-proxy-sites/connect-with-ton-proxy.mdx#firefox: Settings → General → Network Settings → Configure; choose Manual proxy settings; set HTTP Proxy 127.0.0.1, Port 8080.

---

- [ ] **4394. Clarify HTTP proxy address usage**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx?plain=1

Avoid implying users should browse to http://localhost:8080 or http://<your_public_ip>:8080; clarify these are HTTP proxy endpoints to configure in clients (or use with curl -x), and cross-reference connect-with-ton-proxy.mdx for setup.

---

- [ ] **4395. Note executable path differences for prebuilt binaries**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx?plain=1

Add a note that when using prebuilt release binaries, paths differ from build-tree examples (e.g., run ./rldp-http-proxy from the download directory); adjust commands accordingly.

---

- [ ] **4396. Neutralize phrasing for “.adnl” suffix**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx?plain=1#accessing-ton-sites

Change “use the ADNL address directly with a fake .adnl domain” to a neutral phrasing like “use the ADNL address with the .adnl suffix.”

---

- [ ] **4397. Rephrase unsourced “TON Proxy 2.0 anonymity” claim**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx?plain=1#recommendations

Remove the version-specific claim or rephrase to a present-tense fact without versioning (e.g., “TON Proxy currently lacks anonymity features…”), unless a source is cited.

---

- [ ] **4398. Document the -A flag**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx?plain=1

Add a parameter note explaining that -A <your_adnl_address> specifies the persistent ADNL address generated earlier.

---

- [ ] **4399. Replace “mainly when” with “especially when”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy.mdx?plain=1

In the sentence about HTTPS/TLS not being required due to ADNL encryption, change “mainly when the entry proxy is hosted locally” to “especially when the entry proxy is hosted locally” for more natural phrasing.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.