### PR TITLE
Update docs for Tolk v1.2

### DIFF
--- a/docs/v3/documentation/smart-contracts/tolk/changelog.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/changelog.mdx
@@ -4,6 +4,15 @@ import Feedback from '@site/src/components/Feedback';
 
 Once new versions are released, they will be announced on this page.
 
+## v1.2
+
+1. Breaking change: `address` is now "internal only" ([details and migration](https://github.com/ton-blockchain/ton/pull/1886))
+2. Rich bounces: not 256 bits, but the full body on bounce
+3. Cheap builder-to-slice, StateInit, and address composition
+4. Compilation errors significantly improved
+5. Anonymous functions supported
+6. Borrow checker and other stuff related to undefined behavior
+
 ## v1.1
 
 1. `map<K, V>` — a convenient zero-overhead wrapper over TVM dictionaries

--- a/docs/v3/documentation/smart-contracts/tolk/language-guide.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/language-guide.mdx
@@ -178,7 +178,8 @@ repeat (10) {
 - `cell` - a TVM cell
 - `slice` - a TVM slice; you can also use `bitsN`. (e.g. `bits512` for storing a signature)
 - `builder` - a TVM builder
-- `address` - blockchain address
+- `address` - internal (standard) address
+- `any_address` — internal/external/none address
 - `coins` - Toncoin or coin amounts
 - `void` - no return value
 - `never` -  function never returns (always throws an exception)
@@ -285,10 +286,7 @@ A dedicated type for blockchain addresses:
 
 ```tolk
 val addr = address("EQDKbjIcfM6ezt8KjKJJLshZJJSqX7XOA4ff-W72r5gqPrHF");
-
-if (addr.isInternal()) {
-    var workchain = addr.getWorkchain();
-}
+val workchain = addr.getWorkchain();
 ```
 
 ## Tensors
@@ -643,7 +641,7 @@ Create messages using a high-level syntax:
 
 ```tolk
 val reply = createMessage({
-    bounce: false,
+    bounce: BounceMode.NoBounce,
     value: ton("0.05"),
     dest: senderAddress,
     body: RequestedInfo { ... }

--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/create-message.mdx
@@ -6,7 +6,7 @@ In FunC, you had to compose message cells manually and regularly face code like:
 
 ```func
 cell m = begin_cell()
-    .store_uint(0x18, 6)
+    .store_uint(0x10, 6)
     .store_slice(sender_address)
     .store_coins(50000000)
     .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
@@ -21,7 +21,7 @@ In Tolk, you use a high-level function — and it's even more gas-effective:
 
 ```tolk
 val reply = createMessage({
-    bounce: true,
+    bounce: BounceMode.NoBounce,
     value: ton("0.05"),
     dest: senderAddress,
     body: RequestedInfo { ... }
@@ -94,7 +94,7 @@ dest: someAddress,
 dest: (workchain, hash)
 ```
 
-It's either an address, OR a OR (WorkChain + hash), OR ...:
+It's either an address, OR (WorkChain + hash), OR ...:
 
 ```tolk
 struct CreateMessageOptions<TBody> {
@@ -310,26 +310,26 @@ If you don't need any `body` at all, just leave it out:
 
 ```tolk
 createMessage({
-    bounce: true,
+    bounce: BounceMode.NoBounce,
     dest: somewhere,
     value: remainingBalance
 });
 ```
 
-A curious reader might ask, "what's the type of `body` here? How is it expressed in the type system?" The answer is: `never`.
+A curious reader might ask, "what's the type of `body` here? How is it expressed in the type system?" The answer is: `void`.
 
 Actually, `CreateMessageOptions` is declared like this:
 
 ```tolk
 // declared in stdlib
-struct CreateMessageOptions<TBody = never> {
+struct CreateMessageOptions<TBody = void> {
     ...
     body: TBody;
 }
 ```
 
-Hence, when we miss `body` in `createMessage`, it leads to the default `TBody = never`.
-And by convention, fields having `never` type are not required in a literal.
+Hence, when we miss `body` in `createMessage`, it leads to the default `TBody = void`.
+And by convention, fields having `void` type are not required in a literal.
 It's not that obvious, but it is definitely beautiful.
 
 ## Don't confuse StateInit and code+data, they are different
@@ -421,9 +421,9 @@ emitMsg.send(SEND_MODE_REGULAR);
 **Available options for external-out messages** are only `dest` and `body`, actually:
 
 ```tolk
-struct CreateExternalLogMessageOptions<TBody = never> {
+struct CreateExternalLogMessageOptions<TBody = void> {
     /// destination is either an external address or a pattern to calculate it
-    dest: address |         // either some valid external/none address (not internal!)
+    dest: any_address |     // either some valid external/none address (not internal!)
           builder |         // ... or a manually constructed builder with a valid external address
           ExtOutLogBucket;  // ... or encode topic/eventID in destination
     

--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-detail.mdx
@@ -685,7 +685,8 @@ We have the following types:
 - `coins` and function `ton("0.05")`
 - `int32`, `uint64`, and other fixed-width integers (just int at TVM) [details](https://github.com/ton-blockchain/ton/pull/1559)
 - `bytesN` and `bitsN`, similar to `intN` (backed by slices at TVM)
-- `address` (internal/external/none, still a slice at TVM)
+- `address` (internal (standard) address, still a slice at TVM)
+- `any_address` (internal/external/none)
 - `void` (more canonical to be named `unit`, but `void` is more reliable)
 - `self`, to make chainable methods, described below; actually it's not a type, it can only occur instead of return type of a function
 - `never` (an always-throwing function returns `never`, for example; an _impossible type_ is also `never`)
@@ -815,6 +816,77 @@ return tupleLast(t);       // ok if function specifies return type
 ```
 
 Also note that `T` for asm functions must occupy one stack slot, whereas for a user-defined function, `T` could be of any shape. Otherwise, asm body is unable to handle it properly.
+
+### Anonymous functions (lambdas)
+
+You can use lambdas — function expressions, without capturing outer variables. They can be passed as callbacks, assigned to variables, etc.
+
+```tolk
+fun callAndAssertTrue(callback: () -> bool) {
+    val result = callback();
+    assert (result == true) throw 123;
+}
+
+callAndAssertTrue(fun() {   // lambda
+    ...
+    return ...;
+});
+```
+
+Unlike regular functions, where you must specify all parameters types, lambda parameters types may be omitted if they can be inferred:
+```tolk
+fun Result.pushMath(mutate self, loadFn: (int, slice) -> int) {
+    val ans = mathFn(32, "...");
+    self.output.push(ans);
+}
+
+r.pushMath(fun(bits, s) {    // bits is `int`, s is `slice`
+    return s.loadUint(bits)
+});
+
+// but it's an error: param's type cannot be inferred here:
+val doubleFn = fun(param) { return param * 2 };
+// correct is:
+val doubleFn = fun(param: int) { return param * 2 };
+```
+
+From the type system point of view, a function (and a lambda) has a special type `(...ArgsT) -> ReturnT`.
+
+```tolk
+// a regular function
+fun abs(a: int): int { ... }
+
+val cb1 = abs;                           // (int) -> int
+val cb2 = fun(a: coins): MyData { ... }; // (coins) -> MyData 
+val cb3 = fun(a: slice) {};              // (slice) -> void
+```
+
+As first-class functions, lambdas can even be returned:
+```tolk
+fun createFinalizer() {
+    return fun(b: builder) {
+        b.storeUint(0xFFFFFFFF, 32);
+        return b.toSlice();
+    }
+}
+
+val f = createFinalizer();    // (builder) -> slice
+f(beginCell());               // slice with 32 bits
+```
+
+While lambdas are not common in smart contracts, they become useful in general purpose tools. 
+They can easily be combined with generics of any level, nested into each other, and so on.
+
+Note that lambdas are not closures: capturing outer variables not supported.
+```tolk
+fun outer(x: int) {
+    return fun(y: int) {
+        return x + y;    // error: undefined symbol `x`
+    }
+}
+```
+
+Capturing variables is nearly impossible to implement on a stack machine, just like inheritance (conceptually equivalent).
 
 ### #include → import. Strict imports
 
@@ -1557,22 +1629,20 @@ globalTuple.1.2 += 10;  // "GETGLOB" + ... + "SETGLOB"
 
 ### Type address
 
-In TVM, all **binary data** is just **a slice.** Same goes for addresses: while TL-B describes the entity `MsgAddress` (internal/external/none/var address),
-
-and TVM assembler has instructions to load/validate addresses, nevertheless: at the low level, it's just a slice.
+In TVM, all **binary data** is just **a slice.** Same goes for addresses: while TL-B describes the entity `MsgAddress`, at the TVM level, it's just a slice.
 That's why in FunC's standard library `loadAddress` returned `slice`, and `storeAddress` accepted `slice`.
 
-Tolk introduces the dedicated `address` type. It's still a TVM slice at runtime (internal/external/none),
+Tolk introduces the dedicated `address` type meaning "internal address". It's still a TVM slice at runtime,
 but it differs from an **abstract slice** from the type system point of view:
 
-1. Integrated with auto-serialization: compiler knows how to pack/unpack it (`LDMSGADDR` and `STSLICE`)
+1. Integrated with auto-serialization: compiler knows how to pack/unpack it (`LDSTDADDR` and `STSTDADDR`)
 2. Comparable: operators `==` and `!=` work on addresses:
 
 ```tolk
 if (senderAddress == msg.owner)
 ```
 
-3. Introspectable: `address.isNone()`, `address.isInternal()`, `address.isExternal()`, `address.getWorkchain()` and `address.getWorkchainAndHash()` (valid for internal addresses)
+3. Introspectable: `address.getWorkchain()` and `address.getWorkchainAndHash()`
 
 Passing a slice instead leads to an error:
 
@@ -1580,9 +1650,11 @@ Passing a slice instead leads to an error:
 var a: slice = s.loadAddress();  // error, can not assign `address` to `slice`
 ```
 
+There is also a type `any_address` to store internal/external/none.
+
 **Embedding a const address into a contract**
 
-Use the built-in `address()` function, which accepts a standard address. In FunC, there was a postfix `"..."a` that returned a slice.
+Use the built-in `address()` function. In FunC, there was a postfix `"..."a` that returned a slice.
 
 ```tolk
 address("EQCRDM9h4k3UJdOePPuyX40mCgA4vxge5Dc5vjBR8djbEKC5")
@@ -1612,20 +1684,16 @@ According to a standard, there are different types of addresses. The most freque
 - `01` (**external** prefix) + len (9 bits) + len bits — external addresses
 - `00` (**none** prefix) — address **none**, 2 bits
 
-The `address` type can hold any of these. Most often, it's an internal address. But the type system does not restrict it exactly: this can't be done without heavy runtime checks.
+**`address` is "internal only"** (90% use cases).  
+**`address?` (nullable) is "internal/none"** (9% use cases).  
+**`any_address` is "internal/external/none"** (1% use cases).
 
-So, if `address` comes from an untrusted input, you should probably validate it:
+Remember that `address` is (WorkChain + hash). When it comes from untrusted input, you should probably validate it:
 
 ```tolk
 val newOwner = msg.nextOwnerAddress;
-assert(newOwner.isInternal()) throw 403;
 assert(newOwner.getWorkchain() == BASECHAIN) throw 403;
 ```
-
-All in all, if you don't trust inputs — you should validate everything: numbers, payload, and addresses particularly.
-But if an input comes from a trusted source (your own contract storage, for example) — of course, you can rely on its contents.
-The compiler does not insert hidden instructions.
-Just remember, that `address` in general can hold all valid types.
 
 ### Type aliases type NewName = \<existing type>
 
@@ -2502,7 +2570,7 @@ No more manual `beginCell().storeUint(...).storeRef(...)` boilerplate. Just desc
 
 ```tolk
 val reply = createMessage({
-    bounce: false,
+    bounce: BounceMode.NoBounce,
     value: ton("0.05"),
     dest: senderAddress,
     body: RequestedInfo { ... }
@@ -2850,17 +2918,31 @@ fun onInternalMessage(in: InMessage) {
 }
 ```
 
-**Remember about 256 bits on bounces**
+**Bounced body is either "first 256 bits" or "the entire body"**
 
-Currently, TON Blockchain works in such a way that when a message is bounced, only the first 256 bits are present, starting with 0xFFFFFFFF ("bounced prefix"). That's why you manually control which fields you can read (they fit the rest of the 224 bits) and which do not.
+When you use `createMessage`, its parameter `bounce` is an enum:
+* `BounceMode.NoBounce`
+* `BounceMode.Only256BitsOfBody` — `in.bouncedBody` will be "0xFFFFFFFF" + first 256 bits of original body (cheapest)
+* `BounceMode.RichBounce` — parse `in.bouncedBody` with `RichBounceBody.fromSlice`
+* `BounceMode.RichBounceOnlyRootCell` — same, but `originalBody` will contain only a root cell
 
 ```tolk
+// demo for "old-fashioned" 256 bits (if you send all with Only256BitsOfBody) 
 fun onBouncedMessage(in: InMessageBounced) {
-    in.bouncedBody    // 256 bits
+    in.bouncedBody    // 32-bit prefix + 256 bits
 
-    // typically, you'll do
     in.bouncedBody.skipBouncedPrefix();   // skips 0xFFFFFFFF
     // handle rest of body, probably with lazy match
+}
+```
+
+```tolk
+// demo for "rich bounces" to access not 256 bits, but the entire body
+// (if you send ALL outgoing messages with BounceMode.RichBounce)
+fun onBouncedMessage(in: InMessageBounced) {
+    val rich = lazy RichBounceBody.fromSlice(in.bouncedBody);
+    // handle rich.originalBody, probably with lazy match
+    // use rich.xxx to get exitCode, gasUsed, and so on
 }
 ```
 

--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/in-short.mdx
@@ -65,6 +65,7 @@ get fun currentCounter(): int { ... }
 25. Convenient `map<K, V>` instead of low-level TVM dictionaries
 26. Auto-detect and inline functions at the compiler level
 27. Various optimizations for gas efficiency
+28. Anonymous functions (lambdas)
 
 ### Tooling around
 

--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/mutability.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/mutability.mdx
@@ -79,7 +79,6 @@ fun someFn(x: int) {
 var origX = 0;
 someFn(origX);  // origX remains 0
 someFn(10);     // ok, just int
-origX.someFn(); // still allowed (but not recommended), origX remains 0
 ```
 
 The same goes for cells, slices, whatever:

--- a/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx
+++ b/docs/v3/documentation/smart-contracts/tolk/tolk-vs-func/pack-to-from-cells.mdx
@@ -45,18 +45,20 @@ For example, if you assign 256 to uint8, asm command "8 STU" will fail with code
 | `coins`                  | VarUInteger 16                           | `STGRAMS`                           |
 | `varint16`, 32, etc.     | Var(U)Integer 16/32                      | `STVARINT16` / `STVARUINT32` / etc. |
 | `bits8`, `bits123`, etc. | just N bits                              | runtime check + `STSLICE` (1)       |
-| `address`                | MsgAddress (internal/external/none)      | `STSLICE` (2)                       |
+| `address`                | addr_std (internal, 267 bits)            | `STSTDADDR`                         |
+| `address?`               | addr_none or addr_std (2/267 bits)       | `STOPTSTDADDR`                      |
+| `any_address`            | MsgAddress (internal/external/none)      | `STSLICE`                           |
 | `bool`                   | one bit                                  | `1 STI`                             |
 | `cell`                   | untyped reference, TL-B `^Cell`          | `STREF`                             |
 | `cell?`                  | maybe reference, TL-B `(Maybe ^Cell)`    | `STOPTREF`                          |
 | `Cell<T>`                | typed reference, TL-B `^T`               | `STREF`                             |
 | `Cell<T>?`               | maybe typed reference, TL-B `(Maybe ^T)` | `STOPTREF`                          |
 | `RemainingBitsAndRefs`   | rest of slice                            | `STSLICE`                           |
-| `builder`                | only for writing, not for reading (5)    | `STB`                               |
-| `slice`                  | only for writing, not for reading (5)    | `STSLICE`                           |
+| `builder`                | only for writing, not for reading (4)    | `STB`                               |
+| `slice`                  | only for writing, not for reading (4)    | `STSLICE`                           |
 | `T?`                     | TL-B `(Maybe T)`                         | `1 STI` + IF ...                    |
-| `T1 \| T2`               | TL-B `(Either T1 T2)`                    | `1 STI` + IF ... + ELSE ... (3)     |
-| `T1 \| T2 \| ...`        | TL-B multiple constructors               | IF ... + ELSE IF ... + ELSE ... (4) |
+| `T1 \| T2`               | TL-B `(Either T1 T2)`                    | `1 STI` + IF ... + ELSE ... (2)     |
+| `T1 \| T2 \| ...`        | TL-B multiple constructors               | IF ... + ELSE IF ... + ELSE ... (3) |
 | `(T1, T2)`               | TL-B `(Pair T1 T2)` = one by one         | pack T1 + pack T2                   |
 | `(T1, T2, ...)`          | nested pairs = one by one                | pack T1 + pack T2 + ...             |
 | `SomeStruct`             | fields one by one                        | like a tensor                       |
@@ -67,21 +69,14 @@ For example, if you assign 256 to uint8, asm command "8 STU" will fail with code
   These checks ensure that serialized binary data will be correct, but they cost gas.
   However, if you guarantee that a slice is valid (for example, it comes from trusted sources), pass an option `skipBitsNValidation` to disable runtime checks.
 
-- (2) In TVM, all addresses are also plain slices. Type `address` indicates that it's a slice containing _some_ valid address (internal/external/none).
-  It's packed with `STSLICE` (no runtime checks) and loaded with `LDMSGADDR`.
-
-Don't confuse `address none` with null! `None` is a valid address (two zero bits), whereas `address?` is `maybe address` (bit "0" OR bit "1" + address).
-
-- (3) TL-B Either is expressed with a union `T1 | T2`. For example, `int32 | int64` is packed as ("0" + 32-bit int OR "1" + 64-bit int).
-
+- (2) TL-B Either is expressed with a union `T1 | T2`. For example, `int32 | int64` is packed as ("0" + 32-bit int OR "1" + 64-bit int). 
 However, if T1 and T2 are both structures with manual serialization prefixes, those prefixes are used instead of a 0/1 bit.
 
-
-- (4) To (un)pack a union, say, `Msg1 | Msg2 | Msg3`, we need serialization prefixes. For structures, you can specify them manually
+- (3) To (un)pack a union, say, `Msg1 | Msg2 | Msg3`, we need serialization prefixes. For structures, you can specify them manually
 (or the compiler will generate them right here). For primitives, like `int32 | int64 | int128 | int256`, the compiler generates a prefix tree 
 (00/01/10/11 in this case). Read **auto-generating serialization prefixes** below.
 
-- (5) Using raw `builder` and `slice` for writing is supported but not recommended, as they do not reveal any information about their internal structure.
+- (4) Using raw `builder` and `slice` for writing is supported but not recommended, as they do not reveal any information about their internal structure.
 Auto-generated TypeScript wrappers will be available in the future. However, for a raw `slice`, a wrapper cannot be generated, as there is no way to predict how to read such a field back.
 This feature will likely be removed in the future.
 
@@ -92,11 +87,12 @@ This feature will likely be removed in the future.
 struct A {
     f1: int8       // just int8
     f2: int8?      // maybe int8
-    f3: address    // internal/external/none
-    f4: bool       // TRUE (-1) serialized as bit '1'
-    f5: B          // embed fields of struct B
-    f6: B?         // maybe B
-    f7: coins      // used for money amounts
+    f3: address    // internal address (267 bits)
+    f4: address?   // internal or none (`null` <-> '00', `address` <-> 267 bits) 
+    f5: bool       // TRUE (-1) serialized as bit '1'
+    f6: B          // embed fields of struct B
+    f7: B?         // maybe B
+    f8: coins      // used for money amounts
 
     r1: cell          // always-existing untyped ref
     r2: Cell<B>       // typed ref
@@ -590,7 +586,7 @@ Why do we say "potentially"? Because for many types, their size can vary:
 
 - `int8?` is either one or nine bits
 - `coins` is variadic: from 4 bits (small values) up to 124 bits
-- `address` is internal (267 bits), or external (up to 521 bits), or none (2 bits); but since external addresses are very rare, estimation is "from 2 to 267 bits"
+- `any_address` is internal (267 bits), or external (up to 521 bits), or none (2 bits)
 
 So, suppose you have:
 
@@ -646,45 +642,6 @@ All in all, the compiler indicates on potential cell overflow, and it's your cho
 
 Probably, in the future, there will be more policies (besides "suppress") — for example, to auto-repack fields. For now, it's absolutely straightforward.
 
-## Write builder, read slice
-
-Since Tolk remains low-level whenever you need, it allows doing tricky things. Suppose you manually create an address from bits:
-
-```tolk
-var addrB = beginCell()
-           .storeUint(0b01)   // addr_extern
-           ...;
-```
-
-And you want to use this `addrB` (it's `builder`! not `address`) to write into a storage:
-
-```tolk
-struct MyStorage {
-    ...
-    addr: address
-}
-
-var st: MyStorage;
-st.addr = addrB;   // error, can not assign `builder` to `address`
-```
-
-Of course, you can do `addrB.endCell().beginParse() as address`, but creating a cell is expensive. How can you write `addrB` directly?
-
-The solution is: if you want `builder` for writing, and `address` for reading... Do exactly what you want!
-
-```tolk
-struct MyStorageData<T> {
-    ...
-    addr: T
-}
-
-type MyStorage = MyStorageData<address>
-type MyStorageForWrite = MyStorageData<builder>
-```
-
-The same technique can be combined with `RemainingBitsAndRefs` and some more cases.
-Moreover, for performance optimizations, you can create different "views" over the same data. Don't underestimate generics and the type system in general.
-
 ## Integration with message sending
 
 Auto-serialization is natively integrated with sending messages to other contracts.
@@ -692,7 +649,7 @@ You just "send some object," and the compiler automatically serializes it, detec
 
 ```tolk
 val reply = createMessage({
-    bounce: true,
+    bounce: BounceMode.RichBounce,
     value: ton("0.05"),
     dest: senderAddress,
     body: RequestedInfo {     // auto-serialized

--- a/src/grammar/allow-list-dictionary.txt
+++ b/src/grammar/allow-list-dictionary.txt
@@ -101,6 +101,7 @@ Playmuse
 Prer
 Prerequisites
 Pushgateway
+PUSHNULL
 RLDP
 Ratelance
 Reindexing

--- a/src/theme/prism/prism-tolk.js
+++ b/src/theme/prism/prism-tolk.js
@@ -18,7 +18,7 @@
       }
     ],
 
-    'type-hint': /\b(int|cell|void|never|bool|slice|tuple|builder|continuation|coins|int8|int16|int32|int64|uint8|uint16|uint32|uint64|uint256|bytes16|bytes32|bytes64|bits8|bits16|bits32|bits64|bits128|bits256|address|map)\b/,
+    'type-hint': /\b(int|cell|void|never|bool|slice|tuple|builder|continuation|coins|int8|int16|int32|int64|uint8|uint16|uint32|uint64|uint256|bytes16|bytes32|bytes64|bits8|bits16|bits32|bits64|bits128|bits256|address|any_address|map)\b/,
 
     'boolean': /\b(false|true|null)\b/,
 


### PR DESCRIPTION
## Description

Update documentation for Tolk Language according to changes in Tolk v1.2.

* https://github.com/ton-blockchain/ton/pull/1886

### Notable changes in Tolk v1.2:

1. Breaking change: address is now "internal only"
2. Rich bounces: not 256 bits, but the full body on bounce
3. Cheap builder-to-slice, StateInit, and address composition
4. Compilation errors significantly improved
5. Anonymous functions supported
6. Borrow checker and other stuff related to undefined behavior
7. Several low-level capabilities and minor fixes/improvements

## Checklist

- [x] I have created an issue.
- [x] I am working on content that aligns with the [Style guide](https://docs.ton.org/v3/contribute/style-guide/).
- [x] I have reviewed and formatted the content according to [Content standardization](https://docs.ton.org/v3/contribute/content-standardization/).
- [x] I have reviewed and formatted the text in the article according to [Typography](https://docs.ton.org/v3/contribute/typography/).
