### PR TITLE
Split: update docs/v3/guidelines/web3/ton-storage/storage-faq.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/web3/ton-storage/storage-faq.mdx
+++ b/docs/v3/guidelines/web3/ton-storage/storage-faq.mdx
@@ -4,51 +4,52 @@ import Feedback from '@site/src/components/Feedback';
 
 ## How to assign a TON domain to a TON Storage bag 
 
-1. [Upload your bag of files](/v3/guidelines/web3/ton-storage/storage-daemon#creating-a-bag-of-files) to the network and copy the bag ID. 
+1. [Upload your bag of files](/v3/guidelines/web3/ton-storage/storage-daemon#creating-a-bag-of-files) to the network and copy the bag ID (`<BagID>`). 
 2. Open Google Chrome on your computer. 
-3. Install a TON extension:
+3. Install a wallet browser extension (TON Wallet or MyTonWallet):
    - [TON Wallet](https://chrome.google.com/webstore/detail/ton-wallet/nphplpgoakhhjchkkhmiggakijnkhfnd)
-   - or [MyTonWallet](https://chrome.google.com/webstore/detail/mytonwallet/fldfpgipfncgndfolcbkdeeknbbbnhcc)
+   - [MyTonWallet](https://chrome.google.com/webstore/detail/mytonwallet/fldfpgipfncgndfolcbkdeeknbbbnhcc)
 4. Open the extension, click "Import wallet", and import the wallet that owns the domain using your recovery phrase. 
-5. Go to [dns.ton.org](https://dns.ton.org), open your domain, and click "Edit". 
-6. Paste the bag ID into the "Storage" field and click "Save".
+5. Go to [dns.ton.org](https://dns.ton.org), open your domain, and click "Edit". (See how to open a domain for editing in the [DNS guide](/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management#how-to-open-a-domain-for-editing).)
+6. Paste the `<BagID>` into the "Storage" field and click "Save". Confirm the transaction in the extension.
 
-## How to host static TON site in TON Storage
+## How to host a static TON Site in TON Storage
 
 1. [Create a bag](/v3/guidelines/web3/ton-storage/storage-daemon#creating-a-bag-of-files) from the folder containing your static website. 
 2. The folder must contain an `index.html` file. 
 3. Upload the bag to the network and copy the bag ID. 
-4. Open Google Chrome and install a [TON extension](https://chrome.google.com/webstore/detail/ton-wallet/nphplpgoakhhjchkkhmiggakijnkhfnd) or [MyTonWallet](https://chrome.google.com/webstore/detail/mytonwallet/fldfpgipfncgndfolcbkdeeknbbbnhcc).  
+4. Open Google Chrome and install a wallet browser extension ([TON Wallet](https://chrome.google.com/webstore/detail/ton-wallet/nphplpgoakhhjchkkhmiggakijnkhfnd) or [MyTonWallet](https://chrome.google.com/webstore/detail/mytonwallet/fldfpgipfncgndfolcbkdeeknbbbnhcc)).  
 5. Import the wallet that owns the domain using your recovery phrase. 
-6. Go to [dns.ton.org](https://dns.ton.org), open your domain, and click "Edit". 
-7. Paste the bag ID into the "Site" field, select "Host in TON Storage", and click "Save".
+6. Go to [dns.ton.org](https://dns.ton.org), open your domain, and click "Edit". (See how to open a domain for editing in the [DNS guide](/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management#how-to-open-a-domain-for-editing).)
+7. Paste the `<BagID>` into the "Site" field, select "Host in TON Storage", and click "Save". Confirm the transaction in the extension.
+   
+   Note: Depending on the UI version, the field may appear as "Storage" or "Site". For details, see the [DNS guide](/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management#how-to-link-a-ton-site-to-a-domain).
 
 ## How to migrate TON NFT content to TON Storage
 
-If you're using a [standard NFT contract](https://github.com/ton-blockchain/token-contract/blob/main/nft/nft-collection-editable.fc), update the content prefix by sending a [message](https://github.com/ton-blockchain/token-contract/blob/2d411595a4f25fba43997a2e140a203c140c728a/nft/nft-collection-editable.fc#L132) to your NFT collection smart contract from the collection owner's wallet.
+If you're using a [standard NFT contract](https://github.com/ton-blockchain/token-contract/blob/2d411595a4f25fba43997a2e140a203c140c728a/nft/nft-collection-editable.fc), update the content prefix by sending a [message](https://github.com/ton-blockchain/token-contract/blob/2d411595a4f25fba43997a2e140a203c140c728a/nft/nft-collection-editable.fc#L132) to your NFT collection smart contract from the collection owner's wallet.
 
 - **Old URL prefix example:** `https://mysite/my_collection/`
-- **New URL prefix format:** `tonstorage://my_bag_id/`.
+- **New URL prefix format:** `tonstorage://<BagID>/` (where `<BagID>` is a 64-character hex hash; see [Adding a bag of files](/v3/guidelines/web3/ton-storage/storage-daemon#adding-a-bag-of-files)).
 
 
 ## How to assign a TON domain to a TON Storage bag (low-level)
 
-You need to assign the following value to the sha256("storage") DNS Record of your TON domain:
-```
+You need to assign the following value to the `sha256("storage")` DNS record of your TON domain:
+```tlb
 dns_storage_address#7473 bag_id:uint256 = DNSRecord;
 ```
 
-## How to host static TON site in TON Storage (low-level)
+## How to host a static TON Site in TON Storage (low-level)
 
 
 To host a static site via TON Storage directly:
 - [Create a bag](/v3/guidelines/web3/ton-storage/storage-daemon#creating-a-bag-of-files) from your website folder. The folder must include `index.html`. 
-- Assign the following value to the DNS record with key sha256("site"):
+- Assign the following value to the DNS record with key `sha256("site")`:
 
-```
+```tlb
 dns_storage_address#7473 bag_id:uint256 = DNSRecord;
 ```
 
 
 <Feedback />
-


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-web3-ton-storage-storage-faq.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/web3/ton-storage/storage-faq.mdx`

Related issues (from issues.normalized.md):
- [ ] **4441. Align DNS field names with DNS guide**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-faq.mdx?plain=1

Align this page’s DNS field names/options with the documented UI in the DNS guide, or add a short note mapping fields and link to docs/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management.mdx#how-to-link-a-ton-site-to-a-domain; if the UI truly has a "Storage" field or "Host in TON Storage" toggle, reflect it consistently across both pages.

---

- [ ] **4442. Define or remove tonstorage:// scheme**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-faq.mdx?plain=1

Either link to a page that defines the tonstorage:// scheme and resolution rules, or present it as tonstorage://<BagID>/ with a brief note that <BagID> is a 64‑character hex hash (see storage-daemon.mdx#adding-a-bag-of-files); if the scheme is not user-facing, remove or replace it.

---

- [ ] **4443. Capitalize “TON Site” in headings**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-faq.mdx?plain=1

Update headings to "How to host a static TON Site in TON Storage" and "How to host a static TON Site in TON Storage (low‑level)" for consistency with other pages.

---

- [ ] **4444. Standardize BagID placeholder and definition**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-faq.mdx?plain=1

Use <BagID> consistently in text and examples (including the URI example) and, on first use, add that it is a 64‑character hex hash with a reference to storage-daemon.mdx#adding-a-bag-of-files.

---

- [ ] **4445. Add extension confirmation step**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-faq.mdx?plain=1

In both DNS-edit procedures, after "Save" add "Confirm the transaction in the extension." to match the DNS guide workflow.

---

- [ ] **4446. Add tlb language tags to code fences**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-faq.mdx?plain=1

Annotate both TL‑B code blocks with the tlb language tag for syntax highlighting (start the code fence with tlb).

---

- [ ] **4447. Format DNS record keys as code**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-faq.mdx?plain=1

Refer to DNS keys with code formatting and consistent casing, e.g., “assign the value to the sha256("storage") DNS record” and similarly for sha256("site").

---

- [ ] **4448. Clarify wallet extension link and fix list bullets**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-faq.mdx?plain=1

Replace the ambiguous “TON extension” link text with “TON Wallet” or “wallet browser extension (TON Wallet or MyTonWallet)”, and remove the stray “or” bullet by listing both extensions cleanly or combining into a single sentence.

---

- [ ] **4449. Stabilize NFT migration GitHub links**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-faq.mdx?plain=1

Make the two GitHub links consistent and stable: avoid mixing main and pinned commits; pin both to a specific commit (optionally keep line anchors) or remove line anchors to prevent brittleness.

---

- [ ] **4450. Cross-link DNS editing guide**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-faq.mdx?plain=1

After instructing to open dns.ton.org, add a short note linking to docs/v3/guidelines/web3/ton-proxy-sites/site-and-domain-management.mdx#how-to-open-a-domain-for-editing to keep UI expectations consistent.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.