### PR TITLE
chore: deprecation notices in announcement bar and in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# TON documentation 📚
+# ARCHIVED! Actual TON documentation is moved to: https://github.com/ton-org/docs
 
 <img align="left" width="300px" src="static\img\readme\about.png">
-
-This is the official repository for The Open Network documentation.
 
 Latest documentation release: [docs.ton.org](https://docs.ton.org).
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -141,12 +141,13 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
-      // announcementBar: {
-      //   // id: 'contribute/hacktoberfest',
-      //   content: '<a rel="noopener noreferrer" target="_blank" href="https://society.ton.org/hack-ton-berfest-2023?utm_source=tondocs&utm_medium=top_banner&utm_campaign=promo"><span>The <b>HACK-TON-BERFEST 2023</b> event is near! Double-merch, NFT rewards and more!</span> <span class="mobile-view">Double-merch, NFT reward and more!</span></a>',
-      //   textColor: '#F3F3F7',
-      //   isCloseable: false,
-      // },
+      announcementBar: {
+        id: 'deprecation_notice',
+        content: '<a rel="noopener noreferrer" href="https://docs.ton.org"><span>Deprecated! Please, visit the new documentation at <b>docs.ton.org</b></span> <span class="mobile-view">Deprecated, go to <b>new docs</b>!</span></a>',
+        backgroundColor: '#0088CC',
+        textColor: '#FFFFFF',
+        isCloseable: false,
+      },
       metadata: [
         {
           name: 'keywords',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -144,7 +144,7 @@ const config = {
       announcementBar: {
         id: 'deprecation_notice',
         content: '<a rel="noopener noreferrer" href="https://docs.ton.org"><span>Deprecated! Please, visit the new documentation at <b>docs.ton.org</b></span> <span class="mobile-view">Deprecated, go to <b>new docs</b>!</span></a>',
-        backgroundColor: '#0088CC',
+        backgroundColor: '#CC0000',
         textColor: '#FFFFFF',
         isCloseable: false,
       },

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1814,11 +1814,7 @@ a img,button img {
 }
 
 [role=banner] {
-  background-image: url(/static/img/banner-bg.svg),linear-gradient(90deg,#9997f3 -.76%,#69aeff 93.89%)!important;
-  background-repeat: no-repeat;
-  background-position: center center;
-  font-weight: 600;
-  font-size: 16px;
+  font-size: 24px;
   line-height: 24px;
   min-height: 44px
 }
@@ -1852,22 +1848,6 @@ a img,button img {
 
 [role=banner] a {
   text-decoration: none!important
-}
-
-[role=banner] a span {
-  position: relative
-}
-
-[role=banner] a span::after {
-  content: "";
-  position: absolute;
-  top: -2px;
-  right: -18px;
-  width: 18px;
-  height: 18px;
-  color: red;
-  background: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTguNzAzNjEgOC43MDI4MkM4LjMxMzgzIDguMzEzMDMgOC4zMTU5NSA3LjY3ODkzIDguNzAzOTIgNy4yOTA5N0w4Ljc5MTc2IDcuMjAzMTJDOS4xODE3MiA2LjgxMzE2IDkuODExMzUgNi44MTA1NSAxMC4yMDU4IDcuMjA1MDNMMTUuMjg5OSAxMi4yODkxQzE1LjY4MDkgMTIuNjgwMSAxNS42ODQzIDEzLjMxMDYgMTUuMjg5OSAxMy43MDVMMTAuMjA1OCAxOC43ODkxQzkuODE0ODIgMTkuMTgwMSA5LjE3OTczIDE5LjE3ODkgOC43OTE3NiAxOC43OTFMOC43MDM5MiAxOC43MDMxQzguMzEzOTYgMTguMzEzMiA4LjMxMDYxIDE3LjY4NDMgOC43MDM2MSAxNy4yOTEzTDEyLjk5NzggMTIuOTk3TDguNzAzNjEgOC43MDI4MloiIGZpbGw9IiNGM0YzRjYiLz4KPC9zdmc+Cg==);
-  background-size: contain
 }
 
 .alert{


### PR DESCRIPTION
## Description

New documentation is available under the same URL: https://docs.ton.org/, whereas its corresponding repository is now hosted at: https://github.com/ton-org/docs.

Closes #1790

## Checklist

- [x] There is an issue.
- [x] I am working on content that aligns with the [Style guide](https://docs.ton.org/v3/contribute/style-guide/).
- [x] I have reviewed and formatted the content according to [Content standardization](https://docs.ton.org/v3/contribute/content-standardization/).
- [x] I have reviewed and formatted the text in the article according to [Typography](https://docs.ton.org/v3/contribute/typography/).

## Preview

### Iteration 1

```
backgroundColor: '#0088CC',
textColor: '#FFFFFF',
```

<img width="1280" height="634" alt="image" src="https://github.com/user-attachments/assets/da4cd578-e121-48f4-98e3-9835948ba88a" />

(mobile preview has a shorter text of "Deprecated, go to new docs!")

### Current

```
backgroundColor: '#CC0000',
textColor: '#FFFFFF',
```

<img width="1877" height="940" alt="image" src="https://github.com/user-attachments/assets/16dabd06-e2db-4cac-9c73-c7eadb926187" />
