### PR TITLE
Split: update docs/v3/guidelines/web3/ton-proxy-sites/ton-sites-for-applications.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/web3/ton-proxy-sites/ton-sites-for-applications.mdx
+++ b/docs/v3/guidelines/web3/ton-proxy-sites/ton-sites-for-applications.mdx
@@ -1,13 +1,13 @@
 import Feedback from '@site/src/components/Feedback';
 
-# TON Sites for applications
+# TON Sites for Applications
 
-## How to support TON Site in your application?
+## How to support a TON Site in your application?
 
-You can launch TON Site in your application by directly integrating a local entry proxy into your product.
+You can launch a TON Site in your application by directly integrating a local [entry proxy](/v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy#running-an-entry-proxy) into your product.
 Libraries and example integrations are available for popular platforms:
 
-- [Andriod](https://github.com/andreypfau/tonutils-proxy-android-example)
+- [Android](https://github.com/andreypfau/tonutils-proxy-android-example)
 - [iOS](https://github.com/ton-blockchain/ton-proxy-swift)
 
 :::caution


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-web3-ton-proxy-sites-ton-sites-for-applications.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/web3/ton-proxy-sites/ton-sites-for-applications.mdx`

Related issues (from issues.normalized.md):
- [ ] **4414. Use title case in H1**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/ton-sites-for-applications.mdx?plain=1#L3

Change the page title to title case: "# TON Sites for Applications".

---

- [ ] **4415. Add article “a” before “TON Site” in H2 and sentence**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/ton-sites-for-applications.mdx?plain=1#L5-L7

Add the missing article in both places: change the H2 to "## How to support a TON Site in your application?" and the sentence to "You can launch a TON Site in your application by directly integrating a local entry proxy into your product."

---

- [ ] **4416. Link “entry proxy” to setup section**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/ton-sites-for-applications.mdx?plain=1#L7

Link the phrase "entry proxy" to /v3/guidelines/web3/ton-proxy-sites/running-your-own-ton-proxy#running-an-entry-proxy to guide readers to the setup instructions.

---

- [ ] **4417. Correct “Andriod” to “Android”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-proxy-sites/ton-sites-for-applications.mdx?plain=1#L10

Fix the misspelling in the list item to "- [Android](https://github.com/andreypfau/tonutils-proxy-android-example)".

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.