### PR TITLE
replacing the deprecated `VS Code` extension `FunC Language Support` with the new `TON`

### DIFF
--- a/i18n/ru/docusaurus-plugin-content-docs/current/v3/documentation/archive/compile.mdx
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/v3/documentation/archive/compile.mdx
@@ -42,7 +42,7 @@ npm create ton@latest
 ### Требования
 
 - [Node.js](https://nodejs.org) последней версии, например, v18, проверьте версию с помощью `node -v`
-- IDE с поддержкой TypeScript и FunC, например [Visual Studio Code](https://code.visualstudio.com/) с [плагином FunC](https://marketplace.visualstudio.com/items?itemName=tonwhales.func-vscode)
+- IDE с поддержкой TypeScript и FunC, например [Visual Studio Code](https://code.visualstudio.com/) с [плагином TON](https://marketplace.visualstudio.com/items?itemName=ton-core.vscode-ton)
 
 ### Как использовать?
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/v3/documentation/smart-contracts/getting-started/ide-plugins.mdx
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/v3/documentation/smart-contracts/getting-started/ide-plugins.mdx
@@ -23,8 +23,8 @@
 
 Visual Studio Code — это бесплатная и популярная IDE для разработчиков.
 
-- [Ссылка на маркетплейс](https://marketplace.visualstudio.com/items?itemName=tonwhales.func-vscode)
-- [Репозиторий GitHub](https://github.com/ton-foundation/vscode-func)
+- [Ссылка на маркетплейс](https://marketplace.visualstudio.com/items?itemName=ton-core.vscode-ton)
+- [Репозиторий GitHub](https://github.com/ton-blockchain/ton-language-server)
 
 ## Плагин FunC для Sublime Text
 

--- a/i18n/ru/docusaurus-plugin-content-docs/current/v3/documentation/smart-contracts/getting-started/javascript.mdx
+++ b/i18n/ru/docusaurus-plugin-content-docs/current/v3/documentation/smart-contracts/getting-started/javascript.mdx
@@ -39,7 +39,7 @@ npm create ton@latest
 ### Требования
 
 - [Node.js](https://nodejs.org/) с последней версией, например v18, проверьте версию с помощью `node -v`
-- IDE с поддержкой TypeScript и FunC, например [Visual Studio Code](https://code.visualstudio.com/) с [плагином FunC](https://marketplace.visualstudio.com/items?itemName=tonwhales.func-vscode)
+- IDE с поддержкой TypeScript и FunC, например [Visual Studio Code](https://code.visualstudio.com/) с [плагином TON](https://marketplace.visualstudio.com/items?itemName=ton-core.vscode-ton)
 
 ## Ссылки
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/v3/documentation/archive/compile.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/v3/documentation/archive/compile.mdx
@@ -38,7 +38,7 @@ npm create ton@latest
 ### 要求
 
 - [Node.js](https://nodejs.org)的最新版本，如v18，使用`node -v`验证版本
-- 支持TypeScript和FunC的IDE，如[Visual Studio Code](https://code.visualstudio.com/)，配备[FunC插件](https://marketplace.visualstudio.com/items?itemName=tonwhales.func-vscode)
+- 支持TypeScript和FunC的IDE，如[Visual Studio Code](https://code.visualstudio.com/)，配备[TON插件](https://marketplace.visualstudio.com/items?itemName=ton-core.vscode-ton)
 
 ### 如何使用？
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/v3/documentation/smart-contracts/getting-started/ide-plugins.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/v3/documentation/smart-contracts/getting-started/ide-plugins.mdx
@@ -19,8 +19,8 @@
 
 Visual Studio Code 是开发者的免费且受欢迎的 IDE。
 
-- [Marketplace 链接](https://marketplace.visualstudio.com/items?itemName=tonwhales.func-vscode)
-- [GitHub 代码库](https://github.com/ton-foundation/vscode-func)
+- [Marketplace 链接](https://marketplace.visualstudio.com/items?itemName=ton-core.vscode-ton)
+- [GitHub 代码库](https://github.com/ton-blockchain/ton-language-server)
 
 ## FunC Sublime Text 插件
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/v3/documentation/smart-contracts/getting-started/javascript.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/v3/documentation/smart-contracts/getting-started/javascript.mdx
@@ -35,7 +35,7 @@ npm create ton@latest
 ### 要求
 
 - [Node.js](https://nodejs.org/) 使用像v18这样的近期版本，用`node -v`验证版本
-- 支持TypeScript和FunC的IDE，如[Visual Studio Code](https://code.visualstudio.com/)，配合[FunC插件](https://marketplace.visualstudio.com/items?itemName=tonwhales.func-vscode)
+- 支持TypeScript和FunC的IDE，如[Visual Studio Code](https://code.visualstudio.com/)，配合[FunC插件](https://marketplace.visualstudio.com/items?itemName=ton-core.vscode-ton)
 
 ## 参考资料
 


### PR DESCRIPTION
## Description

The `FunC Language Support` extension and the repository itself are declared deprecated. I have replaced the old `FunC Language Support` extension with the new `TON`.

See: https://github.com/ton-blockchain/ton-language-server/issues/167

## Checklist

- [ ] I have created an issue.
- [x] I am working on content that aligns with the [Style guide](https://docs.ton.org/v3/contribute/style-guide/).
- [x] I have reviewed and formatted the content according to [Content standardization](https://docs.ton.org/v3/contribute/content-standardization/).
- [x] I have reviewed and formatted the text in the article according to [Typography](https://docs.ton.org/v3/contribute/typography/).
