### PR TITLE
Split: update docs/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management.mdx
+++ b/docs/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management.mdx
@@ -15,7 +15,7 @@ import Feedback from '@site/src/components/Feedback';
 > If you lose access, you can restore your wallet in any TON wallet app using this recovery phrase.
 > In Tonkeeper: go to Settings → Wallet protection → Your private key.
 > 
-> Store your recovery phrase securely. Never share it with anyone; anyone with access can control your funds.
+> Store your 24 words securely. Never share it. Anyone with access to your phrase can access your funds.
 > 
 
 4. Go to [dns.ton.org](https://dns.ton.org), open your domain, and click "Edit"


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-web3-ton-proxy-sites-site-and-domain-management.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management.mdx`

Related issues (from issues.normalized.md):
- [x] **4400. Title-case H1 and replace ampersand**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management.mdx?plain=1#L3

Change “Site & domain management” to “Site and Domain Management” for title case consistency and to avoid “&”.

---

- [ ] **4401. Generalize extension naming**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management.mdx?plain=1#L8

Replace “Install the TON Chrome extension” with “Install a TON wallet extension (e.g., TON Wallet or MyTonWallet).”

---

- [x] **4402. Use “owns the domain”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management.mdx?plain=1#L9

Replace “holds the domain” with “owns the domain” for clarity and consistency.

---

- [x] **4403. Make recovery callout title singular**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management.mdx?plain=1#L11

Change the callout header from “Recovery phrases” to “Recovery phrase”.

---

- [ ] **4404. Correct recovery phrase length**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management.mdx?plain=1#L13

Change “Your recovery phrase consists of 24 words” to “Your recovery phrase consists of 12 or 24 words.”

---

- [x] **4405. Fix restoration wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management.mdx?plain=1#L15

Replace “You can restore this phrase …” with “If you lose access, you can restore your wallet in any TON wallet app using this recovery phrase.”

---

- [ ] **4406. Remove product-specific private key path**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management.mdx?plain=1#L16

Replace the Tonkeeper-specific “Settings → Wallet protection → Your private key” line with “Refer to your wallet’s documentation to view or back up your recovery phrase.”

---

- [ ] **4407. Strengthen storage and no‑sharing guidance**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management.mdx?plain=1#L18-L19

Replace with: “Store your recovery phrase securely. Never share it with anyone; anyone with access can control your funds.”

---

- [ ] **4408. Add Testnet DNS hint**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management.mdx?plain=1#L22

Append: “(Use https://dns.ton.org/?testnet=true on Testnet.)”

---

- [ ] **4409. Use “Toncoin”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management.mdx?plain=1#L26

Replace “coins” with “Toncoin” for accurate currency naming.

---

- [x] **4410. Say “hexadecimal format”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management.mdx?plain=1#L35

Replace “in HEX format” with “in hexadecimal format”.

---

- [ ] **4411. Link to DNS subresolvers reference**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management.mdx?plain=1#L40-L46

Append: “See TON DNS resolvers for details.” linking to docs/v3/guidelines/web3/ton-dns/subresolvers.mdx.

---

- [ ] **4412. Pin smart contract links to SHAs**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management.mdx?plain=1

The links to https://github.com/ton-blockchain/ton/blob/master/crypto/smartcont/dns-manual-code.fc and https://github.com/ton-blockchain/ton/blob/master/crypto/smartcont/dns-auto-code.fc should be updated to blob/<commit-sha>/… to avoid master-branch drift.

---

- [ ] **4413. Remove extra blank lines before Feedback**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management.mdx?plain=1

Reduce multiple consecutive blank lines before the closing “<Feedback />” component to a single blank line.

---

- [ ] **4441. Align DNS field names with DNS guide**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-faq.mdx?plain=1

Align this page’s DNS field names/options with the documented UI in the DNS guide, or add a short note mapping fields and link to docs/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management.mdx#how-to-link-a-ton-site-to-a-domain; if the UI truly has a "Storage" field or "Host in TON Storage" toggle, reflect it consistently across both pages.

---

- [x] **4450. Cross-link DNS editing guide**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-faq.mdx?plain=1

After instructing to open dns.ton.org, add a short note linking to docs/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management.mdx#how-to-open-a-domain-for-editing to keep UI expectations consistent.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.