### PR TITLE
Update documentation for nanotons reservation process

### DIFF
--- a/docs/v3/documentation/smart-contracts/func/docs/stdlib.mdx
+++ b/docs/v3/documentation/smart-contracts/func/docs/stdlib.mdx
@@ -532,7 +532,7 @@ The behavior depends on the `mode` parameter:
 - If `mode = 1` or `mode = 3`, all but the `amount` of nanotons is reserved.
 
 This process is equivalent to generating an outbound message that transfers the `amount` of nanotons or `b − amount` nanotons,
-where `b` represents the remaining balance, to the current smart contract. This ensures that subsequent output actions cannot exceed the remaining funds.
+where `b` represents the remaining balance, to oneself. This ensures that subsequent output actions cannot exceed the remaining funds.
 
 **Mode Flags**
 


### PR DESCRIPTION
Clarify the recipient of the nanotons in the process description.

## Description

The simplified behavior of raw_reserve is explained incorrectly.

See issue for more details.

Closes https://github.com/ton-community/ton-docs/issues/1786

## Checklist

- [x] I have created an issue.
- [x] I am working on content that aligns with the [Style guide](https://docs.ton.org/v3/contribute/style-guide/).
- [x] I have reviewed and formatted the content according to [Content standardization](https://docs.ton.org/v3/contribute/content-standardization/).
- [x] I have reviewed and formatted the text in the article according to [Typography](https://docs.ton.org/v3/contribute/typography/).
