### PR TITLE
Add dRPC NodeCloud to TON RPC providers section 

### DIFF
--- a/docs/v3/guidelines/dapps/apis-sdks/api-types.mdx
+++ b/docs/v3/guidelines/dapps/apis-sdks/api-types.mdx
@@ -27,6 +27,7 @@ We recommend integrating at least 2 providers for production environment.
 - [GetBlock](https://getblock.io/nodes/ton/) (see a [tutorial](/v3/guidelines/dapps/apis-sdks/getblock-ton-api))
 - [Chainbase](https://chainbase.com/)
 - [NowNodes](https://nownodes.io/nodes/ton)
+- [dRPC NodeCloud](https://drpc.org/chainlist/ton-mainnet-rpc)
 
 ### Own instance
 


### PR DESCRIPTION

## Description

Added dRPC NodeCloud as an RPC provider for the TON ecosystem under the Providers section.
Webpage: https://drpc.org/chainlist/ton

## Checklist

- [x ] I have created an issue.
- [ x] I am working on content that aligns with the [Style guide](https://docs.ton.org/v3/contribute/style-guide/).
- [ x] I have reviewed and formatted the content according to [Content standardization](https://docs.ton.org/v3/contribute/content-standardization/).
- [ x] I have reviewed and formatted the text in the article according to [Typography](https://docs.ton.org/v3/contribute/typography/).
