### PR TITLE
Update docs for Tolk v1.1

### DIFF
--- a/docs/v3/documentation/smart-contracts/tolk/changelog.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/changelog.mdx
@@ -4,6 +4,14 @@ import Feedback from '@site/src/components/Feedback';
 
 Once new versions are released, they will be announced on this page.
 
+## v1.1
+
+1. `map<K, V>` — a convenient zero-overhead wrapper over TVM dictionaries
+2. `enum` — group numeric constants into a distinct type
+3. `private` and `readonly` fields in structures
+4. Enhanced overload resolution and partial specialization
+
+
 ## v1.0
 
 1. The magic `lazy` keyword — lazy loading, partial loading, partial updating

--- a/docs/v3/documentation/smart-contracts/tolk/language-guide.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/language-guide.mdx
@@ -9,17 +9,17 @@ import Feedback from "@site/src/components/Feedback";
 ## Table of contents
 
 1. [Basic syntax](#basic-syntax)
-3. [Functions](#functions)
-4. [Variables and types](#variables-and-types)
-5. [Control flow](#control-flow)
-6. [Type system](#type-system)
-7. [Collections](#collections)
-8. [Error handling](#error-handling)
-9. [Structures](#structures)
-10. [Methods](#methods)
-11. [Imports and modules](#imports-and-modules)
-12. [Advanced features](#advanced-features)
-13. [Standard library](#standard-library)
+2. [Functions](#functions)
+3. [Variables and types](#variables-and-types)
+4. [Control flow](#control-flow)
+5. [Type system](#type-system)
+6. [Error handling](#error-handling)
+7. [Structures](#structures)
+8. [Methods](#methods)
+9. [Enums](#enums)
+10. [Imports and modules](#imports-and-modules)
+11. [Advanced features](#advanced-features)
+12. [Standard library](#standard-library)
 
 ## Basic syntax
 
@@ -375,6 +375,24 @@ struct Container<T> {
 var intContainer: Container<int> = { value: 42, isEmpty: false };
 ```
 
+### Field modifiers
+
+* `private` field — accessible only within methods
+* `readonly` field — immutable after object creation
+```tolk
+struct PosInTuple {
+    private readonly t: tuple
+    curIndex: int
+}
+
+fun PosInTuple.last(mutate self) {
+    // `t` is visible only in methods
+    // and can not be modified
+    self.curIndex = self.t.size() - 1;
+}
+```
+
+
 ## Methods
 
 ### Instance methods
@@ -420,30 +438,78 @@ fun builder.storeInt32(mutate self, value: int32): self {
 }
 ```
 
+## Enums
+
+```tolk
+// will be 0 1 2
+enum Color {
+    Red
+    Green
+    Blue
+}
+```
+
+They are:
+- similar to TypeScript/C++ enums
+- distinct type, not just `int`
+- checked on deserialization
+- allowed in `throw` and `assert`
+
+### Enums syntax
+
+Enum members can be separated by `,` or by `;` or by a newline — like struct fields.
+
+Like in TypeScript and C++, you can manually specify a value, the following will be auto-calculated.
+```tolk
+enum Mode {
+    Foo = 256,
+    Bar,        // implicitly 257
+}
+```
+
+### Enums usage: they are distinct types
+
+Since enums are types, you can
+- declare variables and parameters
+- declare methods for an enum
+- use them in struct fields, in unions, in generics, etc.
+
+```tolk
+struct Gradient {
+    from: Color
+    to: Color? = null
+}
+
+fun Color.isRed(self) {
+    return self == Color.Red
+}
+
+var g: Gradient = { from: Color.Blue };
+g.from.isRed();       // false
+```
+
+Enums are integers under the hood. They can be cast to `int` and back with `as` operator.
+
+### Serialization of enums
+
+You can manually specify `:intN`. Otherwise, the compiler will auto-calculate it.
+```tolk
+// will be (un)packed as `int8`
+enum Role1: int8 { Admin, User, Guest }
+
+// will (un)packed as `uint2` (auto-calculated to fit all values)
+enum Color { Red, Green, Blue }
+```
+
+On deserialization, an input value is checked for correctness. E.g., for `Role`, if input&lt;0 or input&gt;2, an exception "5 (integer out of range)" will be thrown.
+
 ## Imports and modules
 
 ### Import syntax
 
 ```tolk
-import "another";
-import "@stdlib/tvm-dicts";
-```
-
-### Standard library
-
-Common functions are available by default:
-
-```tolk
-// Common functions always available
-var time = blockchain.logicalTime();
-```
-
-Some functions require importing specific modules (your IDE will suggest them):
-
-```tolk
-import "@stdlib/tvm-dicts";
-
-var dict = createEmptyDict();
+import "another"
+import "@stdlib/gas-payments"
 ```
 
 ## Advanced features
@@ -586,6 +652,22 @@ reply.send(SEND_MODE_REGULAR);
 ```
 
 Deep dive: [Sending messages](/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx).
+
+
+## Standard library
+
+Common functions are available by default:
+```tolk
+// Common functions always available
+var time = blockchain.logicalTime();
+```
+
+While more specific ones require importing (IDE suggests you):
+```tolk
+import "@stdlib/gas-payments"
+
+var fee = calculateStorageFee(...);
+```
 
 
 <Feedback />

--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx
@@ -326,8 +326,8 @@ fun third<X>(t: tuple): X
     asm "THIRD"
 
 @pure
-fun iDictDeleteGet(dict: cell, keyLen: int, index: int): (cell, slice, int)
-    asm(index dict keyLen) "DICTIDELGET NULLSWAPIFNOT"
+fun builder.storeSlice(mutate self, s: slice): self
+    asm(s self) "STSLICE"
 
 @pure
 fun mulDivFloor(x: int, y: int, z: int): int
@@ -1226,11 +1226,11 @@ All names in the standard library were reconsidered. Now, functions are called u
   <tbody>
     <tr>
       <td>
-        <code dangerouslySetInnerHTML={{__html: 'cur_lt()<br>car(l)<br>get_balance().pair_first()<br>raw_reserve(count)<br>dict~idict_add?(...)<br>dict~udict::delete_get_max()<br>t~tpush(triple(x, y, z))<br>s.slice_bits()<br>~dump(x)<br>...'}} />
+        <code dangerouslySetInnerHTML={{__html: 'cur_lt()<br>car(l)<br>get_balance().pair_first()<br>raw_reserve(count)<br>dict~idict_add?(...)<br>t~tpush(triple(x, y, z))<br>s.slice_bits()<br>~dump(x)<br>...'}} />
       </td>
 
       <td>
-        <code dangerouslySetInnerHTML={{__html: 'blockchain.logicalTime()<br>listGetHead(l)<br>contract.getOriginalBalance()<br>reserveToncoinsOnBalance(count)<br>dict.iDictSetIfNotExists(...)<br>dict.uDictDeleteLastAndGet()<br>t.push([x, y, z])<br>s.remainingBitsCount()<br>debug.print(x)<br>...'}} />
+        <code dangerouslySetInnerHTML={{__html: 'blockchain.logicalTime()<br>listGetHead(l)<br>contract.getOriginalBalance()<br>reserveToncoinsOnBalance(count)<br>dict.addIfNotExists(...)<br>t.push([x, y, z])<br>s.remainingBitsCount()<br>debug.print(x)<br>...'}} />
       </td>
     </tr>
   </tbody>
@@ -1277,16 +1277,14 @@ It works in such a way. Tolk compiler knows how to locate a standard library. If
 Standard library is split into multiple files: `common.tolk` (most common functions), `gas-payments.tolk` (calculating gas fees), `tvm-dicts.tolk`, and others. Functions from `common.tolk` are available always (a compiler implicitly imports it). Other files are needed to be explicitly imported:
 
 ```tolk
-import "@stdlib/tvm-dicts"   // ".tolk" optional
+import "@stdlib/gas-payments"       // ".tolk" optional
 
-...
-var dict = createEmptyDict();
-dict.iDictSet(...);
+var fee = calculateStorageFee(...);
 ```
 
 Mind the rule **import what you use**, it's applied to `@stdlib/...` files also (with the only exception of `common.tolk`).
 
-JetBrains IDE plugin automatically discovers stdlib folder and inserts necessary imports as you type.
+IDE plugins automatically discover the stdlib folder and inserts necessary imports as you type.
 
 ### Logical operators && ||, logical not !
 
@@ -1677,8 +1675,7 @@ i = null;       // error, can't assign `null` to `int`
 i = maybeInt;   // error, can't assign `int?` to `int`
 ```
 
-Such a code will not work. You must **explicitly declare the variable as nullable**::
-
+Such a code will not work. You must **explicitly declare the variable as nullable**:
 ```tolk
 // incorrect
 var i = null;
@@ -1744,23 +1741,6 @@ fun analyzeStorage(nCells: int, lastCell: cell?) {
     if (nCells) {           // then lastCell 100% not null
         doSmth(lastCell!);  // use ! for this fact
     }
-}
-```
-
-In practice, you'll use this operator working with low-level dicts API.
-Tolk will have a high-level `map<K,V>` in the future.
-For now, working with dicts will require the `!` operator.
-
-```tolk
-// it returns either (slice, true) or (null, false)
-@pure
-fun dict.iDictGet(self, keyLen: int, key: int): (slice?, bool)
-    asm(key self keyLen) "DICTIGET" "NULLSWAPIFNOT"
-
-var (cs, exists) = myDict.iDictGet(...);
-// if exists is true, cs is not null
-if (exists) {
-    cs!.loadInt(32);
 }
 ```
 
@@ -2036,6 +2016,30 @@ var d: DefDemo = { f2: 5 };  // ok
 
 Structs can have methods as extension functions, read below.
 
+Fields can have modifiers:
+* `private` field — accessible only within methods
+* `readonly` field — immutable after object creation
+```tolk
+struct PositionInTuple {
+    private readonly t: tuple
+    currentIndex: int
+}
+
+fun PositionInTuple.create(t: tuple): PositionInTuple {
+    // the only way to create an object with a private field
+    // is from a static method (or asm function)
+    return { t, currentIndex: 0 }
+}
+
+fun PositionInTuple.next(mutate self) {
+    // self.t can not be modified: it's readonly
+    self.currentIndex += 1;
+}
+
+var p = PositionInTuple.create(someTuple);
+// p.t is unavailable here: it's private
+```
+
 ### Generic structs and aliases
 
 They exist only at the type level (no runtime cost).
@@ -2204,49 +2208,22 @@ fun T?.isNull(self): bool {
 }
 ```
 
-When you call `someObj.method()`, multiple methods with the same name may exist and theoretically be acceptable:
-
-```tolk
-fun T.copy(self) { ... }
-fun int.copy(self) { ... }
-
-someVar.copy();   // ???
-```
-
-So, the compiler performs matching to find as precise method as follows:
-
-1. Search for exact type receiver like `int.copy` (most practical cases finish here)
-2. Search for non-generic receivers that are acceptable (like `int32.copy` / `int?.copy`)
-3. Search for generic receivers except `T` (like `Container<T>.copy`)
-4. Search for `T` receivers (`T.copy`)
-
+When you call `someObj.method()`, multiple methods are applicable, the compiler chooses the most precise one:
 ```tolk
 fun int.copy(self) { ... }
 fun T.copy(self) { ... }
 
-6.copy()              // int.copy (rule 1)
-(6 as int32).copy()   // int.copy (rule 2)
-(6 as int32?).copy()  // T.copy with T=int? (rule 4)
-```
+6.copy()              // int.copy
+(6 as int32).copy()   // T.copy with T=int32
+(6 as int32?).copy()  // T.copy with T=int?
 
-```tolk
 type MyMessage = CounterIncrement | CounterReset
 fun MyMessage.check() { ... }
 fun CounterIncrement.check() { ... }
 
-MyMessage{...}.check()         // first (rule 1)
-CounterIncrement{...}.check()  // second (rule 1)
-CounterReset{...}.check()      // first (rule 2)
-```
-
-In case of ambiguity, an error is printed:
-
-```tolk
-fun int?.doSmth(self) { ... }
-fun int64.doSmth(self) { ... }
-
-var v: int32;
-v.doSmth();   // error: no exact match, but two possible acceptable receivers
+MyMessage{...}.check()         // first
+CounterIncrement{...}.check()  // second
+CounterReset{...}.check()      // first
 ```
 
 You can assign a generic function to the variable, but you should explicitly specify types:
@@ -2258,6 +2235,168 @@ fun Container<T>.getItem(self) { ... }
 var callable1 = genericFn<slice>;
 var callable2 = Container<int32>.getItem;
 callable2(someContainer32);   // pass it as self
+```
+
+### Enums
+
+```tolk
+// will be 0 1 2
+enum Color {
+    Red
+    Green
+    Blue
+}
+```
+
+They are:
+- similar to TypeScript/C++ enums
+- distinct type, not just `int`
+- checked on deserialization
+- exhaustive in `match`
+
+**Syntax of `enum`**
+
+Enum members can be separated by `,` or by `;` or by a newline — like struct fields.
+
+Like in TypeScript and C++, you can manually specify a value, the following will be auto-calculated.
+```tolk
+enum Mode {
+    Foo = 256,
+    Bar,        // implicitly 257
+}
+```
+
+**Enums are distinct types, not integers**
+
+`Color.Red` is `Color`, not `int`, although it holds a value "0" at runtime.
+
+```tolk
+fun isRed(c: Color) {
+    return c == Color.Red
+}
+
+isRed(Color.Blue)    // ok
+isRed(1)             // error, can not pass `int` to `Color`
+```
+
+Since enums are types, you can
+- declare variables and parameters
+- declare methods for an enum
+- use them in struct fields, in unions, in generics, etc.
+
+```tolk
+struct Gradient {
+    from: Color
+    to: Color? = null
+}
+
+fun Color.isRed(self) {
+    return self == Color.Red
+}
+
+var g: Gradient = { from: Color.Blue };
+g.from.isRed();       // false
+Color.Red.isRed();    // true
+
+match (g.to) {
+    null => ...
+    Color => ...
+}
+```
+
+**Enums are integers under the hood**
+
+An enum, like `Color`, is just `int` at the TVM level. It can be cast back and forth:
+- `Color.Blue as int` (will be 2)
+- `2 as Color` (will be Color.Blue)
+
+Note that using `as` you can reach an invalid enum value. It's undefined behavior: `100 as Color` is a valid syntax, but the program may behave unexpectedly after this point.
+
+Although on deserialization via `fromCell()`, the compiler inserts necessary checks that an encoded integer is a valid enum value.
+
+Note that enums are NOT similar to Rust. In Rust, every member of an enum may have its own shape. In Tolk, we have union types — a more powerful solution. So, enums are just integer constants.
+
+**`match` for enums is exhaustive**
+
+If you use pattern matching, the compiler checks that you've covered all cases.
+```tolk
+match (someColor) {
+    Color.Red => {}
+    Color.Green => {}
+    // error: Color.Blue is missing
+}
+```
+
+You should cover all cases or use `else` to "catch the remaining":
+```tolk
+match (someColor) {
+    Color.Red => {}
+    else => {}
+}
+```
+
+Of course, you can use `==` like for integers and addresses:
+```tolk
+if (someColor == Color.Red) {}
+else {}
+```
+
+Note that `someColor is Color.Red` is invalid syntax: `is` operator is used for types. E.g. if you have `var union: Color | A` and check `u is Color`. So, just `==` for checking values, no surprises.
+
+**Enums are allowed in `throw` and `assert`**
+
+```tolk
+enum Err {
+    InvalidId = 0x100
+    TooHighId
+}
+
+assert (id < 1000) throw Err.TooHighId;  // excno = 257
+```
+
+**Enums and serialization**
+
+Enums can be packed to/from cells like `intN` or `uintN`, where N
+- either specified manually `enum Role: int8 { ... }`
+- or calculated automatically: minimal N to fit all values
+
+_You can manually specify serialization type_:
+```tolk
+// `Role` will be (un)packed as `int8`
+enum Role: int8 {
+    Admin,
+    User,
+    Guest,
+}
+
+struct ChangeRoleMsg {
+    ownerAddress: address
+    newRole: Role    // int8: -128 <= V <= 127
+}
+```
+
+_Or it will be calculated automatically_. For `Role` above — `uint2`, it's enough to fit values "0 1 2".
+```tolk
+// `Role` will (un)packed as `uint2`
+enum Role {
+	Admin,
+	User,
+	Guest,
+}
+```
+
+_On deserialization, an input value is checked for correctness_. Say, you have `enum Role: int8` with "0 1 2" values. Then if input&lt;0 or input&gt;2, an exception "5 (integer out of range)" will be thrown.
+
+This works not only for ranges, but with manually specified enum values, also.
+```tolk
+enum OwnerHashes: uint256 {
+    id1 = 0x1234,
+    id2 = 0x2345,
+    ...
+}
+
+// on serialization, just "store uint256"
+// on deserialization, "load uint256" + throw 5 if v not in [0x1234, 0x2345, ...]
 ```
 
 ### Auto-detect and inline functions
@@ -2372,6 +2511,258 @@ reply.send(SEND_MODE_REGULAR);
 ```
 
 Continue reading on a separate page: [Universal createMessage](/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message).
+
+### Convenient map&lt;K,V&gt; instead of low-level TVM dictionaries
+
+Tolk introduces a convenient way to work with TVM dictionaries:
+- a generic type `map<K, V>` — any serializable keys and values
+- the compiler automatically generates effective asm instructions and performs (de)serialization on demand
+- natural syntax for iterating forwards, backwards, or starting from a specified key
+- absolutely zero overhead compared to low-level approach
+
+**Basic demo: `set`, `exists`, `get`, etc.**
+
+```tolk
+var m: map<int8, int32> = createEmptyMap();
+m.set(1, 10);
+m.addIfNotExists(2, -20);
+m.replaceIfExists(2, 20);
+m.delete(2);   // now: [ 1 => 10 ]
+
+m.exists(1);   // true
+m.exists(2);   // false
+
+val r1 = m.get(1);
+if (r1.isFound) {   // true
+    val v = r1.loadValue();  // 10
+}
+
+val r2 = m.get(2);
+if (r2.isFound) {   // false
+    ...
+}
+
+m.mustGet(1);   // 10
+m.mustGet(2);   // runtime error
+```
+
+**Note: `m.get(key)` returns not "optional value", but "isFound + loadValue()"**
+
+```tolk
+// NOT like this
+var v = m.get(key);
+if (v != null) {
+    // "then v is the value" — NO, not like this
+}
+
+// BUT
+var r = m.get(key);
+if (r.isFound) {
+    val v = r.loadValue();   // this is the value
+}
+```
+
+In other words, `m.get(key)` returns NOT `V?` but a special struct.
+
+If you expect a key to exist, feel free to call `m.mustGet(key)`, it returns `V` and throws on a missing key.
+
+
+**Why "isFound" but not "optional value"?**
+
+TLDR:
+- Gas consumption (zero overhead)
+- Nullable values can be supported, like `map<int32, address?>` or `map<K, Point?>`. Returning `V?`, you can't differ "key exists, value is null" vs "key doesn't exist".
+
+Detailed explanation can be found on GitHub.
+
+**Iterating forward and backward**
+
+There is no special syntax like `foreach` and so on. The principle is simple:
+- find the starting key; most likely, `r = m.findFirst()` or `r = m.findLast()`
+- while `r.isFound`, you:
+    - use `r.getKey()` and `r.loadValue()`
+    - move the cursor: `r = m.iterateNext(r)` or `r = m.iteratePrev(r)`
+
+Example: iterate all keys forward
+```tolk
+// suppose you have a map [ 1 => 10, 2 => 20, 3 => 30 ]
+// this function will print "1 10 2 20 3 30"
+fun iterateAndPrint<K, V>(m: map<K, V>) {
+    var r = m.findFirst();
+    while (r.isFound) {
+        debug.print(r.getKey());
+        debug.print(r.loadValue());
+        r = m.iterateNext(r);
+    }
+}
+```
+
+Example: iterate from key&lt;=2 backward
+```tolk
+// suppose `m` is `[ int => address ]`, already filled
+// for every key<=2, print addr.workchain
+fun printWorkchainsBackwards(m: map<int32, address>) {
+    var r = m.findKeyLessOrEqual(2);
+    while (r.isFound) {
+        val a = r.loadValue();   // it's address
+        debug.print(a.getWorkchain());
+        r = m.iteratePrev(r);
+    }
+}
+```
+
+So, iteration over maps perfectly fits into existing syntax.
+
+**Note: `while (r.isFound)`, not `while (r == null)`**
+
+Similar to `m.get(key)`, when you check existence via `isFound`.
+
+```tolk
+// this is a cursor, it has "isFound" + "getKey()" + "loadValue()"
+// (methods are applicable only if isFound)
+var r = m.findFirst();
+while (r.isFound) {
+    // ... use r.getKey() and r.loadValue()    
+    r = m.iterateNext(r);
+}
+
+// similar to map.get() with "isFound" + "loadValue()"
+var f = m.get(key);
+if (f.isFound) {
+    // ... use f.loadValue()
+}
+```
+
+The reason "why" is the same: zero overhead, no hidden runtime instructions or stack manipulations.
+
+**Note: `m.isEmpty()`, not `m == null`**
+
+Since `map` is a dedicated type, you should **check it via `m.isEmpty()`**, because `m == null` will NOT work. It's quite obvious. Suppose you are writing your own wrapper over dictionaries:
+```tolk
+struct MyMap {
+    tvmDict: cell | null
+}
+
+fun MyMap.isEmpty(self) {}
+```
+
+Then given `var m: MyMap`, you will call `m.isEmpty()`, you will not expect `m == null` to work, right? Same for built-in maps. The compiler will give a warning:
+```text
+variable `m` of type `map<int32, int64>` can never be `null`, this condition is always false
+```
+
+Don't forget about this when transitioning your code from low-level dicts to high-level maps, and pay attention to compiler warnings in the console.
+
+By the way, *a nullable map* is a valid type: `var m: map<...>?`, why not. Now, this variable can be null and not null. When not null, it can hold an empty map or non-empty map. Don't use it in practice, this example just explains why `m == null` doesn't make sense otherwise.
+
+**Allowed types for K and V**
+
+Almost all keys and values are allowed:
+```tolk
+// all these types are valid
+map<int32, Point?>
+map<address, address>
+map<Point, map<int3, bool>>
+map<uint256, Cell<SnakeData>>
+map<bits18, slice>
+```
+
+Although there are some **NOT allowed** types. General rules:
+* a key must be fixed-width with 0 refs
+    - int32, uint64, address, bits256, Point; 
+    - invalid K: int, coins, cell
+* a value must be serializable:
+    - int32, coins, AnyStruct, Cell&lt;AnyStruct&gt; 
+    - invalid V: int, builder
+
+In practice, K is most likely intN/uintN/address, V is any serializable value.
+
+At the TVM level, keys can be numbers or slices. When K is complex (K=Point, for example), the compiler automatically performs (de)serialization to slices.
+```tolk
+struct Point {
+    x: int8
+    y: int8
+}
+
+// the compiler automatically packs Point to a 16-bit slice key
+var m: map<Point, V>
+```
+
+Although if K is a struct with a single intN field, it effectively behaves like a number.
+```tolk
+struct UserId {
+    v: int32
+}
+
+// works equally to K=int32 without extra serialization
+var m: map<UserId, V>
+```
+
+**Full list of methods for maps**
+
+JetBrains IDE and VS Code will gently suggest all methods after dot, most of them are self-explanatory.
+
+<table className="code-remove-bg">
+    <thead>
+    <tr>
+        <th>Function/method and description</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr><td><code>{'createEmptyMap<K, V>(): map<K, V>'}</code></td></tr>
+    <tr><td>Returns an empty typed map.<br/>It's essentially "PUSHNULL", since TVM NULL represents an empty map.</td></tr>
+    <tr><td><code>{'createMapFromLowLevelDict<K, V>(d: dict): map<K, V>'}</code></td></tr>
+    <tr><td>Converts a low-level TVM dictionary to a typed map.<br/>Actually, does nothing: accepts an "optional cell" and returns the same "optional cell", so if you specify key/value types incorrectly, it will fail later, at <code className="inline">map.get</code> and similar.</td></tr>
+    <tr><td><code>{'m.toLowLevelDict(): dict'}</code></td></tr>
+    <tr><td>Converts a high-level map to a low-level TVM dictionary.<br/>Actually, does nothing: returns the same "optional cell".</td></tr>
+    <tr><td><code>{'m.isEmpty(): bool'}</code></td></tr>
+    <tr><td>Checks whether a map is empty (whether a cell is null).<br/>Note: a check <code className="inline">m == null</code> will not work, use <code className="inline">m.isEmpty()</code>.</td></tr>
+    <tr><td><code>{'m.exists(key: K): bool'}</code></td></tr>
+    <tr><td>Checks whether a key exists in a map.</td></tr>
+    <tr><td><code>{'m.get(key: K): MapLookupResult<'+'V'+'>'}</code></td></tr>
+    <tr><td>Gets an element by key.<br/>If not found, does NOT throw, just returns isFound = false.</td></tr>
+    <tr><td><code>{'m.mustGet(key: K, throwIfNotFound: int = 9): V'}</code></td></tr>
+    <tr><td>Gets an element by key and throws if it doesn't exist.</td></tr>
+    <tr><td><code>{'m.set(key: K, value: V): self'}</code></td></tr>
+    <tr><td>Sets an element by key.<br/>Since it returns <code className="inline">self</code>, calls may be chained.</td></tr>
+    <tr><td><code>{'m.setAndGetPrevious(key: K, value: V): MapLookupResult<'+'V'+'>'}</code></td></tr>
+    <tr><td>Sets an element and returns the previous element at that key.<br/>If no previous, isFound = false.</td></tr>
+    <tr><td><code>{'m.replaceIfExists(key: K, value: V): bool'}</code></td></tr>
+    <tr><td>Sets an element only if the key already exists.<br/>Returns whether an element was replaced.</td></tr>
+    <tr><td><code>{'m.replaceAndGetPrevious(key: K, value: V): MapLookupResult<'+'V'+'>'}</code></td></tr>
+    <tr><td>Sets an element only if the key already exists and returns the previous element at that key.</td></tr>
+    <tr><td><code>{'m.addIfNotExists(key: K, value: V): bool'}</code></td></tr>
+    <tr><td>Sets an element only if the key does not exist.<br/>Returns whether an element was added.</td></tr>
+    <tr><td><code>{'m.addOrGetExisting(key: K, value: V): MapLookupResult<'+'V'+'>'}</code></td></tr>
+    <tr><td>Sets an element only if the key does not exist. If exists, returns an old value.</td></tr>
+    <tr><td><code>{'m.delete(key: K): bool'}</code></td></tr>
+    <tr><td>Delete an element at the key.<br/>Returns whether an element was deleted.</td></tr>
+    <tr><td><code>{'m.deleteAndGetDeleted(key: K): MapLookupResult<'+'V'+'>'}</code></td></tr>
+    <tr><td>Delete an element at the key and returns the deleted element.<br/>If not exists, isFound = false.</td></tr>
+    <tr><td><code>{'m.findFirst(): MapEntry<K, V>'}</code></td></tr>
+    <tr><td>Finds the first (minimal) element in a map. If key are integers, it's the minimal integer. If keys are addresses or complex structures (represented as slices), it's lexicographically smallest. For an empty map, just returns isFound = false.</td></tr>
+    <tr><td><code>{'m.findLast(): MapEntry<K, V>'}</code></td></tr>
+    <tr><td>Finds the last (maximal) element in a map. If key are integers, it's the maximal integer. If keys are addresses or complex structures (represented as slices), it's lexicographically largest. For an empty map, just returns isFound = false.</td></tr>
+    <tr><td><code>{'m.findKeyGreater(pivotKey: K): MapEntry<K, V>'}</code></td></tr>
+    <tr><td>Finds an element with key &gt; pivotKey.</td></tr>
+    <tr><td><code>{'m.findKeyGreaterOrEqual(pivotKey: K): MapEntry<K, V>'}</code></td></tr>
+    <tr><td>Finds an element with key &gt;= pivotKey.</td></tr>
+    <tr><td><code>{'m.findKeyLess(pivotKey: K): MapEntry<K, V>'}</code></td></tr>
+    <tr><td>Finds an element with key &lt; pivotKey.</td></tr>
+    <tr><td><code>{'m.findKeyLessOrEqual(pivotKey: K): MapEntry<K, V>'}</code></td></tr>
+    <tr><td>Finds an element with key &lt;= pivotKey.</td></tr>
+    <tr><td><code>{'m.iterateNext(current: MapEntry<K, V>): MapEntry<K, V>'}</code></td></tr>
+    <tr><td>Iterate over a map in ascending order, see demos above.</td></tr>
+    <tr><td><code>{'m.iteratePrev(current: MapEntry<K, V>): MapEntry<K, V>'}</code></td></tr>
+    <tr><td>Iterate over a map in descending order, see demos above.</td></tr>
+    </tbody>
+</table>
+
+**Q: What about augmented hashmaps and prefix dictionaries?**
+
+Since they are extremely rarely used, they are not embedded into the type system.  
+For prefix dicts, import `@stdlib/tvm-dicts` and use asm functions.  
+For augmented hashmaps and merkle proofs, implement your own interaction.
 
 ### Modern onInternalMessage
 

--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx
@@ -56,13 +56,15 @@ get fun currentCounter(): int { ... }
 16. Structures are supported
 17. Generics are supported
 18. Methods (as extension functions) are supported
-19. Trailing comma is supported
-20. Semicolon after the last statement in a block is optional
-21. Fift output contains original .tolk lines as comments
-22. [Auto-packing](/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells) to/from cells — for any types
-23. [Universal createMessage](/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message) to avoid manual cells composition
-24. Auto-detect and inline functions at the compiler level
-25. Various optimizations for gas efficiency
+19. Enums are supported
+20. Trailing comma is supported
+21. Semicolon after the last statement in a block is optional
+22. Fift output contains original .tolk lines as comments
+23. [Auto-packing](/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells) to/from cells — for any types
+24. [Universal createMessage](/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message) to avoid manual cells composition
+25. Convenient `map<K, V>` instead of low-level TVM dictionaries
+26. Auto-detect and inline functions at the compiler level
+27. Various optimizations for gas efficiency
 
 ### Tooling around
 

--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/mutability.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/mutability.mdx
@@ -48,7 +48,7 @@ The goal is to have calls identical to JS and other languages:
   </tr>
   <tr>
     <td><code>{'dict~udict_set(...);'}</code></td>
-    <td><code>{'dict.uDictSet(...);'}</code></td>
+    <td><code>{'dict.set(...);'}</code></td>
   </tr>
   <tr>
     <td><code>{'b~store_uint(x, 32);'}</code></td>

--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx
@@ -60,8 +60,9 @@ For example, if you assign 256 to uint8, asm command "8 STU" will fail with code
 | `(T1, T2)`               | TL-B `(Pair T1 T2)` = one by one         | pack T1 + pack T2                   |
 | `(T1, T2, ...)`          | nested pairs = one by one                | pack T1 + pack T2 + ...             |
 | `SomeStruct`             | fields one by one                        | like a tensor                       |
+| `enum SomeEnum`          | intN or uintN, where N manual or auto    | `enum SomeEnum: int8` for manual    |
 
-- (1) By analogy with `intN`, there is are `bytesN` types. It's just a `slice` under the hood: the type shows how to serialize this slice.
+- (1) By analogy with `intN`, there are `bytesN` types. It's just a `slice` under the hood: the type shows how to serialize this slice.
   By default, before `STSLICE`, the compiler inserts runtime checks (get bits/refs count + compare with N + compare with 0).
   These checks ensure that serialized binary data will be correct, but they cost gas.
   However, if you guarantee that a slice is valid (for example, it comes from trusted sources), pass an option `skipBitsNValidation` to disable runtime checks.

--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/stdlib.mdx
@@ -189,63 +189,63 @@ Note: FunC uses snake_case names (for example, `begin_cell`), while Tolk methods
 | list_next                         | listNext                           | lisp-lists      |
 | car                               | listGetHead                        | lisp-lists      |
 | cdr                               | listGetTail                        | lisp-lists      |
-| new_dict                          | createEmptyDict                    | tvm-dicts       |
-| dict_empty?(d) or dot             | d.dictIsEmpty                      | tvm-dicts       |
-| idict_set_ref                     | iDictSetRef                        | tvm-dicts       |
-| udict_set_ref                     | uDictSetRef                        | tvm-dicts       |
-| idict_get_ref                     | iDictGetRefOrNull                  | tvm-dicts       |
-| idict_get_ref?                    | iDictGetRef                        | tvm-dicts       |
-| udict_get_ref?                    | uDictGetRef                        | tvm-dicts       |
-| idict_set_get_ref                 | iDictSetAndGetRefOrNull            | tvm-dicts       |
-| udict_set_get_ref                 | iDictSetAndGetRefOrNull            | tvm-dicts       |
-| idict_delete?                     | iDictDelete                        | tvm-dicts       |
-| udict_delete?                     | uDictDelete                        | tvm-dicts       |
-| idict_get?                        | iDictGet                           | tvm-dicts       |
-| udict_get?                        | uDictGet                           | tvm-dicts       |
-| idict_delete_get?                 | iDictDeleteAndGet                  | tvm-dicts       |
-| udict_delete_get?                 | uDictDeleteAndGet                  | tvm-dicts       |
-| udict_set                         | uDictSet                           | tvm-dicts       |
-| idict_set                         | iDictSet                           | tvm-dicts       |
-| dict_set                          | sDictSet                           | tvm-dicts       |
-| udict_add?                        | uDictSetIfNotExists                | tvm-dicts       |
-| udict_replace?                    | uDictSetIfExists                   | tvm-dicts       |
-| idict_add?                        | iDictSetIfNotExists                | tvm-dicts       |
-| idict_replace?                    | iDictSetIfExists                   | tvm-dicts       |
-| udict_set_builder                 | uDictSetBuilder                    | tvm-dicts       |
-| idict_set_builder                 | iDictSetBuilder                    | tvm-dicts       |
-| dict_set_builder                  | sDictSetBuilder                    | tvm-dicts       |
-| udict_add_builder?                | uDictSetBuilderIfNotExists         | tvm-dicts       |
-| udict_replace_builder?            | uDictSetBuilderIfExists            | tvm-dicts       |
-| idict_add_builder?                | iDictSetBuilderIfNotExists         | tvm-dicts       |
-| idict_replace_builder?            | iDictSetBuilderIfExists            | tvm-dicts       |
-| udict_delete_get_min              | uDictDeleteFirstAndGet             | tvm-dicts       |
-| idict_delete_get_min              | iDictDeleteFirstAndGet             | tvm-dicts       |
-| dict_delete_get_min               | sDictDeleteFirstAndGet             | tvm-dicts       |
-| udict_delete_get_max              | uDictDeleteLastAndGet              | tvm-dicts       |
-| idict_delete_get_max              | iDictDeleteLastAndGet              | tvm-dicts       |
-| dict_delete_get_max               | sDictDeleteLastAndGet              | tvm-dicts       |
-| udict_get_min?                    | uDictGetFirst                      | tvm-dicts       |
-| udict_get_max?                    | uDictGetLast                       | tvm-dicts       |
-| udict_get_min_ref?                | uDictGetFirstAsRef                 | tvm-dicts       |
-| udict_get_max_ref?                | uDictGetLastAsRef                  | tvm-dicts       |
-| idict_get_min?                    | iDictGetFirst                      | tvm-dicts       |
-| idict_get_max?                    | iDictGetLast                       | tvm-dicts       |
-| idict_get_min_ref?                | iDictGetFirstAsRef                 | tvm-dicts       |
-| idict_get_max_ref?                | iDictGetLastAsRef                  | tvm-dicts       |
-| udict_get_next?                   | uDictGetNext                       | tvm-dicts       |
-| udict_get_nexteq?                 | uDictGetNextOrEqual                | tvm-dicts       |
-| udict_get_prev?                   | uDictGetPrev                       | tvm-dicts       |
-| udict_get_preveq?                 | uDictGetPrevOrEqual                | tvm-dicts       |
-| idict_get_next?                   | iDictGetNext                       | tvm-dicts       |
-| idict_get_nexteq?                 | iDictGetNextOrEqual                | tvm-dicts       |
-| idict_get_prev?                   | iDictGetPrev                       | tvm-dicts       |
-| idict_get_preveq?                 | iDictGetPrevOrEqual                | tvm-dicts       |
-| udict::delete_get_min             | uDictDeleteFirstAndGet             | tvm-dicts       |
-| idict::delete_get_min             | iDictDeleteFirstAndGet             | tvm-dicts       |
-| dict::delete_get_min              | sDictDeleteFirstAndGet             | tvm-dicts       |
-| udict::delete_get_max             | uDictDeleteLastAndGet              | tvm-dicts       |
-| idict::delete_get_max             | iDictDeleteLastAndGet              | tvm-dicts       |
-| dict::delete_get_max              | sDictDeleteLastAndGet              | tvm-dicts       |
+| new_dict                          | createEmptyMap                     |                 |
+| dict_empty?(d) or dot             | m.isEmpty                          |                 |
+| idict_set_ref                     | use native maps                    |                 |
+| udict_set_ref                     | use native maps                    |                 |
+| idict_get_ref                     | use native maps                    |                 |
+| idict_get_ref?                    | use native maps                    |                 |
+| udict_get_ref?                    | use native maps                    |                 |
+| idict_set_get_ref                 | use native maps                    |                 |
+| udict_set_get_ref                 | use native maps                    |                 |
+| idict_delete?                     | use native maps                    |                 |
+| udict_delete?                     | use native maps                    |                 |
+| idict_get?                        | use native maps                    |                 |
+| udict_get?                        | use native maps                    |                 |
+| idict_delete_get?                 | use native maps                    |                 |
+| udict_delete_get?                 | use native maps                    |                 |
+| udict_set                         | use native maps                    |                 |
+| idict_set                         | use native maps                    |                 |
+| dict_set                          | use native maps                    |                 |
+| udict_add?                        | use native maps                    |                 |
+| udict_replace?                    | use native maps                    |                 |
+| idict_add?                        | use native maps                    |                 |
+| idict_replace?                    | use native maps                    |                 |
+| udict_set_builder                 | use native maps                    |                 |
+| idict_set_builder                 | use native maps                    |                 |
+| dict_set_builder                  | use native maps                    |                 |
+| udict_add_builder?                | use native maps                    |                 |
+| udict_replace_builder?            | use native maps                    |                 |
+| idict_add_builder?                | use native maps                    |                 |
+| idict_replace_builder?            | use native maps                    |                 |
+| udict_delete_get_min              | use native maps                    |                 |
+| idict_delete_get_min              | use native maps                    |                 |
+| dict_delete_get_min               | use native maps                    |                 |
+| udict_delete_get_max              | use native maps                    |                 |
+| idict_delete_get_max              | use native maps                    |                 |
+| dict_delete_get_max               | use native maps                    |                 |
+| udict_get_min?                    | use native maps                    |                 |
+| udict_get_max?                    | use native maps                    |                 |
+| udict_get_min_ref?                | use native maps                    |                 |
+| udict_get_max_ref?                | use native maps                    |                 |
+| idict_get_min?                    | use native maps                    |                 |
+| idict_get_max?                    | use native maps                    |                 |
+| idict_get_min_ref?                | use native maps                    |                 |
+| idict_get_max_ref?                | use native maps                    |                 |
+| udict_get_next?                   | use native maps                    |                 |
+| udict_get_nexteq?                 | use native maps                    |                 |
+| udict_get_prev?                   | use native maps                    |                 |
+| udict_get_preveq?                 | use native maps                    |                 |
+| idict_get_next?                   | use native maps                    |                 |
+| idict_get_nexteq?                 | use native maps                    |                 |
+| idict_get_prev?                   | use native maps                    |                 |
+| idict_get_preveq?                 | use native maps                    |                 |
+| udict::delete_get_min             | use native maps                    |                 |
+| idict::delete_get_min             | use native maps                    |                 |
+| dict::delete_get_min              | use native maps                    |                 |
+| udict::delete_get_max             | use native maps                    |                 |
+| idict::delete_get_max             | use native maps                    |                 |
+| dict::delete_get_max              | use native maps                    |                 |
 | pfxdict_get?                      | prefixDictGet                      | tvm-dicts       |
 | pfxdict_set?                      | prefixDictSet                      | tvm-dicts       |
 | pfxdict_delete?                   | prefixDictDelete                   | tvm-dicts       |
@@ -285,20 +285,15 @@ you can quickly wrap any TVM instruction yourself.
     <td><code>{'var flags = cs.loadUint(32);'}</code></td>
   </tr>
   <tr>
-    <td><code>{'dict~udict_set(...);'}</code></td>
-    <td><code>{'dict.uDictSet(...);'}</code></td>
-  </tr>
-  <tr>
     <td>...</td>
     <td>...</td>
   </tr>
   </tbody>
 </table>
 
-Most FunC functions used with `~` tilda in practice now mutate the object; see examples above.
-
-For example, if you used `dict~udict_set(…)`, just use `dict.uDictSet(…)`, and everything is fine. 
-But if you used `dict.udict_set(…)` to obtain a copy, you'll need to express it another way.
+Most FunC functions used with `~` tilda in practice now mutate the object.
+For example, if you used `cs~load_uint(…)`, just use `cs.loadUint(…)`, and everything is fine. 
+But if you used `cs.load_uint(…)` to obtain a copy, you'll need to express it another way.
 
 [Read about mutability](/v3/documentation/smart-contracts/tolk/tolk-vs-func/mutability).
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1391,7 +1391,7 @@ table.cmp-func-tolk-table:not(.different-col-widths) th {
   width: 50%;
 }
 
-table.cmp-func-tolk-table code:not(.inline) {
+table.cmp-func-tolk-table code:not(.inline), table.code-remove-bg code:not(.inline) {
   display: block;
   padding: 0 3px;
   background: transparent;

--- a/src/theme/prism/prism-tolk.js
+++ b/src/theme/prism/prism-tolk.js
@@ -18,11 +18,11 @@
       }
     ],
 
-    'type-hint': /\b(enum|int|cell|void|never|bool|slice|tuple|builder|continuation|coins|int8|int16|int32|int64|uint8|uint16|uint32|uint64|uint256|bytes16|bytes32|bytes64|bits8|bits16|bits32|bits64|bits128|bits256|address)\b/,
+    'type-hint': /\b(int|cell|void|never|bool|slice|tuple|builder|continuation|coins|int8|int16|int32|int64|uint8|uint16|uint32|uint64|uint256|bytes16|bytes32|bytes64|bits8|bits16|bits32|bits64|bits128|bits256|address|map)\b/,
 
     'boolean': /\b(false|true|null)\b/,
 
-    'keyword': /\b(do|if|as|is|try|else|while|break|throw|catch|return|assert|repeat|continue|asm|builtin|import|export|true|false|null|redef|mutate|tolk|global|const|var|val|fun|get|struct|match|type|lazy)\b/,
+    'keyword': /\b(do|if|as|is|try|else|while|break|throw|catch|return|assert|repeat|continue|asm|builtin|import|export|true|false|null|redef|mutate|tolk|global|const|var|val|fun|get\sfun|struct|match|type|lazy|enum|private|readonly)\b/,
 
     'self': /\b(self)\b/,
 


### PR DESCRIPTION
## Description

Update documentation for Tolk Language according to changes in Tolk v1.1.

* https://github.com/ton-blockchain/ton/pull/1795

### Notable changes in Tolk v1.1:

1 `map<K, V>` — a convenient zero-overhead wrapper over TVM dictionaries
2. `enum` — group numeric constants into a distinct type
3. `private` and `readonly` fields in structures
4. Enhanced overload resolution and partial specialization

Closes #1754 

## Checklist

- [x] I have created an issue.
- [x] I am working on content that aligns with the [Style guide](https://docs.ton.org/v3/contribute/style-guide/).
- [x] I have reviewed and formatted the content according to [Content standardization](https://docs.ton.org/v3/contribute/content-standardization/).
- [x] I have reviewed and formatted the text in the article according to [Typography](https://docs.ton.org/v3/contribute/typography/).
