### PR TITLE
docs: add note about HTTPS requirement for TonConnect manifest

### DIFF
--- a/docs/v3/guidelines/ton-connect/quick-start.mdx
+++ b/docs/v3/guidelines/ton-connect/quick-start.mdx
@@ -17,6 +17,13 @@ import Feedback from '@site/src/components/Feedback';
 
 ## Create a manifest
 
+:::note
+TonConnect can run on `localhost`, but the app manifest must be accessible over the public internet via **HTTPS**.  
+All URLs in the manifest, such as `url` and `icons`, must also be publicly available.  
+
+For more information, see the [local development guide](https://github.com/ton-connect/sdk/blob/main/guidelines/work-with-localhost.md).
+:::
+
 A TON Connect *manifest* is a small JSON file that lets wallets discover your DApp:
 
 ```jsonc


### PR DESCRIPTION
## Description

Added a note in the TonConnect documentation explaining that while TonConnect can run on `localhost`, 
the app manifest and its URLs must be accessible over HTTPS.  

This clarification helps developers avoid connection issues during local development.  
References: [TonConnect localhost guidelines](https://github.com/ton-connect/sdk/blob/main/guidelines/work-with-localhost.md)

Closes #1776 

## Checklist

- [x] I have created an issue.
- [x] I am working on content that aligns with the [Style guide](https://docs.ton.org/v3/contribute/style-guide/).
- [x] I have reviewed and formatted the content according to [Content standardization](https://docs.ton.org/v3/contribute/content-standardization/).
- [x] I have reviewed and formatted the text in the article according to [Typography](https://docs.ton.org/v3/contribute/typography/).
