### PR TITLE
Split: update docs/v3/guidelines/web3/ton-storage/storage-provider.mdx (from ai-fixes-big vs main)

### DIFF
--- a/docs/v3/guidelines/web3/ton-storage/storage-provider.mdx
+++ b/docs/v3/guidelines/web3/ton-storage/storage-provider.mdx
@@ -8,9 +8,9 @@ A **storage provider** is a service that stores files for a fee.
 
 Precompiled binaries of `storage-daemon` and `storage-daemon-cli` are available for Linux, Windows, and macOS at [TON auto builds](https://github.com/ton-blockchain/ton/releases/latest).
 
-## Compile from sources
+## Compile from source
 
-To build `storage-daemon` and `storage-daemon-cli` from the source, follow the [instruction](/v3/guidelines/smart-contracts/howto/compile/compilation-instructions#storage-daemon).
+To build `storage-daemon` and `storage-daemon-cli` from source, follow the [instructions](/v3/guidelines/smart-contracts/howto/compile/compilation-instructions#storage-daemon).
 
 ## Key concepts
 
@@ -21,67 +21,60 @@ A storage provider consists of:
 
 The process works as follows:
 
-1. The owner of the provider launches the `storage-daemon`, deploying the main smart contract, and configuring the necessary parameters. The contract address is then shared with potential clients.
+1. The owner of the provider launches the storage-daemon, deploys the main smart contract, and configures the necessary parameters. The contract address is then shared with potential clients.
 
-2. A client uses the `storage-daemon` to create **a bag** from their files and sends an internal message to the provider's smart contract.
+2. A client uses the `storage-daemon` to create a bag from their files and sends an internal message to the provider's smart contract.
 
-3. The smart contract creates a storage contract for **this bag**.
+3. The smart contract creates a storage contract for this bag.
 
 4. The provider detects the request on-chain, downloads the bag, and activates the storage contract.
 
-5. The client transfers payment to the storage contract. The provider must regularly submit proof that the bag is still being stored to continue receiving payment.
+5. The client transfers payment to the storage contract. The provider must regularly submit storage proofs that the bag is still being stored to continue receiving payment.
 
 6. If the contract's funds are depleted, it becomes inactive, and the provider is no longer obligated to store the bag. The client can either refill the contract or retrieve their files.
 
 :::info
-Clients can retrieve their files anytime by providing proof of ownership to the storage contract. Once validated, the contract releases the files and deactivates itself.
+Clients can retrieve their files anytime by providing proof of ownership to the storage contract. Once validated, the contract allows retrieval of the files and deactivates itself.
 :::
 
 ## Smart contract
 
 View the [smart contract source code](https://github.com/ton-blockchain/ton/tree/master/storage/storage-daemon/smartcont).
 
-## Using a provider by clients
+## Using a provider
 
-To use a storage provider, you need to first know the address of its smart contract. You can retrieve the provider's parameters using the following command in `storage-daemon-cli`:
+To use a storage provider, you need to first know the address of its smart contract. You can retrieve the provider's parameters using the following command in `storage-daemon-cli` (on-chain parameters):
 
-```
+```bash
 get-provider-params <address>
 ```
-
-### Provider parameters
-
-- Whether new storage contracts are accepted.
-- Minimum and maximum _Bag_ size (in bytes).
-- Rate - the cost of storage. Specified in nanoTON per megabyte per day.
-- Max span - how often the provider should provide proofs of _Bag_ storage.
 
 The output includes the following parameters:
 
 - Whether new storage contracts are currently accepted.
-- Minimum and maximum **bag** size (in bytes).
+- Minimum and maximum bag size (in bytes).
 - Rate – the cost of storage specified in nanoTON per megabyte per day.
-- Max span – the interval at which the provider must submit proof of **bag** storage.
+- Max span – the interval at which the provider must submit proofs of bag storage.
 
-### A request to store
+### Storage request
 
-To request storage, you need to create a **bag** and generate a message using the following command:
+To request storage, you need to create a bag and generate a message using the following command:
 
-```
+```bash
 new-contract-message <BagID> <file> --query-id 0 --provider <address>
 ```
 
 ### Notes
 
-- This command may take some time to execute for large **bags**.
+- This command may take some time to execute for large bags.
 - The generated message body, not the full internal message, is saved to `<file>`.
-- Query ID can be any integer from `0` to `2^64 - 1`.
+- The query ID can be any integer from `0` to `2^64 - 1`.
 - The generated message includes the provider's current rate and max span parameters. These values are displayed after execution and should be reviewed before sending.
 - If the provider updates their parameters before the message is submitted, it will be rejected. This ensures that the storage contract is created under the client's agreed-upon conditions.
 
-The client must then send the generated message body to the provider's smart contract address. If an error occurs, the message bounces back to the sender. If successful, a new storage contract is created, and the client receives a message from the contract with [`op=0xbf7bd0c1`](https://github.com/ton-blockchain/ton/tree/testnet/storage/storage-daemon/smartcont/constants.fc#L3) and the same query ID.
+The client must then send the generated message body to the provider's smart contract address. If an error occurs, the message bounces back to the sender. If successful, a new storage contract is created, and the client receives a message from the contract with [`op=0xbf7bd0c1`](https://github.com/ton-blockchain/ton/blob/master/storage/storage-daemon/smartcont/constants.fc#L3) and the same query ID.
 
-At this stage, the contract is not yet active. Once the provider downloads the bag, the contract is activated, and the client receives another message from the same contract with  [`op=0xd4caedcd`](https://github.com/SpyCheese/ton/blob/tonstorage/storage/storage-daemon/smartcont/constants.fc#L4).
+At this stage, the contract is not yet active. Once the provider downloads the bag, the contract is activated, and the client receives another message from the same contract with  [`op=0xd4caedcd`](https://github.com/ton-blockchain/ton/blob/master/storage/storage-daemon/smartcont/constants.fc#L4).
 
 #### Client balance
 
@@ -89,12 +82,12 @@ The storage contract maintains a client balance, which consists of the funds tra
 
 - The initial balance is the amount sent when creating the storage contract with the request.
 - The client can top up the contract anytime by making transfers to the storage contract — this can be done from any wallet address.
-- The current balance can be retrieved using the [`get_storage_contract_data`](https://github.com/ton-blockchain/ton/tree/testnet/storage/storage-daemon/smartcont/storage-contract.fc#L222) getter method. It is returned as the second value: `balance`.
+- The current balance can be retrieved using the [`get_storage_contract_data`](https://github.com/ton-blockchain/ton/blob/master/storage/storage-daemon/smartcont/storage-contract.fc#L222) getter method. It is returned as the second value: `balance`.
 
 ### Contract closure
 
 :::info
-If the storage contract is closed, the client receives a message with the remaining balance and [`op=0xb6236d63`](https://github.com/ton-blockchain/ton/tree/testnet/storage/storage-daemon/smartcont/constants.fc#L6).
+If the storage contract is closed, the client receives a message with the remaining balance and [`op=0xb6236d63`](https://github.com/ton-blockchain/ton/blob/master/storage/storage-daemon/smartcont/constants.fc#L6).
 :::
 
 A storage contract may be closed under the following conditions:
@@ -102,7 +95,7 @@ A storage contract may be closed under the following conditions:
 - Immediately after creation, before activation, if the provider declines the request, e.g., due to capacity limits or configuration issues.
 - When the client balance reaches 0.
 - Voluntarily by the provider.
-- Voluntarily by the client by sending a message with [`op=0x79f937ea`](https://github.com/ton-blockchain/ton/tree/testnet/storage/storage-daemon/smartcont/constants.fc#L2) from the address with any query ID.
+- Voluntarily by the client by sending a message with [`op=0x79f937ea`](https://github.com/ton-blockchain/ton/blob/master/storage/storage-daemon/smartcont/constants.fc#L2) from the client's wallet; the message may use any query ID.
 
 ## Running and configuring a provider
 
@@ -110,65 +103,68 @@ The storage provider is a component of the `storage-daemon` and is managed using
 
 ### Create a main smart contract
 
-To deploy the provider’s smart contract from `storage-daemon-cli`, run:
+To deploy the provider's smart contract from `storage-daemon-cli`, run:
 
-```
+```bash
 deploy-provider
 ```
 
 :::info IMPORTANT!
-During deployment, you’ll be prompted to send a non-bounceable message with 1 TON to the specified address to initialize the provider. You can verify successful deployment with the `get-provider-info` command.
+During deployment, you'll be prompted to send a non-bounceable message with 1 TON to the specified address to initialize the provider. You can verify successful deployment with the `get-provider-info` command.
 :::
 
-By default, the contract does not accept new storage contracts. Before activating it, you must configure the provider configuration, which is stored in  `storage-daemon`, and contract parameters stored on-chain.
-
-### Configuration
+By default, the contract does not accept new storage contracts. Before activation, configure the provider settings stored in storage-daemon and the on-chain contract parameters.
 
 The provider configuration includes:
 
 - `max contracts` - maximum number of concurrent storage contracts.
-- `max total size` - maximum total size of _bags_ in storage contracts.
+- `max total size` - maximum total size of bags in storage contracts.
 
-To view the current configuration:
+To view the current configuration (local daemon state):
 
-```
+```bash
 get-provider-info
 ```
 
 To update the configuration:
 
-```
+```bash
 set-provider-config --max-contracts 100 --max-total-size 100000000000
 ```
 
 ### Contract parameters
 
 - `accept` - whether to accept new storage contracts.
-- `max file size`, `min file size` - size limits for one _bag_.
+- `min file size`, `max file size` - per-bag size limits; set via `--min-file-size`/`--max-file-size`.
 - `rate` - cost of storage specified in nanoTON per megabyte per day.
 - `max span` - how often the provider will have to submit storage proofs.
 
-To view the current parameters:
+To view the current parameters (local daemon state):
+
+```bash
+get-provider-info
+```
+
+To view on-chain parameters:
 
 ```
-get-provider-info
+get-provider-params <address>
 ```
 
 To update the parameters:
 
-```
+```bash
 set-provider-params --accept 1 --rate 1000000000 --max-span 86400 --min-file-size 1024 --max-file-size 1000000000
 ```
 
 **Note:** in the `set-provider-params` command, you may update only a subset of parameters. Any omitted values will retain their current settings. Since blockchain data is not updated instantly, executing multiple `set-provider-params` commands quickly can lead to inconsistent results.
 
-It is recommended that the provider’s smart contract be funded with more than 1 TON after deployment to cover future transaction fees. However, avoid transferring large amounts during the initial non-bounceable setup.
+It is recommended that the provider's smart contract be funded with more than 1 TON after deployment to cover future transaction fees. However, avoid transferring large amounts during the initial non-bounceable setup.
 
-After setting the `accept` parameter to `1`, the smart contract will start accepting requests from clients and creating storage contracts, while the storage daemon will automatically process them: downloading and distributing _Bags_, generating storage proofs.
+After setting the `accept` parameter to `1`, the smart contract starts accepting requests from clients and creates storage contracts. The storage daemon automatically:
 
-- The provider begins accepting client requests once the `accept` parameter is set to `1` and creates storage contracts. The storage daemon will automatically:
-- Download and distribute **bags**.
-- Generate and submit storage proofs.
+- Downloads and distributes bags.
+- Generates and submits storage proofs.
 
 ## Further work with the provider
 
@@ -176,7 +172,7 @@ After setting the `accept` parameter to `1`, the smart contract will start accep
 
 To list all active storage contracts and their balances:
 
-```
+```bash
 get-provider-info --contracts --balances
 ```
 
@@ -185,27 +181,31 @@ Each contract displays:
 - `Client$`: funds provided by the client.
 - `Contract$`: total funds in the contract.
 
-The difference between these values represents the provider’s earnings, which can be withdrawn using `withdraw <address>`.
+The difference between these values represents the provider's earnings, which can be withdrawn using `withdraw <address>`.
 
 To withdraw from all contracts with at least 1 TON available:
-`withdraw-all`
+```bash
+withdraw-all
+```
 
 To close a specific contract:
-`close-contract <address>`
+```bash
+close-contract <address>
+```
 
-Closing a contract automatically transfers available funds to the main provider contract. The exact process occurs automatically when the client’s balance is depleted. In both cases, the associated bag files will be deleted—unless other active contracts still use them.
+Closing a contract automatically transfers available funds to the main provider contract. The same process occurs automatically when the client's balance is depleted. In both cases, the associated bag files will be deleted—unless other active contracts still use them.
 
 ### Transfer
 
 You can transfer funds from the main smart contract to any address (the amount is specified in nanoTON):
 
-```
+```bash
 send-coins <address> <amount>
 send-coins <address> <amount> --message "Some message"
 ```
 
 :::info
-All _bags_ stored by the provider are available with the command `list` and can be used as usual. To prevent disrupting the provider's operations, do not delete them or use this storage daemon to work with any other _bags_.
+All bags stored by the provider are available with the command `storage-daemon-cli list` and can be used as usual. To avoid disrupting the provider's operations, do not delete them or use this storage daemon to work with any other bags.
 :::
 
 <Feedback />


### PR DESCRIPTION
This PR was generated from branch `split/ai-fixes-big-docs-v3-guidelines-web3-ton-storage-storage-provider.mdx` into `main`.

Changed file(s):
- M: `docs/v3/guidelines/web3/ton-storage/storage-provider.mdx`

Related issues (from issues.normalized.md):
- [ ] **4451. Fix repository links and line anchors**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-provider.mdx?plain=1

Replace the broken SpyCheese constants.fc link with https://github.com/ton-blockchain/ton/blob/master/storage/storage-daemon/smartcont/constants.fc#L4 and update all GitHub source references to the official ton-blockchain/ton repository using blob (not tree) on the master branch so line anchors work and branch usage is consistent.

---

- [ ] **4452. Remove duplicate provider parameters list and standardize style**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-provider.mdx?plain=1

Delete the first “Provider parameters” bullet list and keep the “The output includes the following parameters” list, standardizing punctuation and lowercasing “bag.”

---

- [ ] **4453. Standardize “bag” terminology**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-provider.mdx?plain=1

Use lowercase plain “bag” throughout (no emphasis) except in code or placeholders like <BagID>.

---

- [ ] **4454. Add bash fences for CLI commands**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-provider.mdx?plain=1

Mark all CLI examples with bash and wrap standalone inline commands in fenced bash blocks (e.g., get-provider-params, new-contract-message, deploy-provider, get-provider-info variants, set-provider-config/params, send-coins, withdraw, withdraw-all, close-contract).

---

- [ ] **4455. Fix malformed list after enabling accept**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-provider.mdx?plain=1

Convert the lead sentence into a paragraph and follow with two bullets (or nest them) so only the actions “download and distribute bags” and “generate and submit storage proofs” are list items.

---

- [ ] **4456. Make step 1 verbs parallel**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-provider.mdx?plain=1

Change to “The owner of the provider launches the storage-daemon, deploys the main smart contract, and configures the necessary parameters.”

---

- [ ] **4457. Remove redundancy in “configure the provider configuration”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-provider.mdx?plain=1

Change to “Before activation, configure the provider settings stored in storage-daemon and the on-chain contract parameters.”

---

- [ ] **4458. Use consistent capitalization for “query ID”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-provider.mdx?plain=1

Standardize on “query ID” (lowercase “query,” except at the start of a sentence).

---

- [ ] **4459. Use plural “proofs” where applicable**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-provider.mdx?plain=1

Refer to recurring submissions as “storage proofs” (plural) for accuracy.

---

- [ ] **4460. Clarify sender in client-initiated closure**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-provider.mdx?plain=1

Replace “from the address with any query ID” with wording that specifies the client’s wallet as the sender and that the message may use any query ID.

---

- [ ] **4461. Standardize apostrophes**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-provider.mdx?plain=1

Use straight quotes (') consistently instead of mixing curly and straight apostrophes.

---

- [ ] **4462. Improve “prevent disrupting” phrasing**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-provider.mdx?plain=1

Change to “To avoid disrupting the provider's operations, …”.

---

- [ ] **4463. Use plural “instructions”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-provider.mdx?plain=1

Change “follow the instruction” to “follow the instructions.”

---

- [ ] **4464. Clarify min/max size applies to bag**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-provider.mdx?plain=1

Resolve the “min/max file size” vs bag size ambiguity by renaming to “min bag size”/“max bag size” or by stating explicitly that --min-file-size/--max-file-size set per-bag size limits.

---

- [ ] **4465. Rename section “Using a provider by clients”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-provider.mdx?plain=1

Retitle to “Using a provider” (or “Client usage”) for idiomatic English.

---

- [ ] **4466. Rename section “A request to store”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-provider.mdx?plain=1

Retitle to “Storage request” for clarity.

---

- [ ] **4467. Normalize “from source” wording**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-provider.mdx?plain=1

Use a single form “from source” consistently (not “from sources”/“from the source”).

---

- [ ] **4468. Replace “exact process” with “same process”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-provider.mdx?plain=1

Change “The exact process occurs automatically …” to “The same process occurs automatically …”.

---

- [ ] **4469. Specify tool for the `list` command**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-provider.mdx?plain=1

Clarify that “list” is a storage-daemon-cli command (e.g., “storage-daemon-cli list”).

---

- [ ] **4470. Rephrase “releases the files”**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-provider.mdx?plain=1

Change to “allows retrieval of the files” to avoid implying on-chain file storage.

---

- [ ] **4471. Clarify parameter viewing commands**

https://github.com/ton-community/ton-docs/blob/ee42357f5954f777d7ebd937b2683096da3699bf/docs/v3/guidelines/web3/ton-storage/storage-provider.mdx?plain=1

Explain when to use get-provider-params (on-chain parameters) versus get-provider-info (local daemon state), or standardize on one and note the distinction.

Issues source: `/Users/daniil/Coding/orchestrator/issues.normalized.md`

Generated by `scripts/generate_split_branch_issue_map.py`.